### PR TITLE
Fix streamlit CIR parameter output with f-string

### DIFF
--- a/src/dynamics_heston.py
+++ b/src/dynamics_heston.py
@@ -19,8 +19,7 @@ class DynamicsParametersHeston(pyd.BaseModel):
 
     def write_cir(self) -> None:
         with st.sidebar:
-            st.write(f'CIR Parameter (must be greater than 1): {
-                self.cir_number():.2f}')
+            st.write(f"CIR Parameter (must be greater than 1): {self.cir_number():.2f}")
 
     def mean_variance(self, th, v):
         x = self.kappa*th + CFG.EPS


### PR DESCRIPTION
## Summary
- fix `write_cir` to use a single f-string for Streamlit output

## Testing
- `python -m py_compile src/dynamics_heston.py`
- `python - <<'PY'
import src.dynamics_heston
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a02ee99f8083269bf9cd53c40d6f63