### PR TITLE
Add calibration infrastructure with Heston example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+- Added `src/estimation` module with a generic `Calibrator` base class and a
+  sample `HestonCalibrator` demonstrating least-squares calibration on synthetic
+  data. Documented expected input formats for future data integration.

--- a/src/estimation/README.md
+++ b/src/estimation/README.md
@@ -1,0 +1,18 @@
+# Estimation
+
+Utilities for calibrating model parameters to market data.
+
+## Expected input format
+
+Calibrators expect three NumPy arrays of identical shape:
+
+- `strikes`: option strike prices
+- `maturities`: option maturities in years
+- `prices`: observed option prices
+
+These arrays define the option surface used during optimisation.  Example:
+
+```python
+calib = HestonCalibrator(strikes, maturities, prices)
+params = calib.calibrate(initial_guess)
+```

--- a/src/estimation/__init__.py
+++ b/src/estimation/__init__.py
@@ -1,0 +1,6 @@
+"""Estimation and calibration utilities."""
+
+from .calibrator import Calibrator
+from .heston import HestonCalibrator, sample_calibration
+
+__all__ = ["Calibrator", "HestonCalibrator", "sample_calibration"]

--- a/src/estimation/calibrator.py
+++ b/src/estimation/calibrator.py
@@ -1,0 +1,70 @@
+"""Base classes for parameter calibration.
+
+This module defines the :class:`Calibrator` abstract base class which stores
+market data as NumPy arrays.  Subclasses are expected to implement
+:method:`model_prices` to generate model-implied prices for a vector of model
+parameters.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+from scipy.optimize import least_squares
+
+
+@dataclass
+class Calibrator(ABC):
+    """Abstract optimizer matching model prices to market data.
+
+    Parameters
+    ----------
+    strikes:
+        Array of strike prices.
+    maturities:
+        Array of option maturities with the same shape as ``strikes``.
+    prices:
+        Observed market option prices.
+    """
+
+    strikes: np.ndarray
+    maturities: np.ndarray
+    prices: np.ndarray
+
+    def __post_init__(self) -> None:  # noqa: D401 - short explanation
+        """Validate input array shapes."""
+        self.strikes = np.asarray(self.strikes, dtype=float)
+        self.maturities = np.asarray(self.maturities, dtype=float)
+        self.prices = np.asarray(self.prices, dtype=float)
+        if not (
+            self.strikes.shape == self.maturities.shape == self.prices.shape
+        ):
+            raise ValueError("Input arrays must share the same shape")
+
+    @abstractmethod
+    def model_prices(self, params: Sequence[float]) -> np.ndarray:
+        """Return model prices for the supplied parameters."""
+
+    def residuals(self, params: Sequence[float]) -> np.ndarray:
+        """Difference between model and market prices."""
+        return self.model_prices(params) - self.prices
+
+    def calibrate(self, initial_guess: Sequence[float]) -> np.ndarray:
+        """Calibrate model parameters via least squares.
+
+        Parameters
+        ----------
+        initial_guess:
+            Initial parameter vector for the solver.
+
+        Returns
+        -------
+        numpy.ndarray
+            Optimized parameter vector.
+        """
+
+        result = least_squares(self.residuals, x0=np.asarray(initial_guess))
+        return result.x

--- a/src/estimation/heston.py
+++ b/src/estimation/heston.py
@@ -1,0 +1,64 @@
+"""Heston model calibration utilities."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+from .calibrator import Calibrator
+
+
+class HestonCalibrator(Calibrator):
+    """Calibrate simplified Heston parameters using least squares.
+
+    The pricing formula is intentionally simplistic and serves only as a
+    placeholder.  It allows the calibration workflow to be demonstrated with
+    synthetic data without relying on a full Heston implementation.
+    """
+
+    @staticmethod
+    def price_formula(
+        strikes: np.ndarray, maturities: np.ndarray, params: Sequence[float]
+    ) -> np.ndarray:
+        """Synthetic pricing formula used for demo purposes.
+
+        Parameters
+        ----------
+        strikes, maturities:
+            Arrays defining the option surface.
+        params:
+            Sequence ``[v0, kappa, theta, sigma, rho]``.
+        """
+
+        v0, kappa, theta, sigma, rho = params
+        return (
+            v0
+            + 1e-2 * kappa * strikes
+            + theta * maturities
+            + 1e-1 * sigma * np.sqrt(strikes)
+            + rho * maturities**2
+        )
+
+    def model_prices(self, params: Sequence[float]) -> np.ndarray:
+        return self.price_formula(self.strikes, self.maturities, params)
+
+
+def sample_calibration() -> np.ndarray:
+    """Run a toy calibration against synthetic market data.
+
+    Returns
+    -------
+    numpy.ndarray
+        Estimated parameter vector close to the ground truth.
+    """
+
+    s = np.linspace(80, 120, 5)
+    t = np.linspace(0.1, 1.0, 5)
+    strikes, maturities = np.meshgrid(s, t)
+    strikes, maturities = strikes.ravel(), maturities.ravel()
+    true_params = np.array([0.04, 1.0, 0.04, 0.3, -0.7])
+    prices = HestonCalibrator.price_formula(strikes, maturities, true_params)
+    calibrator = HestonCalibrator(strikes, maturities, prices)
+    initial_guess = true_params + np.array([0.01, -0.1, 0.02, -0.05, 0.1])
+    return calibrator.calibrate(initial_guess)

--- a/tests/test_calibrator.py
+++ b/tests/test_calibrator.py
@@ -1,0 +1,18 @@
+"""Tests for calibration utilities."""
+
+import numpy as np
+
+from src.estimation import HestonCalibrator
+
+
+def test_heston_calibration_recovers_parameters() -> None:
+    s = np.linspace(80, 120, 5)
+    t = np.linspace(0.1, 1.0, 5)
+    strikes, maturities = np.meshgrid(s, t)
+    strikes, maturities = strikes.ravel(), maturities.ravel()
+    true_params = np.array([0.04, 1.0, 0.04, 0.3, -0.7])
+    prices = HestonCalibrator.price_formula(strikes, maturities, true_params)
+    calibrator = HestonCalibrator(strikes, maturities, prices)
+    initial_guess = true_params + np.array([0.01, -0.1, 0.02, -0.05, 0.1])
+    estimated = calibrator.calibrate(initial_guess)
+    assert np.allclose(estimated, true_params, atol=1e-2)


### PR DESCRIPTION
## Summary
- add `Calibrator` base class for parameter estimation
- implement `HestonCalibrator` with synthetic least-squares routine and sample usage
- document expected input arrays and note changes in changelog

## Testing
- `pytest`
- `flake8 src/estimation tests/test_calibrator.py`
- `flake8` *(fails: demo_adaptive.py, main.py, src/core/dynamics_heston.py, src/plots.py, src/time/stepper.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a10c76ee6c832687bff6df07028aa7