### PR TITLE
Add docstring conventions and enable pydocstyle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,7 @@ jobs:
           pip install -r requirements.txt
           pip install -e .
           pip install pytest
+      - name: Run pydocstyle
+        run: pydocstyle src
       - name: Run tests
         run: pytest -q

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing
+
+Thank you for your interest in improving `finite_element_options`.
+
+## Naming conventions
+
+- Use descriptive names whenever possible.
+- Single–letter names are allowed when they are standard mathematical
+  symbols (e.g. `s` for stock price, `v` for variance). Provide context in
+  the surrounding text or docstring so that the meaning is clear.
+- If a very short name is required and pydocstyle complains, append a
+  `# noqa: D401` (or appropriate code) comment to the definition.
+
+## Docstrings
+
+- Every public module, class and function must include a docstring
+  following the [PEP&nbsp;257](https://peps.python.org/pep-0257/) style.
+- Use triple double quotes and start with a one‑line summary.  Leave a
+  blank line before any further description.
+- Include mathematical notation when helpful, e.g. ``\mathbb{E}[V_t]``.
+
+## Development workflow
+
+1. Create a virtual environment and install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   pip install -e .
+   ```
+2. Run the linters and test suite before submitting a pull request:
+   ```bash
+   pydocstyle src
+   pytest
+   ```
+3. Code formatting or lint warnings may be suppressed with `# noqa:`
+   comments when there is a justified reason (such as an intentionally
+   short name).
+
+Happy hacking!

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ matplotlib
 pydantic
 scipy
 aleatory
+pydocstyle

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pydocstyle]
+select = D100,D101,D102,D103,D104,D105,D106,D107

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Core modules for finite-element option pricing."""

--- a/src/cli.py
+++ b/src/cli.py
@@ -12,6 +12,7 @@ from .time.stepper import ThetaScheme
 
 
 def main(args=None):
+    """Parse command-line arguments and run the Heston solver."""
     parser = argparse.ArgumentParser(description="Run Heston option solver")
     parser.add_argument("--k", type=float, default=0.4, help="Strike price")
     parser.add_argument("--T", type=float, default=1.0, help="Maturity")

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core mathematical models and market abstractions."""

--- a/src/core/dynamics_heston.py
+++ b/src/core/dynamics_heston.py
@@ -11,6 +11,19 @@ import CONFIG as CFG
 
 
 class DynamicsParametersHeston(pyd.BaseModel):
+    r"""Parameters for the two-dimensional Heston stochastic volatility model.
+
+    The spot price ``S_t`` and variance ``V_t`` satisfy
+
+    .. math::
+       \begin{aligned}
+       dS_t &= (r-q)S_t\,dt + \sqrt{V_t} S_t\,dW^S_t,\\
+       dV_t &= \kappa(\theta - V_t)\,dt + \sigma\sqrt{V_t}\,dW^V_t,\\
+       \end{aligned}
+
+    with correlation ``\rho = d\langle W^S, W^V \rangle_t``.
+    """
+
     r: float
     q: float
     kappa: float
@@ -27,6 +40,7 @@ class DynamicsParametersHeston(pyd.BaseModel):
         return f"CIR Parameter (must be greater than 1): {self.cir_number():.2f}"
 
     def mean_variance(self, th, v):
+        r"""Return ``\mathbb{E}[V_{t+th} \mid V_t = v]`` under CIR dynamics."""
         x = self.kappa*th + CFG.EPS
         return -np.expm1(-x)/x*(v - self.theta) + self.theta
 

--- a/src/estimation/heston.py
+++ b/src/estimation/heston.py
@@ -41,6 +41,7 @@ class HestonCalibrator(Calibrator):
         )
 
     def model_prices(self, params: Sequence[float]) -> np.ndarray:
+        """Return prices implied by ``params`` across the market grid."""
         return self.price_formula(self.strikes, self.maturities, params)
 
 

--- a/src/plots.py
+++ b/src/plots.py
@@ -1,3 +1,5 @@
+"""Plotting utilities for Streamlit demonstrations."""
+
 import matplotlib.pyplot as plt
 import streamlit as st
 import skfem.visuals as femv
@@ -6,6 +8,7 @@ from skfem.visuals.matplotlib import plot as femplot
 
 
 def plot_mean_variance(t, dynh):
+    r"""Plot ``\mathbb{E}[V_t]`` under Heston dynamics."""
 
     fig, ax = plt.subplots()
     ax.plot(t, dynh.mean_variance(t, 2*dynh.theta))
@@ -29,6 +32,7 @@ def plot_mean_variance(t, dynh):
 
 
 def plot_2d(Vh, f_sv, title: str) -> None:
+    """Render a 2-D field defined on the finite element space ``V_h``."""
     fig, ax = plt.subplots()
     femv.matplotlib.plot(Vh, f_sv, ax=ax, colorbar=True)
     ax.set_xlabel('underlying')

--- a/src/sidebar.py
+++ b/src/sidebar.py
@@ -1,3 +1,5 @@
+"""Streamlit sidebar widgets for interactive option demos."""
+
 import streamlit as st
 import numpy as np
 import scipy.stats as spst
@@ -10,8 +12,10 @@ from src.space.mesh import create_mesh
 
 
 class Sidebar:
