### PR TITLE
Add Statsmodels and PyMC calibrators with synthetic tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Streamlit based user interface for interactive exploration.
 - Streamlit UI and plotting helpers
 - Example demo for adaptive mesh refinement
 - Comprehensive test suite using `pytest`
+- Parameter calibration helpers with SciPy, Statsmodels and Bayesian PyMC approaches
 - Experimental FEniCSx solver for Black-Scholes PDE
 
 ## Installation

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,8 @@ findiff
 numba
 jax
 aleatory
+statsmodels
+pymc
 pydocstyle
 pytest
 pytest-cov

--- a/src/estimation/README.md
+++ b/src/estimation/README.md
@@ -12,7 +12,13 @@ Calibrators expect three NumPy arrays of identical shape:
 
 These arrays define the option surface used during optimisation.  Example:
 
+The module includes:
+
+- ``HestonCalibrator`` using SciPy's least-squares optimizer
+- ``StatsmodelsCalibrator`` relying on statsmodels' ``NonlinearLS``
+- ``PyMCCalibrator`` performing Bayesian inference with PyMC
+
 ```python
-calib = HestonCalibrator(strikes, maturities, prices)
+calib = StatsmodelsCalibrator(strikes, maturities, prices)
 params = calib.calibrate(initial_guess)
 ```

--- a/src/estimation/__init__.py
+++ b/src/estimation/__init__.py
@@ -1,6 +1,21 @@
 """Estimation and calibration utilities."""
 
 from .calibrator import Calibrator
-from .heston import HestonCalibrator, sample_calibration
+from .heston import (
+    HestonCalibrator,
+    StatsmodelsCalibrator,
+    PyMCCalibrator,
+    sample_calibration,
+    sample_statsmodels_calibration,
+    sample_pymc_calibration,
+)
 
-__all__ = ["Calibrator", "HestonCalibrator", "sample_calibration"]
+__all__ = [
+    "Calibrator",
+    "HestonCalibrator",
+    "StatsmodelsCalibrator",
+    "PyMCCalibrator",
+    "sample_calibration",
+    "sample_statsmodels_calibration",
+    "sample_pymc_calibration",
+]

--- a/src/estimation/heston.py
+++ b/src/estimation/heston.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import Sequence
 
 import numpy as np
+from statsmodels.miscmodels.nonlinls import NonlinearLS
+import pymc as pm
 
 from .calibrator import Calibrator
 
@@ -45,6 +47,69 @@ class HestonCalibrator(Calibrator):
         return self.price_formula(self.strikes, self.maturities, params)
 
 
