### PR TITLE
Add stochastic dynamics interface and credit risk jump example

### DIFF
--- a/src/core/interfaces.py
+++ b/src/core/interfaces.py
@@ -52,6 +52,13 @@ class DynamicsModel(Protocol):
         raise NotImplementedError
 
 
+class StochasticDynamicsModel(DynamicsModel, Protocol):
+    """Extension of :class:`DynamicsModel` with stochastic coefficients."""
+
+    def sample(self, rng: np.random.Generator) -> DynamicsModel:
+        """Return a realisation with randomised coefficients."""
+
+
 class SpaceDiscretization(Protocol):
     """Protocol defining the spatial operators required by time steppers."""
 

--- a/src/examples/credit_risk_jump.py
+++ b/src/examples/credit_risk_jump.py
@@ -1,0 +1,44 @@
+"""Credit-risk bond pricing with jump intensity and Monte Carlo comparison."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from src.problems.credit_risk import CreditRiskJumpDynamics, CreditRiskPayoff
+from src.core.market import Market
+from src.space.mesh import create_mesh
+from src.space.solver import SpaceSolver
+from src.space.boundary import DirichletBC
+from src.time.stepper import ThetaScheme
+
+
+def pde_monte_carlo(n_paths: int = 10) -> tuple[float, float]:
+    """Compare PDE estimate against analytic Monte Carlo baseline."""
+    rng = np.random.default_rng(0)
+    dyn = CreditRiskJumpDynamics(r=0.03, lamb=0.02, jump_vol=0.3)
+    payoff = CreditRiskPayoff(recovery=0.4, mkt=Market(r=dyn.r))
+    T = 1.0
+    t = np.linspace(0.0, T, 5)
+    mesh = create_mesh([1.0], 1)
+    stepper = ThetaScheme(theta=0.5)
+
+    pde_vals = []
+    mc_vals = []
+
+    for _ in range(n_paths):
+        sampled = dyn.sample(rng)
+        space = SpaceSolver(mesh, sampled, payoff, is_call=False)
+        u = stepper.solve(t, space, boundary_condition=DirichletBC([]))
+        pde_vals.append(float(u[-1][0]))
+        lamb = sampled.lamb
+        mc_vals.append(
+            np.exp(-dyn.r * T) * (1 - payoff.recovery) * (1 - np.exp(-lamb * T))
+        )
+
+    return float(np.mean(pde_vals)), float(np.mean(mc_vals))
+
+
+if __name__ == "__main__":  # pragma: no cover - example script
+    pde, mc = pde_monte_carlo()
+    print("PDE estimate:", pde)
+    print("Monte Carlo baseline:", mc)


### PR DESCRIPTION
## Summary
- extend DynamicsModel protocol with StochasticDynamicsModel for random coefficients
- add CreditRiskJumpDynamics and Monte Carlo comparison example

## Testing
- `pydocstyle src/problems/credit_risk.py src/core/interfaces.py src/examples/credit_risk_jump.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a117db2dd4832681e9e21eebdecc9f