+    """Collect user input from the Streamlit sidebar."""
 
     def __init__(self):
+        """Instantiate the sidebar widgets."""
         self._make_sidebar()
 
     def _make_sidebar(self):

--- a/src/space/__init__.py
+++ b/src/space/__init__.py
@@ -1,3 +1,5 @@
+"""Spatial discretisation helpers and solvers."""
+
 from .mesh import create_mesh, create_rectangular_mesh
 from .forms import Forms
 from .solver import SpaceSolver

--- a/src/space/adaptive.py
+++ b/src/space/adaptive.py
@@ -39,6 +39,7 @@ class AdaptiveMesh:
             Dict[str, Callable[[np.ndarray], np.ndarray]] | None
         ) = None,
     ) -> None:
+        """Store mesh refinement configuration."""
         self.element = element
         self.criterion = criterion
         self.theta = theta

--- a/src/space/forms.py
+++ b/src/space/forms.py
@@ -16,6 +16,7 @@ class Forms:
         dynh,
         transform: CoordinateTransform | None = None,
     ):
+        """Store references to model objects and transformations."""
         self.is_call = is_call
         self.bsopt = bsopt
         self.dynh = dynh
@@ -23,6 +24,8 @@ class Forms:
 
     @staticmethod
     def id_bil():
+        r"""Identity bilinear form ``\int u v \,dx``."""
+
         @fem.BilinearForm
         def Id_bil(u, v, _):
             return u * v
@@ -30,6 +33,8 @@ class Forms:
         return Id_bil
 
     def l_bil(self):
+        """Diffusion–convection bilinear form for the PDE."""
+
         @fem.BilinearForm
         def L_bil(u, v, w):
             coords = self.transform.untransform_state(w.x)
@@ -46,6 +51,7 @@ class Forms:
         return L_bil
 
     def b_lin(self):
+        """Boundary linear functional associated with the PDE."""
         if not hasattr(self.dynh, "boundary_term"):
             @fem.LinearForm
             def zero(v, w):

--- a/src/space/solver.py
+++ b/src/space/solver.py
@@ -25,6 +25,7 @@ class SpaceSolver:
         *,
         adaptive_criterion: str | None = None,
     ):
+        """Initialize the spatial solver and assemble static operators."""
         self.mesh = mesh
         self.dynh = dynh
         self.bsopt = bsopt

--- a/src/time/__init__.py
+++ b/src/time/__init__.py
@@ -1,3 +1,5 @@
+"""Time-stepping schemes for option valuation."""
+
 from .stepper import TimeStepper, ThetaScheme, CrankNicolson
 
 __all__ = ["TimeStepper", "ThetaScheme", "CrankNicolson"]

--- a/src/time/stepper.py
+++ b/src/time/stepper.py
@@ -30,6 +30,7 @@ class ThetaScheme(TimeStepper):
     """General θ-scheme stepping (θ=1 implicit Euler, θ=0 explicit Euler)."""
 
     def __init__(self, theta: float = 0.5):
+        """Store the parameter ``θ`` controlling implicitness."""
         self.theta = theta
 
     def solve(
@@ -39,6 +40,7 @@ class ThetaScheme(TimeStepper):
         dirichlet_bcs=None,
         is_american: bool = False,
     ) -> np.ndarray:
+        """Return solution grid for the supplied time nodes ``t``."""
         dt = t[1] - t[0]
         v_tsv = np.empty((len(t), space.Vh.N))
         v_tsv[0] = space.initial_condition()
@@ -69,4 +71,5 @@ class CrankNicolson(ThetaScheme):
     """Crank–Nicolson scheme with θ=1/2."""
 
     def __init__(self):
+        """Initialize with ``θ = 1/2``."""
         super().__init__(theta=0.5)

--- a/src/transform.py
+++ b/src/transform.py
@@ -34,9 +34,11 @@ class Identity:
     """Trivial mapping leaving values unchanged."""
 
     def transform(self, x: np.ndarray) -> np.ndarray:
+        """Return ``x`` unchanged."""
         return x
 
     def untransform(self, x: np.ndarray) -> np.ndarray:
+        """Return ``x`` unchanged."""
         return x
 
 
@@ -49,9 +51,11 @@ class LogPrice:
     """
 
     def transform(self, s: np.ndarray) -> np.ndarray:
+        r"""Map spot price ``s`` to log space ``\log s``."""
         return np.log(s)
 
     def untransform(self, x: np.ndarray) -> np.ndarray:
+        """Recover price ``s = e^x`` from log space."""
         return np.exp(x)
 
 
@@ -60,9 +64,11 @@ class SqrtVol:
     """Square-root mapping for (co)variance variables."""
 
     def transform(self, v: np.ndarray) -> np.ndarray:
+        r"""Map variance ``v`` to its root ``\sqrt{v}``."""
         return np.sqrt(v)
 
     def untransform(self, y: np.ndarray) -> np.ndarray:
+        """Square to recover variance ``v = y^2``."""
         return y ** 2
 
 


### PR DESCRIPTION
## Summary
- document naming conventions and docstring requirements
- add missing docstrings with mathematical notation for public APIs
- run pydocstyle in CI and include linter in requirements

## Testing
- `pydocstyle src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1100b5980832685482959bc42d288