### PR TITLE
Add benchmarking and coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -e .
-          pip install pytest
       - name: Run pydocstyle
         run: pydocstyle src
       - name: Run tests
-        run: pytest -q
+        run: pytest --cov=src --cov-report=xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,7 @@
 - Added `src/problems` package with `OptionPricingProblem` and
   `CreditRiskProblem` classes bundling dynamics, payoff and boundary defaults,
   plus a Streamlit demo showcasing their instantiation.
+- Integrated `pytest-benchmark` for performance tracking and configured CI to
+  run tests with coverage reporting.
+- Added mesh creation tests covering domain extent accuracy and invalid
+  dimension handling.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ Execute the unit tests with `pytest`:
 pytest
 ```
 
+Benchmarks leveraging `pytest-benchmark` can be executed alongside the test
+suite. Coverage reports are generated via `pytest-cov`:
+
+```bash
+pytest --cov=src
+```
+
 ## Continuous Integration
 
 This project uses a GitHub Actions workflow to run the test suite on every

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ pydantic
 scipy
 aleatory
 pydocstyle
+pytest
+pytest-cov
+pytest-benchmark

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [pydocstyle]
 select = D100,D101,D102,D103,D104,D105,D106,D107
+
+[tool:pytest]
+addopts = --cov=src --cov-report=term-missing

--- a/tests/test_benchmark_black_scholes.py
+++ b/tests/test_benchmark_black_scholes.py
@@ -1,0 +1,42 @@
+"""Benchmark the Black-Scholes solver on a standard grid."""
+
+import os
+import sys
+import numpy as np
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from src.core.dynamics_black_scholes import (
+    DynamicsParametersBlackScholes,
+)
+from src.core.market import Market
+from src.core.vanilla_bs import EuropeanOptionBs
+from src.space.mesh import create_mesh
+from src.space.solver import SpaceSolver
+from src.space.boundary import DirichletBC
+from src.time.stepper import ThetaScheme
+
+
+def test_black_scholes_benchmark(benchmark) -> None:
+    """Run solver benchmark and validate numerical accuracy."""
+    dh = DynamicsParametersBlackScholes(r=0.03, q=0.0, sig=0.2)
+    mkt = Market(r=dh.r)
+    bsopt = EuropeanOptionBs(k=1.0, q=dh.q, mkt=mkt)
+    t = np.linspace(0.0, 1.0, 5)
+    mesh = create_mesh([2.0], 3)
+    space = SpaceSolver(mesh, dh, bsopt, is_call=True)
+    stepper = ThetaScheme(theta=0.5)
+    bc = DirichletBC([])
+
+    def run():
+        return stepper.solve(t, space, boundary_condition=bc)
+
+    v_tsv = benchmark(run)
+
+    s0 = 1.0
+    node = np.argmin(np.abs(space.Vh.doflocs[0] - s0))
+    price_num = v_tsv[-1, node]
+    price_exact = bsopt.call(t[-1], s0, dh.sig ** 2)
+
+    assert price_num == pytest.approx(price_exact, rel=1e-2)

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,0 +1,18 @@
+"""Tests for mesh creation utilities."""
+
+import numpy as np
+import pytest
+
+from src.space.mesh import create_mesh
+
+
+def test_create_mesh_invalid_dimension() -> None:
+    """Mesh creation should reject dimensions higher than three."""
+    with pytest.raises(ValueError):
+        create_mesh([1.0, 1.0, 1.0, 1.0], 0)
+
+
+def test_create_mesh_domain_extent() -> None:
+    """Generated mesh should span provided domain extents."""
+    mesh = create_mesh([1.0, 1.0], 1)
+    assert np.allclose(mesh.p.max(axis=1), [1.0, 1.0])


### PR DESCRIPTION
## Summary
- add pytest-benchmark and pytest-cov to dependencies
- exercise solver in a benchmark test and add mesh edge-case tests
- enable coverage reporting in CI

## Testing
- `pydocstyle src`
- `pytest --cov=src`


------
https://chatgpt.com/codex/tasks/task_e_68a1199793b083268faed08f480c89eb