### PR TITLE
feat: add problem presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,6 @@
 - Introduced an `AdaptiveMesh` utility enabling residual- or gradient-based
   adaptive refinement. Demo and solver now support configurable criteria and
   tests assert element counts increase or decrease accordingly.
+- Added `src/problems` package with `OptionPricingProblem` and
+  `CreditRiskProblem` classes bundling dynamics, payoff and boundary defaults,
+  plus a Streamlit demo showcasing their instantiation.

--- a/src/examples/problems_demo.py
+++ b/src/examples/problems_demo.py
@@ -1,0 +1,19 @@
+"""Streamlit demo instantiating provided problem presets."""
+
+import streamlit as st
+
+from src.problems import CreditRiskProblem, OptionPricingProblem
+
+
+def main() -> None:
+    """Render the demo page."""
+
+    st.title("Problem Presets")
+    st.subheader("Option Pricing")
+    st.write(OptionPricingProblem())
+    st.subheader("Credit Risk")
+    st.write(CreditRiskProblem())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/problems/__init__.py
+++ b/src/problems/__init__.py
@@ -1,0 +1,7 @@
+"""Problem presets bundling dynamics, payoffs and boundary sets."""
+
+from .base import Problem
+from .option_pricing import OptionPricingProblem
+from .credit_risk import CreditRiskProblem
+
+__all__ = ["Problem", "OptionPricingProblem", "CreditRiskProblem"]

--- a/src/problems/base.py
+++ b/src/problems/base.py
@@ -1,0 +1,22 @@
+"""Problem abstractions supplying PDE components."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.core.interfaces import DynamicsModel, Payoff, BoundaryCondition
+
+
+@dataclass
+class Problem:
+    """Container bundling PDE ingredients.
+
+    Concrete problems provide default instances for the dynamics model,
+    payoff and boundary condition strategy used by the solver.  The
+    attributes are typed according to the core interfaces so they can be
+    consumed directly by the space and time modules.
+    """
+
+    dynamics: DynamicsModel
+    payoff: Payoff
+    boundary_condition: BoundaryCondition

--- a/src/problems/credit_risk.py
+++ b/src/problems/credit_risk.py
@@ -1,0 +1,82 @@
+"""Illustrative credit risk problem with basic defaults."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable
+
+import pydantic as pyd
+
+from src.core.interfaces import Payoff, DynamicsModel
+from src.core.market import Market
+from src.space.boundary import DirichletBC
+
+from .base import Problem
+
+
+class CreditRiskDynamics(pyd.BaseModel):
+    """Toy dynamics with constant default intensity."""
+
+    r: float
+    lamb: float
+
+    def mean_variance(self, th, _):  # pylint: disable=unused-argument
+        """No variance in the simple intensity model."""
+        return 0.0
+
+    def A(self, s):  # pylint: disable=unused-argument
+        """No diffusion term for the intensity process."""
+        return [[0.0]]
+
+    def dA(self, s):  # pylint: disable=unused-argument
+        """Divergence of the diffusion matrix."""
+        return [0.0]
+
+    def b(self, s):  # pylint: disable=unused-argument
+        """Drift capturing the default intensity."""
+        return [-self.lamb * s]
+
+
+@dataclass(frozen=True)
+class CreditRiskPayoff(Payoff):
+    """Simple payoff for a defaultable zero-coupon bond."""
+
+    recovery: float
+    mkt: Market
+
+    def call_payoff(self, s: float) -> float:  # pylint: disable=unused-argument
+        """No call-style payoff; return zero."""
+        return 0.0
+
+    def put_payoff(self, s: float) -> float:
+        """Loss given default modeled as ``1 - recovery``."""
+        return 1.0 - self.recovery
+
+    def call(self, th: float, s: float, v: float) -> float:  # pylint: disable=unused-argument
+        """Call price is zero for the bond."""
+        return 0.0
+
+    def put(self, th: float, s: float, v: float) -> float:  # pylint: disable=unused-argument
+        """Discounted expected loss at maturity."""
+        return self.mkt.discount_factor(th) * self.put_payoff(s)
+
+
+@dataclass
+class CreditRiskProblem(Problem):
+    """Credit risk problem with default intensity and recovery rate."""
+
+    r: float = 0.03
+    default_intensity: float = 0.02
+    recovery: float = 0.4
+    boundaries: Iterable[str] = field(default_factory=lambda: ("default", "survival"))
+
+    def __post_init__(self) -> None:
+        """Instantiate default dynamics, payoff and boundary condition."""
+
+        dynamics: DynamicsModel = CreditRiskDynamics(r=self.r, lamb=self.default_intensity)
+        market = Market(r=self.r)
+        payoff = CreditRiskPayoff(recovery=self.recovery, mkt=market)
+        boundary_condition = DirichletBC(self.boundaries)
+        object.__setattr__(self, "dynamics", dynamics)
+        object.__setattr__(self, "payoff", payoff)
+        object.__setattr__(self, "boundary_condition", boundary_condition)

--- a/src/problems/option_pricing.py
+++ b/src/problems/option_pricing.py
@@ -1,0 +1,54 @@
+"""Problem definition for vanilla option pricing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable
+
+from src.core.dynamics_black_scholes import DynamicsParametersBlackScholes
+from src.core.market import Market
+from src.core.vanilla_bs import EuropeanOptionBs
+from src.space.boundary import DirichletBC
+
+from .base import Problem
+
+
+@dataclass
+class OptionPricingProblem(Problem):
+    """Convenience problem with Black–Scholes defaults.
+
+    Parameters
+    ----------
+    k:
+        Strike price of the option.
+    r:
+        Risk-free rate.
+    q:
+        Continuous dividend yield.
+    sigma:
+        Volatility of the underlying asset.
+    is_call:
+        Whether the option is a call (``True``) or put (``False``).
+    boundaries:
+        Collection of boundary set names where Dirichlet conditions are
+        enforced.  Defaults to ``("left", "right")`` which correspond to
+        the extremes of the one dimensional domain.
+    """
+
+    k: float = 1.0
+    r: float = 0.03
+    q: float = 0.0
+    sigma: float = 0.2
+    is_call: bool = True
+    boundaries: Iterable[str] = field(default_factory=lambda: ("left", "right"))
+
+    def __post_init__(self) -> None:
+        """Instantiate default dynamics, payoff and boundary condition."""
+
+        dynamics = DynamicsParametersBlackScholes(r=self.r, q=self.q, sig=self.sigma)
+        market = Market(r=self.r)
+        payoff = EuropeanOptionBs(k=self.k, q=self.q, mkt=market)
+        boundary_condition = DirichletBC(self.boundaries)
+        object.__setattr__(self, "dynamics", dynamics)
+        object.__setattr__(self, "payoff", payoff)
+        object.__setattr__(self, "boundary_condition", boundary_condition)


### PR DESCRIPTION
## Summary
- add `OptionPricingProblem` and `CreditRiskProblem` presets bundling dynamics, payoff and boundary conditions
- streamlit demo showcasing problem instantiation
- update changelog

## Testing
- `pydocstyle`
- `pydocstyle src/problems src/examples/problems_demo.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1160d8b588326ac208eb7397815bd