### PR TITLE
Add DataFrame market data and xarray snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Streamlit based user interface for interactive exploration.
 - Example demo for adaptive mesh refinement
 - Comprehensive test suite using `pytest`
 - Parameter calibration helpers with SciPy, Statsmodels and Bayesian PyMC approaches
+- Market data handled via pandas DataFrames and solution snapshots via xarray
+- CSV/Parquet serialisation utilities for reproducible experiments
 - Experimental FEniCSx solver for Black-Scholes PDE
 
 ## Installation

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,9 @@ jax
 aleatory
 statsmodels
 pymc
+pandas
+xarray
+pyarrow
 pydocstyle
 pytest
 pytest-cov

--- a/src/data_utils.py
+++ b/src/data_utils.py
@@ -1,0 +1,85 @@
+"""Helpers for market data and solution snapshots.
+
+This module centralises utilities for constructing pandas DataFrames and
+xarray DataArrays used throughout the project.  It also provides simple
+serialisation helpers enabling reproducible experiments.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+
+# ---------------------------------------------------------------------------
+# Market data helpers
+
+
+def make_market_dataframe(
+    strikes: Iterable[float],
+    maturities: Iterable[float],
+    prices: Iterable[float],
+) -> pd.DataFrame:
+    """Return a canonical market DataFrame.
+
+    Parameters
+    ----------
+    strikes, maturities, prices:
+        One-dimensional sequences describing the option surface.
+    """
+
+    return pd.DataFrame({"strike": strikes, "maturity": maturities, "price": prices})
+
+
+def df_to_csv(df: pd.DataFrame, path: str | Path) -> None:
+    """Serialise ``df`` to ``path`` in CSV format."""
+
+    df.to_csv(path, index=False)
+
+
+def df_to_parquet(df: pd.DataFrame, path: str | Path) -> None:
+    """Serialise ``df`` to ``path`` in Parquet format."""
+
+    df.to_parquet(path, index=False)
+
+
+def df_from_csv(path: str | Path) -> pd.DataFrame:
+    """Load market data from ``path`` stored in CSV format."""
+
+    return pd.read_csv(path)
+
+
+def df_from_parquet(path: str | Path) -> pd.DataFrame:
+    """Load market data from ``path`` stored in Parquet format."""
+
+    return pd.read_parquet(path)
+
+
+# ---------------------------------------------------------------------------
+# Solution snapshot helpers
+
+
+def snapshot(
+    array: np.ndarray,
+    time_grid: Iterable[float],
+    space_grid: Iterable[float],
+) -> xr.DataArray:
+    """Convert ``array`` into an :class:`xarray.DataArray` snapshot.
+
+    Parameters
+    ----------
+    array:
+        Two-dimensional ``time`` × ``space`` array of option values.
+    time_grid, space_grid:
+        Coordinate vectors for the respective axes.
+    """
+
+    return xr.DataArray(
+        array,
+        coords={"time": np.asarray(list(time_grid)), "space": np.asarray(list(space_grid))},
+        dims=("time", "space"),
+    )

--- a/src/estimation/heston.py
+++ b/src/estimation/heston.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Sequence
 
 import numpy as np
+import pandas as pd
 from statsmodels.miscmodels.nonlinls import NonlinearLS
 import pymc as pm
 
@@ -51,6 +52,7 @@ class StatsmodelsCalibrator(HestonCalibrator):
     """Calibrate using ``statsmodels`` nonlinear least squares."""
 
     def calibrate(self, initial_guess: Sequence[float]) -> np.ndarray:  # type: ignore[override]
+        """Return parameters estimated via ``statsmodels`` NLS solver."""
         strikes, maturities = self.strikes, self.maturities
 
         class _NLS(NonlinearLS):
@@ -125,7 +127,8 @@ def sample_calibration() -> np.ndarray:
     strikes, maturities = strikes.ravel(), maturities.ravel()
     true_params = np.array([0.04, 1.0, 0.04, 0.3, -0.7])
     prices = HestonCalibrator.price_formula(strikes, maturities, true_params)
-    calibrator = HestonCalibrator(strikes, maturities, prices)
+    data = pd.DataFrame({"strike": strikes, "maturity": maturities, "price": prices})
+    calibrator = HestonCalibrator(data)
     initial_guess = true_params + np.array([0.01, -0.1, 0.02, -0.05, 0.1])
     return calibrator.calibrate(initial_guess)
 
@@ -139,7 +142,8 @@ def sample_statsmodels_calibration() -> np.ndarray:
     strikes, maturities = strikes.ravel(), maturities.ravel()
     true_params = np.array([0.04, 1.0, 0.04, 0.3, -0.7])
     prices = HestonCalibrator.price_formula(strikes, maturities, true_params)
-    calibrator = StatsmodelsCalibrator(strikes, maturities, prices)
+    data = pd.DataFrame({"strike": strikes, "maturity": maturities, "price": prices})
+    calibrator = StatsmodelsCalibrator(data)
     initial_guess = true_params + np.array([0.01, -0.1, 0.02, -0.05, 0.1])
     return calibrator.calibrate(initial_guess)
 
@@ -153,5 +157,6 @@ def sample_pymc_calibration() -> np.ndarray:
     strikes, maturities = strikes.ravel(), maturities.ravel()
     true_params = np.array([0.04, 1.0, 0.04, 0.3, -0.7])
     prices = HestonCalibrator.price_formula(strikes, maturities, true_params)
-    calibrator = PyMCCalibrator(strikes, maturities, prices)
+    data = pd.DataFrame({"strike": strikes, "maturity": maturities, "price": prices})
+    calibrator = PyMCCalibrator(data)
     return calibrator.calibrate(draws=500, chains=2, random_seed=123)

--- a/tests/test_calibrator.py
+++ b/tests/test_calibrator.py
@@ -1,6 +1,7 @@
 """Tests for calibration utilities."""
 
 import numpy as np
+import pandas as pd
 
 from src.estimation import (
     HestonCalibrator,
@@ -9,34 +10,35 @@ from src.estimation import (
 )
 
 
-def _surface() -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+def _surface() -> tuple[pd.DataFrame, np.ndarray]:
     s = np.linspace(80, 120, 5)
     t = np.linspace(0.1, 1.0, 5)
     strikes, maturities = np.meshgrid(s, t)
     strikes, maturities = strikes.ravel(), maturities.ravel()
     true_params = np.array([0.04, 1.0, 0.04, 0.3, -0.7])
     prices = HestonCalibrator.price_formula(strikes, maturities, true_params)
-    return strikes, maturities, prices, true_params
+    data = pd.DataFrame({"strike": strikes, "maturity": maturities, "price": prices})
+    return data, true_params
 
 
 def test_heston_calibration_recovers_parameters() -> None:
-    strikes, maturities, prices, true_params = _surface()
-    calibrator = HestonCalibrator(strikes, maturities, prices)
+    data, true_params = _surface()
+    calibrator = HestonCalibrator(data)
     initial = true_params + np.array([0.01, -0.1, 0.02, -0.05, 0.1])
     estimated = calibrator.calibrate(initial)
     assert np.allclose(estimated, true_params, atol=1e-2)
 
 
 def test_statsmodels_calibration_recovers_parameters() -> None:
-    strikes, maturities, prices, true_params = _surface()
-    calibrator = StatsmodelsCalibrator(strikes, maturities, prices)
+    data, true_params = _surface()
+    calibrator = StatsmodelsCalibrator(data)
     initial = true_params + np.array([0.01, -0.1, 0.02, -0.05, 0.1])
     estimated = calibrator.calibrate(initial)
     assert np.allclose(estimated, true_params, atol=1e-2)
 
 
 def test_pymc_calibration_recovers_parameters() -> None:
-    strikes, maturities, prices, true_params = _surface()
-    calibrator = PyMCCalibrator(strikes, maturities, prices)
+    data, true_params = _surface()
+    calibrator = PyMCCalibrator(data)
     estimated = calibrator.calibrate(draws=200, chains=2, random_seed=123)
     assert np.allclose(estimated, true_params, atol=0.15)

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -1,0 +1,33 @@
+"""Tests for data utility helpers."""
+
+import pandas as pd
+
+from src.data_utils import (
+    make_market_dataframe,
+    df_to_csv,
+    df_from_csv,
+    df_to_parquet,
+    df_from_parquet,
+    snapshot,
+)
+
+import numpy as np
+
+
+def test_dataframe_roundtrip(tmp_path):
+    df = make_market_dataframe([1, 2], [0.5, 0.6], [0.1, 0.2])
+    csv_path = tmp_path / "market.csv"
+    pq_path = tmp_path / "market.parquet"
+    df_to_csv(df, csv_path)
+    df_to_parquet(df, pq_path)
+    assert df.equals(df_from_csv(csv_path))
+    assert df.equals(df_from_parquet(pq_path))
+
+
+def test_snapshot_creation():
+    arr = np.arange(6).reshape(2, 3)
+    time = [0, 1]
+    space = [10, 20, 30]
+    da = snapshot(arr, time, space)
+    assert da.dims == ("time", "space")
+    assert np.all(da[0].values == arr[0])

--- a/tests/test_fd_black_scholes.py
+++ b/tests/test_fd_black_scholes.py
@@ -23,10 +23,10 @@ def test_fd_black_scholes_price():
 
     s0 = 1.0
     idx = np.argmin(np.abs(s_grid - s0))
-    price_num = v[-1, idx]
+    price_num = v.sel(time=t[-1], space=s0, method="nearest").item()
     price_exact = bsopt.call(t[-1], s0, dh.sig ** 2)
     assert price_num == pytest.approx(price_exact, rel=1e-2)
 
-    d_num = delta(v[-1], s_grid[1] - s_grid[0])[idx]
+    d_num = delta(v.sel(time=t[-1]).values, s_grid[1] - s_grid[0])[idx]
     d_exact = bsopt.call_delta(t[-1], s0, dh.sig ** 2)
     assert d_num == pytest.approx(d_exact, rel=2e-2)


### PR DESCRIPTION
## Summary
- Refactor Calibrator to accept market data as pandas DataFrames and expose DataFrame helpers
- Return xarray DataArray snapshots from the finite-difference solver
- Add serialization utilities for CSV/Parquet and corresponding tests

## Testing
- `pydocstyle src/estimation/calibrator.py src/estimation/heston.py src/fdsolver.py src/data_utils.py tests/test_calibrator.py tests/test_fd_black_scholes.py tests/test_data_utils.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a135754cb883269ae42c767097ad32