### PR TITLE
Add Hypothesis invariants tests and CI benchmarking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,10 @@ jobs:
         run: pydocstyle src
       - name: Run tests
         run: pytest --cov=src --cov-report=xml
+      - name: Run benchmarks
+        run: pytest tests/test_benchmark_black_scholes.py --benchmark-json=benchmark.json
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: solver-benchmarks
+          path: benchmark.json

--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ suite. Coverage reports are generated via `pytest-cov`:
 pytest --cov=src
 ```
 
+## Benchmarking
+
+Solver performance is tracked with `pytest-benchmark`.  Run the dedicated
+benchmark suite locally to measure runtime on a fixed mesh:
+
+```bash
+pytest tests/test_benchmark_black_scholes.py --benchmark-only
+```
+
+Results can be saved for comparison and analysed with `pytest-benchmark compare`.
+See [docs/benchmarking.md](docs/benchmarking.md) for details on
+interpreting the output and contrasting runs.
+
 ### FEniCSx Spike
 
 An experimental `FenicsSolver` mirrors the existing scikit-fem backend using

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,0 +1,32 @@
+# Benchmarking
+
+This project uses [`pytest-benchmark`](https://pytest-benchmark.readthedocs.io/) to
+track solver runtime on fixed meshes.  Benchmarks are executed both locally and
+on the continuous integration server.
+
+## Running Benchmarks Locally
+
+Run the benchmark tests in isolation to focus on performance measurements:
+
+```bash
+pytest tests/test_benchmark_black_scholes.py --benchmark-only
+```
+
+To store results for later comparison, write them to a JSON file:
+
+```bash
+pytest tests/test_benchmark_black_scholes.py --benchmark-json=benchmark.json
+```
+
+## Interpreting Results
+
+The JSON output records statistics such as mean, median and minimum runtime for
+each benchmarked function.  Lower values indicate faster solver performance.
+`pytest-benchmark` can compare multiple runs to track regressions:
+
+```bash
+pytest-benchmark compare benchmark.json path/to/previous.json
+```
+
+CI runs publish the latest `benchmark.json` file as a workflow artifact, making
+it easy to download and contrast with local measurements.

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,6 @@ pydocstyle
 pytest
 pytest-cov
 pytest-benchmark
+hypothesis
 # Optional FEniCS backend
 # fenics-dolfinx

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -1,0 +1,69 @@
+"""Property-based tests for payoff and boundary condition invariants."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import scipy.sparse as sps
+from hypothesis import given, strategies as st
+
+from src.core.market import Market
+from src.core.vanilla_bs import EuropeanOptionBs
+from src.space.boundary import apply_dirichlet
+
+
+@given(
+    s=st.floats(min_value=0.0, max_value=1e3, allow_nan=False, allow_infinity=False),
+    k=st.floats(min_value=1e-3, max_value=1e3, allow_nan=False, allow_infinity=False),
+)
+def test_payoff_invariants(s: float, k: float) -> None:
+    """European option payoffs are non-negative and match definitions."""
+    mkt = Market(r=0.01)
+    payoff = EuropeanOptionBs(k=k, q=0.0, mkt=mkt)
+
+    call = payoff.call_payoff(s)
+    put = payoff.put_payoff(s)
+
+    assert call >= 0.0
+    assert put >= 0.0
+    assert call == pytest.approx(max(s - k, 0.0))
+    assert put == pytest.approx(max(k - s, 0.0))
+
+
+@given(
+    n=st.integers(min_value=2, max_value=6),
+    data=st.data(),
+)
+def test_apply_dirichlet_enforces_values(n: int, data: st.DataObject) -> None:
+    """apply_dirichlet sets enforced rows, columns and vector entries."""
+    dofs = data.draw(
+        st.lists(
+            st.integers(min_value=0, max_value=n - 1),
+            min_size=1,
+            max_size=n,
+            unique=True,
+        )
+    )
+
+    A = sps.csr_matrix(np.arange(n * n, dtype=float).reshape(n, n))
+    b = np.arange(n, dtype=float)
+    x = np.arange(n, dtype=float) + 0.5
+
+    class _Basis:
+        def get_dofs(self, boundaries):
+            return np.array(dofs)
+
+    A_enf, b_enf = apply_dirichlet(A.copy(), b.copy(), _Basis(), ["bd"], x)
+
+    for idx in dofs:
+        row = A_enf.getrow(idx).toarray().ravel()
+        expected = np.zeros(n)
+        expected[idx] = 1.0
+        assert np.allclose(row, expected)
+        assert b_enf[idx] == pytest.approx(x[idx])
+
+    for idx in set(range(n)) - set(dofs):
+        assert np.allclose(
+            A_enf.getrow(idx).toarray(), A.getrow(idx).toarray()
+        )
+        assert b_enf[idx] == pytest.approx(b[idx])


### PR DESCRIPTION
## Summary
- add Hypothesis-based tests for payoff non-negativity and Dirichlet enforcement
- record solver runtime in CI and upload benchmark artifact
- document running and interpreting benchmarks

## Testing
- `pydocstyle tests/test_invariants.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a130a2cfbc8326a5679d19ffef2e8c