### PR TITLE
Add roadmap documentation and reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ requirements.txt  Project dependencies
 tests/          Pytest-based test suite
 ```
 
+## Roadmap
+
+See [docs/ROADMAP.md](docs/ROADMAP.md) for development guidelines and prompt templates.
+
 ## License
 
 This project is provided as-is without warranty.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,5 @@
+# Roadmap
+
+1. Maintain this roadmap in `docs/ROADMAP.md` with short, numbered sections for easy retrieval.
+2. When using Codex, prepend prompts with the relevant roadmap excerpt and the target module's docstring for context.
+3. Standardize prompt templates with goal, constraints, and code snippet fields while respecting token limits.


### PR DESCRIPTION
## Summary
- Document roadmap and prompt guidelines in `docs/ROADMAP.md`
- Reference roadmap and prompting guidelines in README

## Testing
- No tests were run; docs-only change

------
https://chatgpt.com/codex/tasks/task_e_68a11c9396e88326911196f67ea7182a