+class StatsmodelsCalibrator(HestonCalibrator):
+    """Calibrate using ``statsmodels`` nonlinear least squares."""
+
+    def calibrate(self, initial_guess: Sequence[float]) -> np.ndarray:  # type: ignore[override]
+        strikes, maturities = self.strikes, self.maturities
+
+        class _NLS(NonlinearLS):
+            def _predict(self, params: Sequence[float]) -> np.ndarray:
+                return HestonCalibrator.price_formula(strikes, maturities, params)
+
+        # Work around missing RegressionResults symbol in statsmodels.miscmodels
+        from statsmodels.regression.linear_model import RegressionResults
+        import statsmodels.regression as regression
+
+        if not hasattr(regression, "RegressionResults"):
+            regression.RegressionResults = RegressionResults
+
+        model = _NLS(endog=self.prices)
+        res = model.fit(start_value=np.asarray(initial_guess), nparams=len(initial_guess))
+        return res.params
+
+
+class PyMCCalibrator(HestonCalibrator):
+    """Bayesian calibration with :mod:`pymc` and simple priors."""
+
+    def calibrate(  # type: ignore[override]
+        self,
+        draws: int = 1000,
+        chains: int = 2,
+        tune: int | None = None,
+        random_seed: int | None = 123,
+        target_accept: float = 0.9,
+    ) -> np.ndarray:
+        """Return posterior means of the Heston parameters."""
+
+        if tune is None:
+            tune = draws
+
+        strikes, maturities = self.strikes, self.maturities
+
+        with pm.Model():
+            v0 = pm.Normal("v0", mu=0.04, sigma=0.1)
+            kappa = pm.Normal("kappa", mu=1.0, sigma=0.5)
+            theta = pm.Normal("theta", mu=0.04, sigma=0.1)
+            sigma = pm.HalfNormal("sigma", sigma=0.3)
+            rho = pm.Uniform("rho", lower=-1.0, upper=1.0)
+            params = pm.math.stack([v0, kappa, theta, sigma, rho])
+            mu = HestonCalibrator.price_formula(strikes, maturities, params)
+            pm.Normal("obs", mu=mu, sigma=0.01, observed=self.prices)
+            trace = pm.sample(
+                draws=draws,
+                tune=tune,
+                chains=chains,
+                random_seed=random_seed,
+                target_accept=target_accept,
+                progressbar=False,
+            )
+
+        posterior = trace.posterior
+        means = [posterior[var].mean().item() for var in ["v0", "kappa", "theta", "sigma", "rho"]]
+        return np.asarray(means)
+
+
 def sample_calibration() -> np.ndarray:
     """Run a toy calibration against synthetic market data.
 
@@ -63,3 +128,30 @@ def sample_calibration() -> np.ndarray:
     calibrator = HestonCalibrator(strikes, maturities, prices)
     initial_guess = true_params + np.array([0.01, -0.1, 0.02, -0.05, 0.1])
     return calibrator.calibrate(initial_guess)
+
+
+def sample_statsmodels_calibration() -> np.ndarray:
+    """Example calibration using :class:`StatsmodelsCalibrator`."""
+
+    s = np.linspace(80, 120, 5)
+    t = np.linspace(0.1, 1.0, 5)
+    strikes, maturities = np.meshgrid(s, t)
+    strikes, maturities = strikes.ravel(), maturities.ravel()
+    true_params = np.array([0.04, 1.0, 0.04, 0.3, -0.7])
+    prices = HestonCalibrator.price_formula(strikes, maturities, true_params)
+    calibrator = StatsmodelsCalibrator(strikes, maturities, prices)
+    initial_guess = true_params + np.array([0.01, -0.1, 0.02, -0.05, 0.1])
+    return calibrator.calibrate(initial_guess)
+
+
+def sample_pymc_calibration() -> np.ndarray:
+    """Example Bayesian calibration returning posterior means."""
+
+    s = np.linspace(80, 120, 5)
+    t = np.linspace(0.1, 1.0, 5)
+    strikes, maturities = np.meshgrid(s, t)
+    strikes, maturities = strikes.ravel(), maturities.ravel()
+    true_params = np.array([0.04, 1.0, 0.04, 0.3, -0.7])
+    prices = HestonCalibrator.price_formula(strikes, maturities, true_params)
+    calibrator = PyMCCalibrator(strikes, maturities, prices)
+    return calibrator.calibrate(draws=500, chains=2, random_seed=123)

--- a/src/examples/calibration_examples.py
+++ b/src/examples/calibration_examples.py
@@ -1,0 +1,41 @@
+"""Synthetic calibration examples for Heston parameters."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from src.estimation import (
+    HestonCalibrator,
+    StatsmodelsCalibrator,
+    PyMCCalibrator,
+)
+
+
+def synthetic_surface() -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Generate a toy option surface and corresponding prices."""
+
+    s = np.linspace(80, 120, 5)
+    t = np.linspace(0.1, 1.0, 5)
+    strikes, maturities = np.meshgrid(s, t)
+    strikes, maturities = strikes.ravel(), maturities.ravel()
+    true_params = np.array([0.04, 1.0, 0.04, 0.3, -0.7])
+    prices = HestonCalibrator.price_formula(strikes, maturities, true_params)
+    return strikes, maturities, prices, true_params
+
+
+def run_statsmodels() -> np.ndarray:
+    """Estimate parameters via :class:`StatsmodelsCalibrator`."""
+
+    strikes, maturities, prices, true_params = synthetic_surface()
+    initial = true_params + np.array([0.01, -0.1, 0.02, -0.05, 0.1])
+    calib = StatsmodelsCalibrator(strikes, maturities, prices)
+    return calib.calibrate(initial)
+
+
+def run_pymc() -> np.ndarray:
+    """Estimate parameters via :class:`PyMCCalibrator`."""
+
+    strikes, maturities, prices, _ = synthetic_surface()
+    calib = PyMCCalibrator(strikes, maturities, prices)
+    return calib.calibrate(draws=500, chains=2, random_seed=123)
+

--- a/tests/test_calibrator.py
+++ b/tests/test_calibrator.py
@@ -2,17 +2,41 @@
 
 import numpy as np
 
-from src.estimation import HestonCalibrator
+from src.estimation import (
+    HestonCalibrator,
+    StatsmodelsCalibrator,
+    PyMCCalibrator,
+)
 
 
-def test_heston_calibration_recovers_parameters() -> None:
+def _surface() -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     s = np.linspace(80, 120, 5)
     t = np.linspace(0.1, 1.0, 5)
     strikes, maturities = np.meshgrid(s, t)
     strikes, maturities = strikes.ravel(), maturities.ravel()
     true_params = np.array([0.04, 1.0, 0.04, 0.3, -0.7])
     prices = HestonCalibrator.price_formula(strikes, maturities, true_params)
+    return strikes, maturities, prices, true_params
+
+
+def test_heston_calibration_recovers_parameters() -> None:
+    strikes, maturities, prices, true_params = _surface()
     calibrator = HestonCalibrator(strikes, maturities, prices)
-    initial_guess = true_params + np.array([0.01, -0.1, 0.02, -0.05, 0.1])
-    estimated = calibrator.calibrate(initial_guess)
+    initial = true_params + np.array([0.01, -0.1, 0.02, -0.05, 0.1])
+    estimated = calibrator.calibrate(initial)
     assert np.allclose(estimated, true_params, atol=1e-2)
+
+
+def test_statsmodels_calibration_recovers_parameters() -> None:
+    strikes, maturities, prices, true_params = _surface()
+    calibrator = StatsmodelsCalibrator(strikes, maturities, prices)
+    initial = true_params + np.array([0.01, -0.1, 0.02, -0.05, 0.1])
+    estimated = calibrator.calibrate(initial)
+    assert np.allclose(estimated, true_params, atol=1e-2)
+
+
+def test_pymc_calibration_recovers_parameters() -> None:
+    strikes, maturities, prices, true_params = _surface()
+    calibrator = PyMCCalibrator(strikes, maturities, prices)
+    estimated = calibrator.calibrate(draws=200, chains=2, random_seed=123)
+    assert np.allclose(estimated, true_params, atol=0.15)


### PR DESCRIPTION
## Summary
- Implement `StatsmodelsCalibrator` using statsmodels' nonlinear least squares for Heston parameters.
- Prototype `PyMCCalibrator` leveraging PyMC priors and posterior sampling.
- Provide synthetic examples and unit tests demonstrating parameter recovery.

## Testing
- `pydocstyle src/estimation src/examples`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a12bbfb0308326b9f57d3027683917