### PR TITLE
docs: expand README with quickstart and demo svg image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,25 @@
 # Finite Element Options
 
 Finite Element Options demonstrates pricing of European options under various
-stochastic models using a finite element discretisation.  The application is
+stochastic models using a finite element discretisation. The application is
 built around [scikit-fem](https://github.com/kinnala/scikit-fem) and provides a
-Streamlit based user interface for interactive exploration.
+Streamlit-based user interface for interactive exploration.
+
+## Quickstart
+
+Install the dependencies and run a simple Black–Scholes pricing example:
+
+```bash
+pip install -r requirements.txt
+python - <<'PY'
+from src.examples.bs_1d import price_call
+grid = price_call()
+print(grid[-1])  # option values at maturity
+PY
+```
+
+The snippet solves a one-dimensional Black–Scholes problem using default
+parameters and prints the final price grid.
 
 ## Features
 
@@ -42,6 +58,13 @@ Run the adaptive mesh demo:
 ```bash
 python demo_adaptive.py
 ```
+
+### Example Output
+
+The adaptive mesh demo refines the domain around sharp features. The final
+solution after several refinement steps is shown below:
+
+![Adaptive mesh solution showing refined grid](docs/images/adaptive_solution.svg)
 
 ## Testing
 

--- a/docs/images/adaptive_solution.svg
+++ b/docs/images/adaptive_solution.svg
@@ -1,0 +1,7041 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="460.8pt" height="345.6pt" viewBox="0 0 460.8 345.6" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2025-08-17T02:57:45.912332</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.5, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 345.6 
+L 460.8 345.6 
+L 460.8 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 57.6 307.584 
+L 343.296 307.584 
+L 343.296 41.472 
+L 57.6 41.472 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="PolyCollection_1">
+    <path d="M 330.309818 174.528 
+L 318.044913 186.194264 
+L 312.609405 173.544062 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #890000"/>
+    <path d="M 305.780008 197.860528 
+L 318.044913 186.194264 
+L 300.3445 185.210327 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #b20000"/>
+    <path d="M 294.908991 172.560125 
+L 312.609405 173.544062 
+L 300.3445 185.210327 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #960000"/>
+    <path d="M 318.044913 186.194264 
+L 312.609405 173.544062 
+L 300.3445 185.210327 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #9b0000"/>
+    <path d="M 140.773746 177.431432 
+L 126.953083 172.353627 
+L 135.692598 165.271707 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3f00"/>
+    <path d="M 113.13242 167.275822 
+L 126.953083 172.353627 
+L 121.871936 160.193902 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3f00"/>
+    <path d="M 130.611451 153.111981 
+L 135.692598 165.271707 
+L 121.871936 160.193902 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4300"/>
+    <path d="M 126.953083 172.353627 
+L 135.692598 165.271707 
+L 121.871936 160.193902 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3f00"/>
+    <path d="M 261.206458 168.893794 
+L 278.057725 170.72696 
+L 266.812378 183.773079 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #b60000"/>
+    <path d="M 294.908991 172.560125 
+L 278.057725 170.72696 
+L 283.663644 185.606244 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a40000"/>
+    <path d="M 272.418297 198.652363 
+L 266.812378 183.773079 
+L 283.663644 185.606244 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d10000"/>
+    <path d="M 278.057725 170.72696 
+L 266.812378 183.773079 
+L 283.663644 185.606244 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #bb0000"/>
+    <path d="M 186.700092 115.845387 
+L 190.198868 105.067279 
+L 201.769105 114.087481 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffe200"/>
+    <path d="M 193.697644 94.28917 
+L 190.198868 105.067279 
+L 205.267881 103.309372 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #beff39"/>
+    <path d="M 216.838119 112.329574 
+L 201.769105 114.087481 
+L 205.267881 103.309372 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffe600"/>
+    <path d="M 190.198868 105.067279 
+L 201.769105 114.087481 
+L 205.267881 103.309372 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #eeff09"/>
+    <path d="M 248.022952 115.210555 
+L 238.312324 126.080257 
+L 232.430535 113.770065 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8d00"/>
+    <path d="M 228.601695 136.949959 
+L 238.312324 126.080257 
+L 222.719907 124.639767 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5d00"/>
+    <path d="M 216.838119 112.329574 
+L 232.430535 113.770065 
+L 222.719907 124.639767 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffa700"/>
+    <path d="M 238.312324 126.080257 
+L 232.430535 113.770065 
+L 222.719907 124.639767 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8600"/>
+    <path d="M 113.13242 167.275822 
+L 107.856787 154.639784 
+L 121.871936 160.193902 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4700"/>
+    <path d="M 102.581153 142.003745 
+L 107.856787 154.639784 
+L 116.596302 147.557863 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5900"/>
+    <path d="M 130.611451 153.111981 
+L 121.871936 160.193902 
+L 116.596302 147.557863 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4a00"/>
+    <path d="M 107.856787 154.639784 
+L 121.871936 160.193902 
+L 116.596302 147.557863 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4e00"/>
+    <path d="M 305.780008 197.860528 
+L 300.3445 185.210327 
+L 289.099152 198.256446 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #c40000"/>
+    <path d="M 294.908991 172.560125 
+L 300.3445 185.210327 
+L 283.663644 185.606244 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a80000"/>
+    <path d="M 272.418297 198.652363 
+L 289.099152 198.256446 
+L 283.663644 185.606244 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d60000"/>
+    <path d="M 300.3445 185.210327 
+L 289.099152 198.256446 
+L 283.663644 185.606244 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #bf0000"/>
+    <path d="M 267.000443 228.961756 
+L 251.52746 220.201184 
+L 269.70937 213.807059 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8200"/>
+    <path d="M 236.054477 211.440613 
+L 251.52746 220.201184 
+L 254.236387 205.046488 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5d00"/>
+    <path d="M 272.418297 198.652363 
+L 269.70937 213.807059 
+L 254.236387 205.046488 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2d00"/>
+    <path d="M 251.52746 220.201184 
+L 269.70937 213.807059 
+L 254.236387 205.046488 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5900"/>
+    <path d="M 248.022952 115.210555 
+L 238.312324 126.080257 
+L 255.879455 127.45058 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6c00"/>
+    <path d="M 228.601695 136.949959 
+L 238.312324 126.080257 
+L 246.168826 138.320282 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3b00"/>
+    <path d="M 263.735957 139.690605 
+L 255.879455 127.45058 
+L 246.168826 138.320282 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2500"/>
+    <path d="M 238.312324 126.080257 
+L 255.879455 127.45058 
+L 246.168826 138.320282 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4300"/>
+    <path d="M 186.700092 115.845387 
+L 175.552531 105.286565 
+L 190.198868 105.067279 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #eeff09"/>
+    <path d="M 164.40497 94.727743 
+L 175.552531 105.286565 
+L 179.051307 94.508457 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a0ff56"/>
+    <path d="M 193.697644 94.28917 
+L 190.198868 105.067279 
+L 179.051307 94.508457 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a4ff53"/>
+    <path d="M 175.552531 105.286565 
+L 190.198868 105.067279 
+L 179.051307 94.508457 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #baff3c"/>
+    <path d="M 70.586182 53.568 
+L 70.586182 68.688 
+L 80.080223 64.590789 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000e8"/>
+    <path d="M 70.586182 83.808 
+L 70.586182 68.688 
+L 80.080223 79.710789 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00b4ff"/>
+    <path d="M 89.574264 75.613577 
+L 80.080223 64.590789 
+L 80.080223 79.710789 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0080ff"/>
+    <path d="M 70.586182 68.688 
+L 80.080223 64.590789 
+L 80.080223 79.710789 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0058ff"/>
+    <path d="M 70.586182 114.048 
+L 79.857168 118.371033 
+L 80.596764 106.76695 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #fbf100"/>
+    <path d="M 89.128155 122.694066 
+L 79.857168 118.371033 
+L 89.867751 111.089984 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffd700"/>
+    <path d="M 90.607347 99.485901 
+L 80.596764 106.76695 
+L 89.867751 111.089984 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #caff2c"/>
+    <path d="M 79.857168 118.371033 
+L 80.596764 106.76695 
+L 89.867751 111.089984 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f1fc06"/>
+    <path d="M 267.000443 228.961756 
+L 283.000117 233.165504 
+L 279.317356 223.453466 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffa300"/>
+    <path d="M 298.999791 237.369252 
+L 283.000117 233.165504 
+L 295.31703 227.657214 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffb900"/>
+    <path d="M 291.63427 217.945177 
+L 279.317356 223.453466 
+L 295.31703 227.657214 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7700"/>
+    <path d="M 283.000117 233.165504 
+L 279.317356 223.453466 
+L 295.31703 227.657214 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff9c00"/>
+    <path d="M 70.586182 235.008 
+L 88.182737 235.443424 
+L 81.847439 226.439865 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #dbff1c"/>
+    <path d="M 105.779291 235.878849 
+L 88.182737 235.443424 
+L 99.443993 226.875289 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d7ff1f"/>
+    <path d="M 93.108695 217.871729 
+L 81.847439 226.439865 
+L 99.443993 226.875289 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffe600"/>
+    <path d="M 88.182737 235.443424 
+L 81.847439 226.439865 
+L 99.443993 226.875289 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #e7ff0f"/>
+    <path d="M 209.018025 229.970423 
+L 208.802201 239.604306 
+L 221.888141 236.195657 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #e7ff0f"/>
+    <path d="M 208.586377 249.238188 
+L 208.802201 239.604306 
+L 221.672317 245.82954 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a4ff53"/>
+    <path d="M 234.758257 242.420891 
+L 221.888141 236.195657 
+L 221.672317 245.82954 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #c7ff30"/>
+    <path d="M 208.802201 239.604306 
+L 221.888141 236.195657 
+L 221.672317 245.82954 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #c7ff30"/>
+    <path d="M 209.018025 229.970423 
+L 205.168522 217.319084 
+L 197.520695 227.532285 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffcc00"/>
+    <path d="M 201.319018 204.667744 
+L 205.168522 217.319084 
+L 193.671192 214.880945 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8900"/>
+    <path d="M 186.023366 225.094146 
+L 197.520695 227.532285 
+L 193.671192 214.880945 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffc100"/>
+    <path d="M 205.168522 217.319084 
+L 197.520695 227.532285 
+L 193.671192 214.880945 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffb200"/>
+    <path d="M 113.592083 86.249074 
+L 101.583174 80.931326 
+L 102.099715 92.867488 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #39ffbe"/>
+    <path d="M 89.574264 75.613577 
+L 101.583174 80.931326 
+L 90.090806 87.549739 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #02e8f4"/>
+    <path d="M 90.607347 99.485901 
+L 102.099715 92.867488 
+L 90.090806 87.549739 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #6dff8a"/>
+    <path d="M 101.583174 80.931326 
+L 102.099715 92.867488 
+L 90.090806 87.549739 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #36ffc1"/>
+    <path d="M 102.581153 142.003745 
+L 95.854654 132.348906 
+L 106.888838 129.380265 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8600"/>
+    <path d="M 89.128155 122.694066 
+L 95.854654 132.348906 
+L 100.162339 119.725425 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffae00"/>
+    <path d="M 111.196524 116.756784 
+L 106.888838 129.380265 
+L 100.162339 119.725425 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffbd00"/>
+    <path d="M 95.854654 132.348906 
+L 106.888838 129.380265 
+L 100.162339 119.725425 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffa300"/>
+    <path d="M 305.780008 197.860528 
+L 298.707139 207.902852 
+L 308.867045 208.577549 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f60b00"/>
+    <path d="M 291.63427 217.945177 
+L 298.707139 207.902852 
+L 301.794176 218.619873 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3f00"/>
+    <path d="M 311.954082 219.294569 
+L 308.867045 208.577549 
+L 301.794176 218.619873 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3b00"/>
+    <path d="M 298.707139 207.902852 
+L 308.867045 208.577549 
+L 301.794176 218.619873 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2d00"/>
+    <path d="M 105.499696 199.627051 
+L 99.304196 208.74939 
+L 110.444201 208.504734 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8d00"/>
+    <path d="M 93.108695 217.871729 
+L 99.304196 208.74939 
+L 104.248701 217.627073 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffb200"/>
+    <path d="M 115.388706 217.382417 
+L 110.444201 208.504734 
+L 104.248701 217.627073 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffb200"/>
+    <path d="M 99.304196 208.74939 
+L 110.444201 208.504734 
+L 104.248701 217.627073 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffa700"/>
+    <path d="M 70.586182 114.048 
+L 70.586182 98.928 
+L 80.596764 106.76695 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ceff29"/>
+    <path d="M 70.586182 83.808 
+L 70.586182 98.928 
+L 80.596764 91.64695 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #5dff9a"/>
+    <path d="M 90.607347 99.485901 
+L 80.596764 106.76695 
+L 80.596764 91.64695 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #9dff5a"/>
+    <path d="M 70.586182 98.928 
+L 80.596764 106.76695 
+L 80.596764 91.64695 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #97ff60"/>
+    <path d="M 113.592083 86.249074 
+L 102.099715 92.867488 
+L 112.394304 101.502929 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #70ff87"/>
+    <path d="M 90.607347 99.485901 
+L 102.099715 92.867488 
+L 100.901935 108.121343 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a4ff53"/>
+    <path d="M 111.196524 116.756784 
+L 112.394304 101.502929 
+L 100.901935 108.121343 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #deff19"/>
+    <path d="M 102.099715 92.867488 
+L 112.394304 101.502929 
+L 100.901935 108.121343 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a4ff53"/>
+    <path d="M 330.309818 235.008 
+L 314.654804 236.188626 
+L 321.13195 227.151285 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffa700"/>
+    <path d="M 298.999791 237.369252 
+L 314.654804 236.188626 
+L 305.476937 228.331911 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffb900"/>
+    <path d="M 311.954082 219.294569 
+L 321.13195 227.151285 
+L 305.476937 228.331911 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7700"/>
+    <path d="M 314.654804 236.188626 
+L 321.13195 227.151285 
+L 305.476937 228.331911 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff9c00"/>
+    <path d="M 135.339984 229.015738 
+L 120.559638 232.447293 
+L 125.364345 223.199078 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f1fc06"/>
+    <path d="M 105.779291 235.878849 
+L 120.559638 232.447293 
+L 110.583999 226.630633 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #deff19"/>
+    <path d="M 115.388706 217.382417 
+L 125.364345 223.199078 
+L 110.583999 226.630633 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffdb00"/>
+    <path d="M 120.559638 232.447293 
+L 125.364345 223.199078 
+L 110.583999 226.630633 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f4f802"/>
+    <path d="M 70.586182 83.808 
+L 80.080223 79.710789 
+L 80.596764 91.64695 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #29ffce"/>
+    <path d="M 89.574264 75.613577 
+L 80.080223 79.710789 
+L 90.090806 87.549739 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00e0fb"/>
+    <path d="M 90.607347 99.485901 
+L 80.596764 91.64695 
+L 90.090806 87.549739 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #6aff8d"/>
+    <path d="M 80.080223 79.710789 
+L 80.596764 91.64695 
+L 90.090806 87.549739 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #30ffc7"/>
+    <path d="M 89.128155 122.694066 
+L 89.867751 111.089984 
+L 100.162339 119.725425 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffd700"/>
+    <path d="M 90.607347 99.485901 
+L 89.867751 111.089984 
+L 100.901935 108.121343 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ceff29"/>
+    <path d="M 111.196524 116.756784 
+L 100.162339 119.725425 
+L 100.901935 108.121343 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffe600"/>
+    <path d="M 89.867751 111.089984 
+L 100.162339 119.725425 
+L 100.901935 108.121343 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f8f500"/>
+    <path d="M 298.999791 237.369252 
+L 295.31703 227.657214 
+L 305.476937 228.331911 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffab00"/>
+    <path d="M 291.63427 217.945177 
+L 295.31703 227.657214 
+L 301.794176 218.619873 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6800"/>
+    <path d="M 311.954082 219.294569 
+L 305.476937 228.331911 
+L 301.794176 218.619873 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6400"/>
+    <path d="M 295.31703 227.657214 
+L 305.476937 228.331911 
+L 301.794176 218.619873 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7e00"/>
+    <path d="M 105.779291 235.878849 
+L 99.443993 226.875289 
+L 110.583999 226.630633 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #e4ff13"/>
+    <path d="M 93.108695 217.871729 
+L 99.443993 226.875289 
+L 104.248701 217.627073 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffd300"/>
+    <path d="M 115.388706 217.382417 
+L 110.583999 226.630633 
+L 104.248701 217.627073 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffd300"/>
+    <path d="M 99.443993 226.875289 
+L 110.583999 226.630633 
+L 104.248701 217.627073 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffe600"/>
+    <path d="M 330.309818 174.528 
+L 318.044913 186.194264 
+L 330.309818 189.648 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #960000"/>
+    <path d="M 305.780008 197.860528 
+L 318.044913 186.194264 
+L 318.044913 201.314264 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #bf0000"/>
+    <path d="M 330.309818 204.768 
+L 330.309818 189.648 
+L 318.044913 201.314264 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #c80000"/>
+    <path d="M 318.044913 186.194264 
+L 330.309818 189.648 
+L 318.044913 201.314264 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #b60000"/>
+    <path d="M 102.581153 142.003745 
+L 86.583667 143.145873 
+L 95.854654 132.348906 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6f00"/>
+    <path d="M 70.586182 144.288 
+L 86.583667 143.145873 
+L 79.857168 133.491033 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6c00"/>
+    <path d="M 89.128155 122.694066 
+L 95.854654 132.348906 
+L 79.857168 133.491033 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff9800"/>
+    <path d="M 86.583667 143.145873 
+L 95.854654 132.348906 
+L 79.857168 133.491033 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7a00"/>
+    <path d="M 105.499696 199.627051 
+L 88.042939 202.197526 
+L 99.304196 208.74939 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8200"/>
+    <path d="M 70.586182 204.768 
+L 88.042939 202.197526 
+L 81.847439 211.319865 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8900"/>
+    <path d="M 93.108695 217.871729 
+L 99.304196 208.74939 
+L 81.847439 211.319865 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffab00"/>
+    <path d="M 88.042939 202.197526 
+L 99.304196 208.74939 
+L 81.847439 211.319865 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff9400"/>
+    <path d="M 305.780008 197.860528 
+L 318.044913 201.314264 
+L 308.867045 208.577549 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #df0000"/>
+    <path d="M 330.309818 204.768 
+L 318.044913 201.314264 
+L 321.13195 212.031285 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ed0400"/>
+    <path d="M 311.954082 219.294569 
+L 308.867045 208.577549 
+L 321.13195 212.031285 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2d00"/>
+    <path d="M 318.044913 201.314264 
+L 308.867045 208.577549 
+L 321.13195 212.031285 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #fa0f00"/>
+    <path d="M 70.586182 114.048 
+L 70.586182 129.168 
+L 79.857168 118.371033 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffc400"/>
+    <path d="M 70.586182 144.288 
+L 70.586182 129.168 
+L 79.857168 133.491033 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8200"/>
+    <path d="M 89.128155 122.694066 
+L 79.857168 118.371033 
+L 79.857168 133.491033 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffae00"/>
+    <path d="M 70.586182 129.168 
+L 79.857168 118.371033 
+L 79.857168 133.491033 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffa700"/>
+    <path d="M 70.586182 235.008 
+L 70.586182 219.888 
+L 81.847439 226.439865 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f4f802"/>
+    <path d="M 70.586182 204.768 
+L 70.586182 219.888 
+L 81.847439 211.319865 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffa700"/>
+    <path d="M 93.108695 217.871729 
+L 81.847439 226.439865 
+L 81.847439 211.319865 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffc800"/>
+    <path d="M 70.586182 219.888 
+L 81.847439 226.439865 
+L 81.847439 211.319865 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffd000"/>
+    <path d="M 330.309818 235.008 
+L 330.309818 219.888 
+L 321.13195 227.151285 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8200"/>
+    <path d="M 330.309818 204.768 
+L 330.309818 219.888 
+L 321.13195 212.031285 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2500"/>
+    <path d="M 311.954082 219.294569 
+L 321.13195 227.151285 
+L 321.13195 212.031285 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5200"/>
+    <path d="M 330.309818 219.888 
+L 321.13195 227.151285 
+L 321.13195 212.031285 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5200"/>
+    <path d="M 70.586182 53.568 
+L 86.818909 53.568 
+L 80.080223 64.590789 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #000096"/>
+    <path d="M 103.051636 53.568 
+L 86.818909 53.568 
+L 96.31295 64.590789 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #000096"/>
+    <path d="M 89.574264 75.613577 
+L 80.080223 64.590789 
+L 96.31295 64.590789 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0038ff"/>
+    <path d="M 86.818909 53.568 
+L 80.080223 64.590789 
+L 96.31295 64.590789 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000d1"/>
+    <path d="M 135.339984 229.015738 
+L 137.237609 215.960966 
+L 125.364345 223.199078 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffdb00"/>
+    <path d="M 139.135233 202.906194 
+L 137.237609 215.960966 
+L 127.26197 210.144305 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff9800"/>
+    <path d="M 115.388706 217.382417 
+L 125.364345 223.199078 
+L 127.26197 210.144305 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffbd00"/>
+    <path d="M 137.237609 215.960966 
+L 125.364345 223.199078 
+L 127.26197 210.144305 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffbd00"/>
+    <path d="M 113.592083 86.249074 
+L 108.32186 69.908537 
+L 101.583174 80.931326 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00c8ff"/>
+    <path d="M 103.051636 53.568 
+L 108.32186 69.908537 
+L 96.31295 64.590789 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000ed"/>
+    <path d="M 89.574264 75.613577 
+L 101.583174 80.931326 
+L 96.31295 64.590789 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0084ff"/>
+    <path d="M 108.32186 69.908537 
+L 101.583174 80.931326 
+L 96.31295 64.590789 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0064ff"/>
+    <path d="M 105.499696 199.627051 
+L 122.317465 201.266622 
+L 110.444201 208.504734 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8200"/>
+    <path d="M 139.135233 202.906194 
+L 122.317465 201.266622 
+L 127.26197 210.144305 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8200"/>
+    <path d="M 115.388706 217.382417 
+L 110.444201 208.504734 
+L 127.26197 210.144305 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffa700"/>
+    <path d="M 122.317465 201.266622 
+L 110.444201 208.504734 
+L 127.26197 210.144305 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8d00"/>
+    <path d="M 267.000443 228.961756 
+L 269.70937 213.807059 
+L 279.317356 223.453466 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8200"/>
+    <path d="M 272.418297 198.652363 
+L 269.70937 213.807059 
+L 282.026283 208.29877 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2d00"/>
+    <path d="M 291.63427 217.945177 
+L 279.317356 223.453466 
+L 282.026283 208.29877 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5200"/>
+    <path d="M 269.70937 213.807059 
+L 279.317356 223.453466 
+L 282.026283 208.29877 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5500"/>
+    <path d="M 209.018025 229.970423 
+L 222.536251 220.705518 
+L 221.888141 236.195657 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffdb00"/>
+    <path d="M 236.054477 211.440613 
+L 222.536251 220.705518 
+L 235.406367 226.930752 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff9800"/>
+    <path d="M 234.758257 242.420891 
+L 221.888141 236.195657 
+L 235.406367 226.930752 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #eeff09"/>
+    <path d="M 222.536251 220.705518 
+L 221.888141 236.195657 
+L 235.406367 226.930752 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffd000"/>
+    <path d="M 305.780008 197.860528 
+L 289.099152 198.256446 
+L 298.707139 207.902852 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #e40000"/>
+    <path d="M 272.418297 198.652363 
+L 289.099152 198.256446 
+L 282.026283 208.29877 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f60b00"/>
+    <path d="M 291.63427 217.945177 
+L 298.707139 207.902852 
+L 282.026283 208.29877 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3400"/>
+    <path d="M 289.099152 198.256446 
+L 298.707139 207.902852 
+L 282.026283 208.29877 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1300"/>
+    <path d="M 267.000443 228.961756 
+L 251.52746 220.201184 
+L 250.87935 235.691323 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffb600"/>
+    <path d="M 236.054477 211.440613 
+L 251.52746 220.201184 
+L 235.406367 226.930752 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8d00"/>
+    <path d="M 234.758257 242.420891 
+L 250.87935 235.691323 
+L 235.406367 226.930752 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f8f500"/>
+    <path d="M 251.52746 220.201184 
+L 250.87935 235.691323 
+L 235.406367 226.930752 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffbd00"/>
+    <path d="M 209.018025 229.970423 
+L 222.536251 220.705518 
+L 205.168522 217.319084 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffb600"/>
+    <path d="M 236.054477 211.440613 
+L 222.536251 220.705518 
+L 218.686747 208.054178 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7700"/>
+    <path d="M 201.319018 204.667744 
+L 205.168522 217.319084 
+L 218.686747 208.054178 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7700"/>
+    <path d="M 222.536251 220.705518 
+L 205.168522 217.319084 
+L 218.686747 208.054178 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8d00"/>
+    <path d="M 330.309818 53.568 
+L 317.723442 61.212933 
+L 330.309818 61.128 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000c4"/>
+    <path d="M 305.137067 68.857867 
+L 317.723442 61.212933 
+L 317.723442 68.772933 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0050ff"/>
+    <path d="M 330.309818 68.688 
+L 330.309818 61.128 
+L 317.723442 68.772933 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0050ff"/>
+    <path d="M 317.723442 61.212933 
+L 330.309818 61.128 
+L 317.723442 68.772933 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0020ff"/>
+    <path d="M 200.448 53.568 
+L 201.394959 64.76352 
+L 211.663462 62.46514 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000d1"/>
+    <path d="M 202.341918 75.95904 
+L 201.394959 64.76352 
+L 212.610421 73.66066 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0078ff"/>
+    <path d="M 222.878924 71.36228 
+L 211.663462 62.46514 
+L 212.610421 73.66066 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #005cff"/>
+    <path d="M 201.394959 64.76352 
+L 211.663462 62.46514 
+L 212.610421 73.66066 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0034ff"/>
+    <path d="M 200.448 53.568 
+L 216.680727 53.568 
+L 211.663462 62.46514 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00008d"/>
+    <path d="M 232.913455 53.568 
+L 216.680727 53.568 
+L 227.896189 62.46514 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00008d"/>
+    <path d="M 222.878924 71.36228 
+L 211.663462 62.46514 
+L 227.896189 62.46514 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0020ff"/>
+    <path d="M 216.680727 53.568 
+L 211.663462 62.46514 
+L 227.896189 62.46514 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000c8"/>
+    <path d="M 238.6154 85.71228 
+L 244.628121 91.65305 
+L 250.087897 85.014893 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #6aff8d"/>
+    <path d="M 250.640842 97.593819 
+L 244.628121 91.65305 
+L 256.100618 90.955663 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a4ff53"/>
+    <path d="M 261.560394 84.317507 
+L 250.087897 85.014893 
+L 256.100618 90.955663 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #6aff8d"/>
+    <path d="M 244.628121 91.65305 
+L 250.087897 85.014893 
+L 256.100618 90.955663 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #7dff7a"/>
+    <path d="M 113.592083 86.249074 
+L 121.028364 94.986202 
+L 126.420417 87.410575 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #53ffa4"/>
+    <path d="M 128.464645 103.72333 
+L 121.028364 94.986202 
+L 133.856698 96.147703 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #97ff60"/>
+    <path d="M 139.24875 88.572076 
+L 126.420417 87.410575 
+L 133.856698 96.147703 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #5dff9a"/>
+    <path d="M 121.028364 94.986202 
+L 126.420417 87.410575 
+L 133.856698 96.147703 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #6dff8a"/>
+    <path d="M 330.309818 53.568 
+L 314.077091 53.568 
+L 317.723442 61.212933 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00008d"/>
+    <path d="M 297.844364 53.568 
+L 314.077091 53.568 
+L 301.490715 61.212933 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00008d"/>
+    <path d="M 305.137067 68.857867 
+L 317.723442 61.212933 
+L 301.490715 61.212933 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0020ff"/>
+    <path d="M 314.077091 53.568 
+L 317.723442 61.212933 
+L 301.490715 61.212933 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000c4"/>
+    <path d="M 200.448 53.568 
+L 184.215273 53.568 
+L 190.409029 63.589254 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #000092"/>
+    <path d="M 167.982545 53.568 
+L 184.215273 53.568 
+L 174.176302 63.589254 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #000092"/>
+    <path d="M 180.370059 73.610509 
+L 190.409029 63.589254 
+L 174.176302 63.589254 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #002cff"/>
+    <path d="M 184.215273 53.568 
+L 190.409029 63.589254 
+L 174.176302 63.589254 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000cd"/>
+    <path d="M 330.309818 83.808 
+L 319.679386 83.590533 
+L 322.0841 89.885619 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #7dff7a"/>
+    <path d="M 309.048954 83.373067 
+L 319.679386 83.590533 
+L 311.453667 89.668152 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #7aff7d"/>
+    <path d="M 313.858381 95.963238 
+L 322.0841 89.885619 
+L 311.453667 89.668152 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #baff3c"/>
+    <path d="M 319.679386 83.590533 
+L 322.0841 89.885619 
+L 311.453667 89.668152 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #90ff66"/>
+    <path d="M 238.6154 85.71228 
+L 243.999823 77.712073 
+L 250.087897 85.014893 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #39ffbe"/>
+    <path d="M 249.384245 69.711867 
+L 243.999823 77.712073 
+L 255.472319 77.014687 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00bcff"/>
+    <path d="M 261.560394 84.317507 
+L 250.087897 85.014893 
+L 255.472319 77.014687 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #39ffbe"/>
+    <path d="M 243.999823 77.712073 
+L 250.087897 85.014893 
+L 255.472319 77.014687 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #1cffdb"/>
+    <path d="M 135.517091 53.568 
+L 132.01931 62.074309 
+L 144.158979 62.856861 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000bf"/>
+    <path d="M 128.52153 70.580617 
+L 132.01931 62.074309 
+L 140.661198 71.36317 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0038ff"/>
+    <path d="M 152.800866 72.145722 
+L 144.158979 62.856861 
+L 140.661198 71.36317 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0048ff"/>
+    <path d="M 132.01931 62.074309 
+L 144.158979 62.856861 
+L 140.661198 71.36317 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0014ff"/>
+    <path d="M 200.296129 176.831059 
+L 215.507481 174.758145 
+L 208.108956 167.372165 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1300"/>
+    <path d="M 230.718833 172.685231 
+L 215.507481 174.758145 
+L 223.320308 165.299251 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ed0400"/>
+    <path d="M 215.921782 157.913271 
+L 208.108956 167.372165 
+L 223.320308 165.299251 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f60b00"/>
+    <path d="M 215.507481 174.758145 
+L 208.108956 167.372165 
+L 223.320308 165.299251 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f60b00"/>
+    <path d="M 200.296129 176.831059 
+L 215.507481 174.758145 
+L 210.709489 183.95669 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1600"/>
+    <path d="M 230.718833 172.685231 
+L 215.507481 174.758145 
+L 225.920841 181.883776 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f10800"/>
+    <path d="M 221.122849 191.082321 
+L 210.709489 183.95669 
+L 225.920841 181.883776 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1a00"/>
+    <path d="M 215.507481 174.758145 
+L 210.709489 183.95669 
+L 225.920841 181.883776 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1300"/>
+    <path d="M 330.309818 83.808 
+L 330.309818 76.248 
+L 319.679386 83.590533 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #49ffad"/>
+    <path d="M 330.309818 68.688 
+L 330.309818 76.248 
+L 319.679386 76.030533 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00ccff"/>
+    <path d="M 309.048954 83.373067 
+L 319.679386 83.590533 
+L 319.679386 76.030533 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #46ffb1"/>
+    <path d="M 330.309818 76.248 
+L 319.679386 83.590533 
+L 319.679386 76.030533 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #29ffce"/>
+    <path d="M 193.697644 94.28917 
+L 198.019781 85.124105 
+L 205.594591 92.27326 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #6aff8d"/>
+    <path d="M 202.341918 75.95904 
+L 198.019781 85.124105 
+L 209.916728 83.108194 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #13fce4"/>
+    <path d="M 217.491538 90.257349 
+L 205.594591 92.27326 
+L 209.916728 83.108194 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #60ff97"/>
+    <path d="M 198.019781 85.124105 
+L 205.594591 92.27326 
+L 209.916728 83.108194 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #49ffad"/>
+    <path d="M 238.6154 85.71228 
+L 230.747162 78.53728 
+L 243.999823 77.712073 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #1cffdb"/>
+    <path d="M 222.878924 71.36228 
+L 230.747162 78.53728 
+L 236.131584 70.537073 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00a4ff"/>
+    <path d="M 249.384245 69.711867 
+L 243.999823 77.712073 
+L 236.131584 70.537073 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #009cff"/>
+    <path d="M 230.747162 78.53728 
+L 243.999823 77.712073 
+L 236.131584 70.537073 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00c4ff"/>
+    <path d="M 248.022952 115.210555 
+L 249.331897 106.402187 
+L 259.523547 108.263121 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffbd00"/>
+    <path d="M 250.640842 97.593819 
+L 249.331897 106.402187 
+L 260.832492 99.454753 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #e7ff0f"/>
+    <path d="M 271.024142 101.315687 
+L 259.523547 108.263121 
+L 260.832492 99.454753 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffea00"/>
+    <path d="M 249.331897 106.402187 
+L 259.523547 108.263121 
+L 260.832492 99.454753 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffe600"/>
+    <path d="M 135.259776 120.865083 
+L 131.862211 112.294207 
+L 140.477283 113.375435 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffe200"/>
+    <path d="M 128.464645 103.72333 
+L 131.862211 112.294207 
+L 137.079717 104.804559 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d4ff23"/>
+    <path d="M 145.694789 105.885787 
+L 140.477283 113.375435 
+L 137.079717 104.804559 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #deff19"/>
+    <path d="M 131.862211 112.294207 
+L 140.477283 113.375435 
+L 137.079717 104.804559 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #e7ff0f"/>
+    <path d="M 286.256501 83.678733 
+L 295.696784 76.2683 
+L 281.600531 76.393833 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #23ffd4"/>
+    <path d="M 305.137067 68.857867 
+L 295.696784 76.2683 
+L 291.040813 68.9834 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00a4ff"/>
+    <path d="M 276.94456 69.108933 
+L 281.600531 76.393833 
+L 291.040813 68.9834 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00a0ff"/>
+    <path d="M 295.696784 76.2683 
+L 281.600531 76.393833 
+L 291.040813 68.9834 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00c4ff"/>
+    <path d="M 164.40497 94.727743 
+L 172.387515 84.169126 
+L 158.602918 83.436732 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #43ffb4"/>
+    <path d="M 180.370059 73.610509 
+L 172.387515 84.169126 
+L 166.585462 72.878115 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00bcff"/>
+    <path d="M 152.800866 72.145722 
+L 158.602918 83.436732 
+L 166.585462 72.878115 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00acff"/>
+    <path d="M 172.387515 84.169126 
+L 158.602918 83.436732 
+L 166.585462 72.878115 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00e0fb"/>
+    <path d="M 286.256501 83.678733 
+L 297.652727 83.5259 
+L 290.129907 90.852757 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #77ff80"/>
+    <path d="M 309.048954 83.373067 
+L 297.652727 83.5259 
+L 301.526133 90.699924 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #7aff7d"/>
+    <path d="M 294.003313 98.026781 
+L 290.129907 90.852757 
+L 301.526133 90.699924 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #beff39"/>
+    <path d="M 297.652727 83.5259 
+L 290.129907 90.852757 
+L 301.526133 90.699924 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #90ff66"/>
+    <path d="M 265.378909 53.568 
+L 257.381577 61.639933 
+L 271.161735 61.338467 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000c4"/>
+    <path d="M 249.384245 69.711867 
+L 257.381577 61.639933 
+L 263.164403 69.4104 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0048ff"/>
+    <path d="M 276.94456 69.108933 
+L 271.161735 61.338467 
+L 263.164403 69.4104 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0048ff"/>
+    <path d="M 257.381577 61.639933 
+L 271.161735 61.338467 
+L 263.164403 69.4104 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0018ff"/>
+    <path d="M 113.592083 86.249074 
+L 121.056806 78.414846 
+L 126.420417 87.410575 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #1fffd7"/>
+    <path d="M 128.52153 70.580617 
+L 121.056806 78.414846 
+L 133.88514 79.576347 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00a8ff"/>
+    <path d="M 139.24875 88.572076 
+L 126.420417 87.410575 
+L 133.88514 79.576347 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #29ffce"/>
+    <path d="M 121.056806 78.414846 
+L 126.420417 87.410575 
+L 133.88514 79.576347 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #09f0ee"/>
+    <path d="M 228.601695 136.949959 
+L 222.261739 147.431615 
+L 235.58773 146.120558 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2500"/>
+    <path d="M 215.921782 157.913271 
+L 222.261739 147.431615 
+L 229.247773 156.602214 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #fa0f00"/>
+    <path d="M 242.573764 155.291157 
+L 235.58773 146.120558 
+L 229.247773 156.602214 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ed0400"/>
+    <path d="M 222.261739 147.431615 
+L 235.58773 146.120558 
+L 229.247773 156.602214 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1300"/>
+    <path d="M 236.054477 211.440613 
+L 228.588663 201.261467 
+L 240.604538 199.818635 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4700"/>
+    <path d="M 221.122849 191.082321 
+L 228.588663 201.261467 
+L 233.138724 189.639489 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2500"/>
+    <path d="M 245.154599 188.196657 
+L 240.604538 199.818635 
+L 233.138724 189.639489 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1600"/>
+    <path d="M 228.588663 201.261467 
+L 240.604538 199.818635 
+L 233.138724 189.639489 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2d00"/>
+    <path d="M 286.256501 83.678733 
+L 295.696784 76.2683 
+L 297.652727 83.5259 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #43ffb4"/>
+    <path d="M 305.137067 68.857867 
+L 295.696784 76.2683 
+L 307.09301 76.115467 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00c8ff"/>
+    <path d="M 309.048954 83.373067 
+L 297.652727 83.5259 
+L 307.09301 76.115467 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #46ffb1"/>
+    <path d="M 295.696784 76.2683 
+L 297.652727 83.5259 
+L 307.09301 76.115467 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #26ffd1"/>
+    <path d="M 238.6154 85.71228 
+L 230.747162 78.53728 
+L 228.053469 87.984814 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #40ffb7"/>
+    <path d="M 222.878924 71.36228 
+L 230.747162 78.53728 
+L 220.185231 80.809814 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00ccff"/>
+    <path d="M 217.491538 90.257349 
+L 228.053469 87.984814 
+L 220.185231 80.809814 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #50ffa7"/>
+    <path d="M 230.747162 78.53728 
+L 228.053469 87.984814 
+L 220.185231 80.809814 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #29ffce"/>
+    <path d="M 265.378909 53.568 
+L 249.146182 53.568 
+L 257.381577 61.639933 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00008d"/>
+    <path d="M 232.913455 53.568 
+L 249.146182 53.568 
+L 241.14885 61.639933 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00008d"/>
+    <path d="M 249.384245 69.711867 
+L 257.381577 61.639933 
+L 241.14885 61.639933 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0018ff"/>
+    <path d="M 249.146182 53.568 
+L 257.381577 61.639933 
+L 241.14885 61.639933 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000bf"/>
+    <path d="M 286.256501 83.678733 
+L 278.640322 92.49721 
+L 273.908447 83.99812 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #77ff80"/>
+    <path d="M 271.024142 101.315687 
+L 278.640322 92.49721 
+L 266.292268 92.816597 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #c4ff33"/>
+    <path d="M 261.560394 84.317507 
+L 273.908447 83.99812 
+L 266.292268 92.816597 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #73ff83"/>
+    <path d="M 278.640322 92.49721 
+L 273.908447 83.99812 
+L 266.292268 92.816597 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #90ff66"/>
+    <path d="M 164.40497 94.727743 
+L 155.04988 100.306765 
+L 151.82686 91.64991 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #8aff6d"/>
+    <path d="M 145.694789 105.885787 
+L 155.04988 100.306765 
+L 142.47177 97.228932 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #adff49"/>
+    <path d="M 139.24875 88.572076 
+L 151.82686 91.64991 
+L 142.47177 97.228932 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #6aff8d"/>
+    <path d="M 155.04988 100.306765 
+L 151.82686 91.64991 
+L 142.47177 97.228932 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #8dff6a"/>
+    <path d="M 265.378909 53.568 
+L 281.611636 53.568 
+L 271.161735 61.338467 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00008d"/>
+    <path d="M 297.844364 53.568 
+L 281.611636 53.568 
+L 287.394462 61.338467 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00008d"/>
+    <path d="M 276.94456 69.108933 
+L 271.161735 61.338467 
+L 287.394462 61.338467 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0018ff"/>
+    <path d="M 281.611636 53.568 
+L 271.161735 61.338467 
+L 287.394462 61.338467 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000c4"/>
+    <path d="M 135.517091 53.568 
+L 151.749818 53.568 
+L 144.158979 62.856861 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00008d"/>
+    <path d="M 167.982545 53.568 
+L 151.749818 53.568 
+L 160.391706 62.856861 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00008d"/>
+    <path d="M 152.800866 72.145722 
+L 144.158979 62.856861 
+L 160.391706 62.856861 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #001cff"/>
+    <path d="M 151.749818 53.568 
+L 144.158979 62.856861 
+L 160.391706 62.856861 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000c4"/>
+    <path d="M 286.256501 83.678733 
+L 281.600531 76.393833 
+L 273.908447 83.99812 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #40ffb7"/>
+    <path d="M 276.94456 69.108933 
+L 281.600531 76.393833 
+L 269.252477 76.71322 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00c0ff"/>
+    <path d="M 261.560394 84.317507 
+L 273.908447 83.99812 
+L 269.252477 76.71322 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #39ffbe"/>
+    <path d="M 281.600531 76.393833 
+L 273.908447 83.99812 
+L 269.252477 76.71322 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #1fffd7"/>
+    <path d="M 164.40497 94.727743 
+L 158.602918 83.436732 
+L 151.82686 91.64991 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #5aff9d"/>
+    <path d="M 152.800866 72.145722 
+L 158.602918 83.436732 
+L 146.024808 80.358899 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00ccff"/>
+    <path d="M 139.24875 88.572076 
+L 151.82686 91.64991 
+L 146.024808 80.358899 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #39ffbe"/>
+    <path d="M 158.602918 83.436732 
+L 151.82686 91.64991 
+L 146.024808 80.358899 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #29ffce"/>
+    <path d="M 261.206458 168.893794 
+L 245.962646 170.789513 
+L 251.890111 162.092476 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #c40000"/>
+    <path d="M 230.718833 172.685231 
+L 245.962646 170.789513 
+L 236.646299 163.988194 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #da0000"/>
+    <path d="M 242.573764 155.291157 
+L 251.890111 162.092476 
+L 236.646299 163.988194 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d60000"/>
+    <path d="M 245.962646 170.789513 
+L 251.890111 162.092476 
+L 236.646299 163.988194 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d10000"/>
+    <path d="M 261.206458 168.893794 
+L 245.962646 170.789513 
+L 253.180529 178.545226 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #c40000"/>
+    <path d="M 230.718833 172.685231 
+L 245.962646 170.789513 
+L 237.936716 180.440944 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #da0000"/>
+    <path d="M 245.154599 188.196657 
+L 253.180529 178.545226 
+L 237.936716 180.440944 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #df0000"/>
+    <path d="M 245.962646 170.789513 
+L 253.180529 178.545226 
+L 237.936716 180.440944 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d60000"/>
+    <path d="M 305.137067 68.857867 
+L 317.723442 68.772933 
+L 307.09301 76.115467 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00a4ff"/>
+    <path d="M 330.309818 68.688 
+L 317.723442 68.772933 
+L 319.679386 76.030533 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00a4ff"/>
+    <path d="M 309.048954 83.373067 
+L 307.09301 76.115467 
+L 319.679386 76.030533 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #26ffd1"/>
+    <path d="M 317.723442 68.772933 
+L 307.09301 76.115467 
+L 319.679386 76.030533 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00ccff"/>
+    <path d="M 202.341918 75.95904 
+L 212.610421 73.66066 
+L 209.916728 83.108194 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00d0ff"/>
+    <path d="M 222.878924 71.36228 
+L 212.610421 73.66066 
+L 220.185231 80.809814 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00b4ff"/>
+    <path d="M 217.491538 90.257349 
+L 209.916728 83.108194 
+L 220.185231 80.809814 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #39ffbe"/>
+    <path d="M 212.610421 73.66066 
+L 209.916728 83.108194 
+L 220.185231 80.809814 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00e4f8"/>
+    <path d="M 232.913455 53.568 
+L 227.896189 62.46514 
+L 241.14885 61.639933 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000c4"/>
+    <path d="M 222.878924 71.36228 
+L 227.896189 62.46514 
+L 236.131584 70.537073 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0050ff"/>
+    <path d="M 249.384245 69.711867 
+L 241.14885 61.639933 
+L 236.131584 70.537073 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0048ff"/>
+    <path d="M 227.896189 62.46514 
+L 241.14885 61.639933 
+L 236.131584 70.537073 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #001cff"/>
+    <path d="M 250.640842 97.593819 
+L 260.832492 99.454753 
+L 256.100618 90.955663 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #c1ff36"/>
+    <path d="M 271.024142 101.315687 
+L 260.832492 99.454753 
+L 266.292268 92.816597 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d7ff1f"/>
+    <path d="M 261.560394 84.317507 
+L 256.100618 90.955663 
+L 266.292268 92.816597 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #83ff73"/>
+    <path d="M 260.832492 99.454753 
+L 256.100618 90.955663 
+L 266.292268 92.816597 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #b4ff43"/>
+    <path d="M 128.464645 103.72333 
+L 137.079717 104.804559 
+L 133.856698 96.147703 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #b1ff46"/>
+    <path d="M 145.694789 105.885787 
+L 137.079717 104.804559 
+L 142.47177 97.228932 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #b7ff40"/>
+    <path d="M 139.24875 88.572076 
+L 133.856698 96.147703 
+L 142.47177 97.228932 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #73ff83"/>
+    <path d="M 137.079717 104.804559 
+L 133.856698 96.147703 
+L 142.47177 97.228932 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #9dff5a"/>
+    <path d="M 297.844364 53.568 
+L 301.490715 61.212933 
+L 287.394462 61.338467 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000c4"/>
+    <path d="M 305.137067 68.857867 
+L 301.490715 61.212933 
+L 291.040813 68.9834 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #004cff"/>
+    <path d="M 276.94456 69.108933 
+L 287.394462 61.338467 
+L 291.040813 68.9834 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #004cff"/>
+    <path d="M 301.490715 61.212933 
+L 287.394462 61.338467 
+L 291.040813 68.9834 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #001cff"/>
+    <path d="M 167.982545 53.568 
+L 174.176302 63.589254 
+L 160.391706 62.856861 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000c8"/>
+    <path d="M 180.370059 73.610509 
+L 174.176302 63.589254 
+L 166.585462 72.878115 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #005cff"/>
+    <path d="M 152.800866 72.145722 
+L 160.391706 62.856861 
+L 166.585462 72.878115 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0050ff"/>
+    <path d="M 174.176302 63.589254 
+L 160.391706 62.856861 
+L 166.585462 72.878115 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0024ff"/>
+    <path d="M 309.048954 83.373067 
+L 301.526133 90.699924 
+L 311.453667 89.668152 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #90ff66"/>
+    <path d="M 294.003313 98.026781 
+L 301.526133 90.699924 
+L 303.930847 96.99501 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d4ff23"/>
+    <path d="M 313.858381 95.963238 
+L 311.453667 89.668152 
+L 303.930847 96.99501 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d1ff26"/>
+    <path d="M 301.526133 90.699924 
+L 311.453667 89.668152 
+L 303.930847 96.99501 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #beff39"/>
+    <path d="M 249.384245 69.711867 
+L 263.164403 69.4104 
+L 255.472319 77.014687 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #009cff"/>
+    <path d="M 276.94456 69.108933 
+L 263.164403 69.4104 
+L 269.252477 76.71322 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #009cff"/>
+    <path d="M 261.560394 84.317507 
+L 255.472319 77.014687 
+L 269.252477 76.71322 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #1cffdb"/>
+    <path d="M 263.164403 69.4104 
+L 255.472319 77.014687 
+L 269.252477 76.71322 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00c0ff"/>
+    <path d="M 128.52153 70.580617 
+L 140.661198 71.36317 
+L 133.88514 79.576347 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #008cff"/>
+    <path d="M 152.800866 72.145722 
+L 140.661198 71.36317 
+L 146.024808 80.358899 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0098ff"/>
+    <path d="M 139.24875 88.572076 
+L 133.88514 79.576347 
+L 146.024808 80.358899 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #13fce4"/>
+    <path d="M 140.661198 71.36317 
+L 133.88514 79.576347 
+L 146.024808 80.358899 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00b4ff"/>
+    <path d="M 230.718833 172.685231 
+L 223.320308 165.299251 
+L 236.646299 163.988194 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #e40000"/>
+    <path d="M 215.921782 157.913271 
+L 223.320308 165.299251 
+L 229.247773 156.602214 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f10800"/>
+    <path d="M 242.573764 155.291157 
+L 236.646299 163.988194 
+L 229.247773 156.602214 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #e40000"/>
+    <path d="M 223.320308 165.299251 
+L 236.646299 163.988194 
+L 229.247773 156.602214 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #e80000"/>
+    <path d="M 230.718833 172.685231 
+L 225.920841 181.883776 
+L 237.936716 180.440944 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ed0400"/>
+    <path d="M 221.122849 191.082321 
+L 225.920841 181.883776 
+L 233.138724 189.639489 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1600"/>
+    <path d="M 245.154599 188.196657 
+L 237.936716 180.440944 
+L 233.138724 189.639489 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f10800"/>
+    <path d="M 225.920841 181.883776 
+L 237.936716 180.440944 
+L 233.138724 189.639489 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f60b00"/>
+    <path d="M 193.697644 94.28917 
+L 205.267881 103.309372 
+L 205.594591 92.27326 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a0ff56"/>
+    <path d="M 216.838119 112.329574 
+L 205.267881 103.309372 
+L 217.164828 101.293461 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ebff0c"/>
+    <path d="M 217.491538 90.257349 
+L 205.594591 92.27326 
+L 217.164828 101.293461 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #94ff63"/>
+    <path d="M 205.267881 103.309372 
+L 205.594591 92.27326 
+L 217.164828 101.293461 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #b4ff43"/>
+    <path d="M 287.330454 112.615603 
+L 279.177298 106.965645 
+L 290.666884 105.321192 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffab00"/>
+    <path d="M 271.024142 101.315687 
+L 279.177298 106.965645 
+L 282.513728 99.671234 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffe200"/>
+    <path d="M 294.003313 98.026781 
+L 290.666884 105.321192 
+L 282.513728 99.671234 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffea00"/>
+    <path d="M 279.177298 106.965645 
+L 290.666884 105.321192 
+L 282.513728 99.671234 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffd000"/>
+    <path d="M 216.838119 112.329574 
+L 217.164828 101.293461 
+L 225.196231 106.602674 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f8f500"/>
+    <path d="M 217.491538 90.257349 
+L 217.164828 101.293461 
+L 225.522941 95.566561 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a0ff56"/>
+    <path d="M 233.554344 100.875774 
+L 225.196231 106.602674 
+L 225.522941 95.566561 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d4ff23"/>
+    <path d="M 217.164828 101.293461 
+L 225.196231 106.602674 
+L 225.522941 95.566561 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ceff29"/>
+    <path d="M 286.256501 83.678733 
+L 278.640322 92.49721 
+L 290.129907 90.852757 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #90ff66"/>
+    <path d="M 271.024142 101.315687 
+L 278.640322 92.49721 
+L 282.513728 99.671234 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #deff19"/>
+    <path d="M 294.003313 98.026781 
+L 290.129907 90.852757 
+L 282.513728 99.671234 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d7ff1f"/>
+    <path d="M 278.640322 92.49721 
+L 290.129907 90.852757 
+L 282.513728 99.671234 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #c4ff33"/>
+    <path d="M 238.6154 85.71228 
+L 228.053469 87.984814 
+L 236.084872 93.294027 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #70ff87"/>
+    <path d="M 217.491538 90.257349 
+L 228.053469 87.984814 
+L 225.522941 95.566561 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #80ff77"/>
+    <path d="M 233.554344 100.875774 
+L 236.084872 93.294027 
+L 225.522941 95.566561 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #b4ff43"/>
+    <path d="M 228.053469 87.984814 
+L 236.084872 93.294027 
+L 225.522941 95.566561 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #8dff6a"/>
+    <path d="M 238.6154 85.71228 
+L 244.628121 91.65305 
+L 236.084872 93.294027 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #80ff77"/>
+    <path d="M 250.640842 97.593819 
+L 244.628121 91.65305 
+L 242.097593 99.234797 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #baff3c"/>
+    <path d="M 233.554344 100.875774 
+L 236.084872 93.294027 
+L 242.097593 99.234797 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #c1ff36"/>
+    <path d="M 244.628121 91.65305 
+L 236.084872 93.294027 
+L 242.097593 99.234797 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a7ff50"/>
+    <path d="M 200.448 53.568 
+L 190.409029 63.589254 
+L 201.394959 64.76352 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000d6"/>
+    <path d="M 180.370059 73.610509 
+L 190.409029 63.589254 
+L 191.355989 74.784774 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0068ff"/>
+    <path d="M 202.341918 75.95904 
+L 201.394959 64.76352 
+L 191.355989 74.784774 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0078ff"/>
+    <path d="M 190.409029 63.589254 
+L 201.394959 64.76352 
+L 191.355989 74.784774 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0038ff"/>
+    <path d="M 135.259776 120.865083 
+L 147.362972 121.466293 
+L 140.477283 113.375435 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffcc00"/>
+    <path d="M 159.466167 122.067503 
+L 147.362972 121.466293 
+L 152.580478 113.976645 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffc400"/>
+    <path d="M 145.694789 105.885787 
+L 140.477283 113.375435 
+L 152.580478 113.976645 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f1fc06"/>
+    <path d="M 147.362972 121.466293 
+L 140.477283 113.375435 
+L 152.580478 113.976645 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffdb00"/>
+    <path d="M 248.022952 115.210555 
+L 249.331897 106.402187 
+L 240.788648 108.043164 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffc400"/>
+    <path d="M 250.640842 97.593819 
+L 249.331897 106.402187 
+L 242.097593 99.234797 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #e1ff16"/>
+    <path d="M 233.554344 100.875774 
+L 240.788648 108.043164 
+L 242.097593 99.234797 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ebff0c"/>
+    <path d="M 249.331897 106.402187 
+L 240.788648 108.043164 
+L 242.097593 99.234797 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #fbf100"/>
+    <path d="M 193.697644 94.28917 
+L 187.033851 83.94984 
+L 198.019781 85.124105 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #4dffaa"/>
+    <path d="M 180.370059 73.610509 
+L 187.033851 83.94984 
+L 191.355989 74.784774 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00c8ff"/>
+    <path d="M 202.341918 75.95904 
+L 198.019781 85.124105 
+L 191.355989 74.784774 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00d8ff"/>
+    <path d="M 187.033851 83.94984 
+L 198.019781 85.124105 
+L 191.355989 74.784774 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0ff8e7"/>
+    <path d="M 164.40497 94.727743 
+L 161.935569 108.397623 
+L 155.04988 100.306765 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #b1ff46"/>
+    <path d="M 159.466167 122.067503 
+L 161.935569 108.397623 
+L 152.580478 113.976645 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffe200"/>
+    <path d="M 145.694789 105.885787 
+L 155.04988 100.306765 
+L 152.580478 113.976645 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d7ff1f"/>
+    <path d="M 161.935569 108.397623 
+L 155.04988 100.306765 
+L 152.580478 113.976645 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #dbff1c"/>
+    <path d="M 248.022952 115.210555 
+L 232.430535 113.770065 
+L 240.788648 108.043164 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffb200"/>
+    <path d="M 216.838119 112.329574 
+L 232.430535 113.770065 
+L 225.196231 106.602674 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffcc00"/>
+    <path d="M 233.554344 100.875774 
+L 240.788648 108.043164 
+L 225.196231 106.602674 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f8f500"/>
+    <path d="M 232.430535 113.770065 
+L 240.788648 108.043164 
+L 225.196231 106.602674 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffd300"/>
+    <path d="M 164.40497 94.727743 
+L 179.051307 94.508457 
+L 172.387515 84.169126 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #66ff90"/>
+    <path d="M 193.697644 94.28917 
+L 179.051307 94.508457 
+L 187.033851 83.94984 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #6aff8d"/>
+    <path d="M 180.370059 73.610509 
+L 172.387515 84.169126 
+L 187.033851 83.94984 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #02e8f4"/>
+    <path d="M 179.051307 94.508457 
+L 172.387515 84.169126 
+L 187.033851 83.94984 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #46ffb1"/>
+    <path d="M 186.700092 115.845387 
+L 175.552531 105.286565 
+L 173.08313 118.956445 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffde00"/>
+    <path d="M 164.40497 94.727743 
+L 175.552531 105.286565 
+L 161.935569 108.397623 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #beff39"/>
+    <path d="M 159.466167 122.067503 
+L 173.08313 118.956445 
+L 161.935569 108.397623 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffd300"/>
+    <path d="M 175.552531 105.286565 
+L 173.08313 118.956445 
+L 161.935569 108.397623 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f4f802"/>
+    <path d="M 261.206458 168.893794 
+L 262.471208 154.2922 
+L 251.890111 162.092476 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #c40000"/>
+    <path d="M 263.735957 139.690605 
+L 262.471208 154.2922 
+L 253.154861 147.490881 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #df0000"/>
+    <path d="M 242.573764 155.291157 
+L 251.890111 162.092476 
+L 253.154861 147.490881 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d60000"/>
+    <path d="M 262.471208 154.2922 
+L 251.890111 162.092476 
+L 253.154861 147.490881 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d60000"/>
+    <path d="M 261.206458 168.893794 
+L 266.812378 183.773079 
+L 253.180529 178.545226 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #c40000"/>
+    <path d="M 272.418297 198.652363 
+L 266.812378 183.773079 
+L 258.786448 193.42451 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #e40000"/>
+    <path d="M 245.154599 188.196657 
+L 253.180529 178.545226 
+L 258.786448 193.42451 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #e40000"/>
+    <path d="M 266.812378 183.773079 
+L 253.180529 178.545226 
+L 258.786448 193.42451 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d60000"/>
+    <path d="M 135.517091 53.568 
+L 119.284364 53.568 
+L 132.01931 62.074309 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #000089"/>
+    <path d="M 103.051636 53.568 
+L 119.284364 53.568 
+L 115.786583 62.074309 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #000089"/>
+    <path d="M 128.52153 70.580617 
+L 132.01931 62.074309 
+L 115.786583 62.074309 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0008ff"/>
+    <path d="M 119.284364 53.568 
+L 132.01931 62.074309 
+L 115.786583 62.074309 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000bb"/>
+    <path d="M 200.296129 176.831059 
+L 200.807573 190.749402 
+L 210.709489 183.95669 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2500"/>
+    <path d="M 201.319018 204.667744 
+L 200.807573 190.749402 
+L 211.220933 197.875033 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4a00"/>
+    <path d="M 221.122849 191.082321 
+L 210.709489 183.95669 
+L 211.220933 197.875033 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2900"/>
+    <path d="M 200.807573 190.749402 
+L 210.709489 183.95669 
+L 211.220933 197.875033 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3400"/>
+    <path d="M 135.259776 120.865083 
+L 123.22815 118.810934 
+L 131.862211 112.294207 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffd700"/>
+    <path d="M 111.196524 116.756784 
+L 123.22815 118.810934 
+L 119.830584 110.240057 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffe200"/>
+    <path d="M 128.464645 103.72333 
+L 131.862211 112.294207 
+L 119.830584 110.240057 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #deff19"/>
+    <path d="M 123.22815 118.810934 
+L 131.862211 112.294207 
+L 119.830584 110.240057 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #feed00"/>
+    <path d="M 205.86375 143.34645 
+L 217.232723 140.148205 
+L 210.892766 150.629861 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3000"/>
+    <path d="M 228.601695 136.949959 
+L 217.232723 140.148205 
+L 222.261739 147.431615 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3000"/>
+    <path d="M 215.921782 157.913271 
+L 210.892766 150.629861 
+L 222.261739 147.431615 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1a00"/>
+    <path d="M 217.232723 140.148205 
+L 210.892766 150.629861 
+L 222.261739 147.431615 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2900"/>
+    <path d="M 228.601695 136.949959 
+L 246.168826 138.320282 
+L 235.58773 146.120558 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2200"/>
+    <path d="M 263.735957 139.690605 
+L 246.168826 138.320282 
+L 253.154861 147.490881 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f60b00"/>
+    <path d="M 242.573764 155.291157 
+L 235.58773 146.120558 
+L 253.154861 147.490881 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ed0400"/>
+    <path d="M 246.168826 138.320282 
+L 235.58773 146.120558 
+L 253.154861 147.490881 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #fa0f00"/>
+    <path d="M 236.054477 211.440613 
+L 254.236387 205.046488 
+L 240.604538 199.818635 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3f00"/>
+    <path d="M 272.418297 198.652363 
+L 254.236387 205.046488 
+L 258.786448 193.42451 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1300"/>
+    <path d="M 245.154599 188.196657 
+L 240.604538 199.818635 
+L 258.786448 193.42451 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1300"/>
+    <path d="M 254.236387 205.046488 
+L 240.604538 199.818635 
+L 258.786448 193.42451 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2200"/>
+    <path d="M 113.592083 86.249074 
+L 108.32186 69.908537 
+L 121.056806 78.414846 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00bcff"/>
+    <path d="M 103.051636 53.568 
+L 108.32186 69.908537 
+L 115.786583 62.074309 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000df"/>
+    <path d="M 128.52153 70.580617 
+L 121.056806 78.414846 
+L 115.786583 62.074309 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0058ff"/>
+    <path d="M 108.32186 69.908537 
+L 121.056806 78.414846 
+L 115.786583 62.074309 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #004cff"/>
+    <path d="M 236.054477 211.440613 
+L 218.686747 208.054178 
+L 228.588663 201.261467 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5500"/>
+    <path d="M 201.319018 204.667744 
+L 218.686747 208.054178 
+L 211.220933 197.875033 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5500"/>
+    <path d="M 221.122849 191.082321 
+L 228.588663 201.261467 
+L 211.220933 197.875033 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3800"/>
+    <path d="M 218.686747 208.054178 
+L 228.588663 201.261467 
+L 211.220933 197.875033 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4a00"/>
+    <path d="M 113.592083 86.249074 
+L 112.394304 101.502929 
+L 121.028364 94.986202 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #73ff83"/>
+    <path d="M 111.196524 116.756784 
+L 112.394304 101.502929 
+L 119.830584 110.240057 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #e1ff16"/>
+    <path d="M 128.464645 103.72333 
+L 121.028364 94.986202 
+L 119.830584 110.240057 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #b7ff40"/>
+    <path d="M 112.394304 101.502929 
+L 121.028364 94.986202 
+L 119.830584 110.240057 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #b1ff46"/>
+    <path d="M 330.309818 114.048 
+L 330.309818 121.608 
+L 321.097273 121.282238 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4300"/>
+    <path d="M 330.309818 129.168 
+L 330.309818 121.608 
+L 321.097273 128.842238 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1600"/>
+    <path d="M 311.884729 128.516476 
+L 321.097273 121.282238 
+L 321.097273 128.842238 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1a00"/>
+    <path d="M 330.309818 121.608 
+L 321.097273 121.282238 
+L 321.097273 128.842238 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2500"/>
+    <path d="M 330.309818 114.048 
+L 321.097273 121.282238 
+L 318.798722 115.256376 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5200"/>
+    <path d="M 311.884729 128.516476 
+L 321.097273 121.282238 
+L 309.586177 122.490614 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2900"/>
+    <path d="M 307.287625 116.464752 
+L 318.798722 115.256376 
+L 309.586177 122.490614 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4e00"/>
+    <path d="M 321.097273 121.282238 
+L 318.798722 115.256376 
+L 309.586177 122.490614 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4300"/>
+    <path d="M 294.908991 172.560125 
+L 304.468309 165.323082 
+L 297.767957 163.203726 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #8d0000"/>
+    <path d="M 314.027627 158.08604 
+L 304.468309 165.323082 
+L 307.327275 155.966684 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #890000"/>
+    <path d="M 300.626923 153.847327 
+L 297.767957 163.203726 
+L 307.327275 155.966684 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #920000"/>
+    <path d="M 304.468309 165.323082 
+L 297.767957 163.203726 
+L 307.327275 155.966684 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #8d0000"/>
+    <path d="M 200.296129 176.831059 
+L 184.171934 176.51485 
+L 188.579385 168.542525 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2200"/>
+    <path d="M 168.047739 176.198641 
+L 184.171934 176.51485 
+L 172.455189 168.226316 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2d00"/>
+    <path d="M 176.86264 160.253992 
+L 188.579385 168.542525 
+L 172.455189 168.226316 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2900"/>
+    <path d="M 184.171934 176.51485 
+L 188.579385 168.542525 
+L 172.455189 168.226316 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2900"/>
+    <path d="M 70.586182 174.528 
+L 81.880576 174.056117 
+L 80.036872 180.023431 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3f00"/>
+    <path d="M 93.17497 173.584234 
+L 81.880576 174.056117 
+L 91.331266 179.551548 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4300"/>
+    <path d="M 89.487562 185.518862 
+L 80.036872 180.023431 
+L 91.331266 179.551548 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4a00"/>
+    <path d="M 81.880576 174.056117 
+L 80.036872 180.023431 
+L 91.331266 179.551548 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4300"/>
+    <path d="M 200.296129 176.831059 
+L 197.831793 166.566122 
+L 188.579385 168.542525 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1e00"/>
+    <path d="M 195.367456 156.301185 
+L 197.831793 166.566122 
+L 186.115048 158.277588 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2200"/>
+    <path d="M 176.86264 160.253992 
+L 188.579385 168.542525 
+L 186.115048 158.277588 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2500"/>
+    <path d="M 197.831793 166.566122 
+L 188.579385 168.542525 
+L 186.115048 158.277588 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2200"/>
+    <path d="M 205.86375 143.34645 
+L 197.986301 138.310196 
+L 195.290427 144.136109 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4300"/>
+    <path d="M 190.108852 133.273941 
+L 197.986301 138.310196 
+L 187.412978 139.099854 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5900"/>
+    <path d="M 184.717105 144.925767 
+L 195.290427 144.136109 
+L 187.412978 139.099854 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4700"/>
+    <path d="M 197.986301 138.310196 
+L 195.290427 144.136109 
+L 187.412978 139.099854 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4a00"/>
+    <path d="M 135.259776 120.865083 
+L 135.91303 130.07622 
+L 141.562668 127.867066 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffa300"/>
+    <path d="M 136.566283 139.287357 
+L 135.91303 130.07622 
+L 142.215921 137.078202 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7a00"/>
+    <path d="M 147.86556 134.869048 
+L 141.562668 127.867066 
+L 142.215921 137.078202 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8200"/>
+    <path d="M 135.91303 130.07622 
+L 141.562668 127.867066 
+L 142.215921 137.078202 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8900"/>
+    <path d="M 70.586182 295.488 
+L 70.586182 287.928 
+L 83.122797 287.7495 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000a4"/>
+    <path d="M 70.586182 280.368 
+L 70.586182 287.928 
+L 83.122797 280.1895 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000ff"/>
+    <path d="M 95.659411 280.011 
+L 83.122797 287.7495 
+L 83.122797 280.1895 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0004ff"/>
+    <path d="M 70.586182 287.928 
+L 83.122797 287.7495 
+L 83.122797 280.1895 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000ed"/>
+    <path d="M 200.448 295.488 
+L 201.908051 282.883311 
+L 213.437726 286.576823 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000c4"/>
+    <path d="M 203.368103 270.278623 
+L 201.908051 282.883311 
+L 214.897777 273.972134 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0064ff"/>
+    <path d="M 226.427451 277.665646 
+L 213.437726 286.576823 
+L 214.897777 273.972134 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0038ff"/>
+    <path d="M 201.908051 282.883311 
+L 213.437726 286.576823 
+L 214.897777 273.972134 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #001cff"/>
+    <path d="M 70.586182 295.488 
+L 86.818909 295.488 
+L 83.122797 287.7495 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #000080"/>
+    <path d="M 103.051636 295.488 
+L 86.818909 295.488 
+L 99.355524 287.7495 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #000080"/>
+    <path d="M 95.659411 280.011 
+L 83.122797 287.7495 
+L 99.355524 287.7495 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000f1"/>
+    <path d="M 86.818909 295.488 
+L 83.122797 287.7495 
+L 99.355524 287.7495 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000a4"/>
+    <path d="M 200.448 295.488 
+L 189.422879 286.2554 
+L 201.908051 282.883311 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000c4"/>
+    <path d="M 178.397758 277.0228 
+L 189.422879 286.2554 
+L 190.88293 273.650711 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0034ff"/>
+    <path d="M 203.368103 270.278623 
+L 201.908051 282.883311 
+L 190.88293 273.650711 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0060ff"/>
+    <path d="M 189.422879 286.2554 
+L 201.908051 282.883311 
+L 190.88293 273.650711 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #001cff"/>
+    <path d="M 200.448 295.488 
+L 216.680727 295.488 
+L 213.437726 286.576823 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #000084"/>
+    <path d="M 232.913455 295.488 
+L 216.680727 295.488 
+L 229.670453 286.576823 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #000084"/>
+    <path d="M 226.427451 277.665646 
+L 213.437726 286.576823 
+L 229.670453 286.576823 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000ff"/>
+    <path d="M 216.680727 295.488 
+L 213.437726 286.576823 
+L 229.670453 286.576823 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000b6"/>
+    <path d="M 330.309818 295.488 
+L 318.282836 287.970743 
+L 330.309818 287.928 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000b2"/>
+    <path d="M 306.255853 280.453486 
+L 318.282836 287.970743 
+L 318.282836 280.410743 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0020ff"/>
+    <path d="M 330.309818 280.368 
+L 330.309818 287.928 
+L 318.282836 280.410743 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0024ff"/>
+    <path d="M 318.282836 287.970743 
+L 330.309818 287.928 
+L 318.282836 280.410743 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000ff"/>
+    <path d="M 113.560466 264.3168 
+L 119.590499 256.6153 
+L 125.963607 263.65115 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0cf4eb"/>
+    <path d="M 125.620531 248.9138 
+L 119.590499 256.6153 
+L 131.993639 255.94965 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #49ffad"/>
+    <path d="M 138.366747 262.9855 
+L 125.963607 263.65115 
+L 131.993639 255.94965 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #13fce4"/>
+    <path d="M 119.590499 256.6153 
+L 125.963607 263.65115 
+L 131.993639 255.94965 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #23ffd4"/>
+    <path d="M 242.68407 261.001402 
+L 250.299787 255.243023 
+L 254.670305 262.738027 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #43ffb4"/>
+    <path d="M 257.915504 249.484645 
+L 250.299787 255.243023 
+L 262.286022 256.979649 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #77ff80"/>
+    <path d="M 266.656541 264.474652 
+L 254.670305 262.738027 
+L 262.286022 256.979649 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #36ffc1"/>
+    <path d="M 250.299787 255.243023 
+L 254.670305 262.738027 
+L 262.286022 256.979649 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #50ffa7"/>
+    <path d="M 200.448 295.488 
+L 184.215273 295.488 
+L 189.422879 286.2554 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #000084"/>
+    <path d="M 167.982545 295.488 
+L 184.215273 295.488 
+L 173.190152 286.2554 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #000084"/>
+    <path d="M 178.397758 277.0228 
+L 189.422879 286.2554 
+L 173.190152 286.2554 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000ff"/>
+    <path d="M 184.215273 295.488 
+L 189.422879 286.2554 
+L 173.190152 286.2554 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000b2"/>
+    <path d="M 135.339984 229.015738 
+L 142.917265 237.866894 
+L 148.937134 230.380621 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #deff19"/>
+    <path d="M 150.494546 246.71805 
+L 142.917265 237.866894 
+L 156.514415 239.231778 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a7ff50"/>
+    <path d="M 162.534283 231.745505 
+L 148.937134 230.380621 
+L 156.514415 239.231778 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d7ff1f"/>
+    <path d="M 142.917265 237.866894 
+L 148.937134 230.380621 
+L 156.514415 239.231778 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #c7ff30"/>
+    <path d="M 135.339984 229.015738 
+L 145.610805 223.553073 
+L 148.937134 230.380621 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f8f500"/>
+    <path d="M 155.881626 218.090409 
+L 145.610805 223.553073 
+L 159.207955 224.917957 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffd300"/>
+    <path d="M 162.534283 231.745505 
+L 148.937134 230.380621 
+L 159.207955 224.917957 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f1fc06"/>
+    <path d="M 145.610805 223.553073 
+L 148.937134 230.380621 
+L 159.207955 224.917957 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffea00"/>
+    <path d="M 330.309818 295.488 
+L 314.077091 295.488 
+L 318.282836 287.970743 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #000084"/>
+    <path d="M 297.844364 295.488 
+L 314.077091 295.488 
+L 302.050108 287.970743 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #000084"/>
+    <path d="M 306.255853 280.453486 
+L 318.282836 287.970743 
+L 302.050108 287.970743 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000ff"/>
+    <path d="M 314.077091 295.488 
+L 318.282836 287.970743 
+L 302.050108 287.970743 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000b2"/>
+    <path d="M 70.586182 265.248 
+L 80.320316 265.29665 
+L 79.556777 257.98977 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #02e8f4"/>
+    <path d="M 90.05445 265.3453 
+L 80.320316 265.29665 
+L 89.290911 258.03842 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00e4f8"/>
+    <path d="M 88.527371 250.73154 
+L 79.556777 257.98977 
+L 89.290911 258.03842 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #39ffbe"/>
+    <path d="M 80.320316 265.29665 
+L 79.556777 257.98977 
+L 89.290911 258.03842 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #16ffe1"/>
+    <path d="M 113.560466 264.3168 
+L 117.796686 271.834 
+L 125.963607 263.65115 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00c0ff"/>
+    <path d="M 122.032905 279.3512 
+L 117.796686 271.834 
+L 130.199826 271.16835 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0068ff"/>
+    <path d="M 138.366747 262.9855 
+L 125.963607 263.65115 
+L 130.199826 271.16835 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00c8ff"/>
+    <path d="M 117.796686 271.834 
+L 125.963607 263.65115 
+L 130.199826 271.16835 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00a4ff"/>
+    <path d="M 163.374017 261.503575 
+L 175.188397 260.320362 
+L 168.104673 253.110187 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #2cffca"/>
+    <path d="M 187.002777 259.13715 
+L 175.188397 260.320362 
+L 179.919053 251.926975 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #39ffbe"/>
+    <path d="M 172.835329 244.7168 
+L 168.104673 253.110187 
+L 179.919053 251.926975 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #70ff87"/>
+    <path d="M 175.188397 260.320362 
+L 168.104673 253.110187 
+L 179.919053 251.926975 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #46ffb1"/>
+    <path d="M 242.68407 261.001402 
+L 247.002702 270.367695 
+L 254.670305 262.738027 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #13fce4"/>
+    <path d="M 251.321335 279.733989 
+L 247.002702 270.367695 
+L 258.988938 272.10432 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0088ff"/>
+    <path d="M 266.656541 264.474652 
+L 254.670305 262.738027 
+L 258.988938 272.10432 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #06ecf1"/>
+    <path d="M 247.002702 270.367695 
+L 254.670305 262.738027 
+L 258.988938 272.10432 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00d0ff"/>
+    <path d="M 290.196288 265.488012 
+L 301.310951 265.78276 
+L 294.972661 259.986294 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #30ffc7"/>
+    <path d="M 312.425614 266.077509 
+L 301.310951 265.78276 
+L 306.087324 260.281043 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #30ffc7"/>
+    <path d="M 299.749035 254.484576 
+L 294.972661 259.986294 
+L 306.087324 260.281043 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #66ff90"/>
+    <path d="M 301.310951 265.78276 
+L 294.972661 259.986294 
+L 306.087324 260.281043 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #43ffb4"/>
+    <path d="M 200.296129 176.831059 
+L 184.171934 176.51485 
+L 189.735477 185.171488 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2500"/>
+    <path d="M 168.047739 176.198641 
+L 184.171934 176.51485 
+L 173.611281 184.855278 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3400"/>
+    <path d="M 179.174824 193.511916 
+L 189.735477 185.171488 
+L 173.611281 184.855278 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3f00"/>
+    <path d="M 184.171934 176.51485 
+L 189.735477 185.171488 
+L 173.611281 184.855278 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3000"/>
+    <path d="M 330.309818 114.048 
+L 318.798722 115.256376 
+L 323.115591 110.344406 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6c00"/>
+    <path d="M 307.287625 116.464752 
+L 318.798722 115.256376 
+L 311.604495 111.552782 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6800"/>
+    <path d="M 315.921364 106.640811 
+L 323.115591 110.344406 
+L 311.604495 111.552782 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8d00"/>
+    <path d="M 318.798722 115.256376 
+L 323.115591 110.344406 
+L 311.604495 111.552782 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7700"/>
+    <path d="M 330.309818 144.288 
+L 330.309818 136.728 
+L 321.971716 143.648567 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ad0000"/>
+    <path d="M 330.309818 129.168 
+L 330.309818 136.728 
+L 321.971716 136.088567 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d60000"/>
+    <path d="M 313.633613 143.009133 
+L 321.971716 143.648567 
+L 321.971716 136.088567 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #b60000"/>
+    <path d="M 330.309818 136.728 
+L 321.971716 143.648567 
+L 321.971716 136.088567 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #bf0000"/>
+    <path d="M 287.330454 112.615603 
+L 297.30904 114.540178 
+L 291.934727 118.997098 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6f00"/>
+    <path d="M 307.287625 116.464752 
+L 297.30904 114.540178 
+L 301.913313 120.921673 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5900"/>
+    <path d="M 296.539001 125.378593 
+L 291.934727 118.997098 
+L 301.913313 120.921673 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4300"/>
+    <path d="M 297.30904 114.540178 
+L 291.934727 118.997098 
+L 301.913313 120.921673 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5900"/>
+    <path d="M 290.75748 139.764349 
+L 295.692201 146.805838 
+L 302.195547 141.386741 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #bf0000"/>
+    <path d="M 300.626923 153.847327 
+L 295.692201 146.805838 
+L 307.130268 148.42823 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a40000"/>
+    <path d="M 313.633613 143.009133 
+L 302.195547 141.386741 
+L 307.130268 148.42823 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ad0000"/>
+    <path d="M 295.692201 146.805838 
+L 302.195547 141.386741 
+L 307.130268 148.42823 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #b20000"/>
+    <path d="M 163.851807 142.202238 
+L 170.357224 151.228115 
+L 160.036034 151.015562 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4a00"/>
+    <path d="M 176.86264 160.253992 
+L 170.357224 151.228115 
+L 166.54145 160.041439 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3400"/>
+    <path d="M 156.22026 159.828887 
+L 160.036034 151.015562 
+L 166.54145 160.041439 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3b00"/>
+    <path d="M 170.357224 151.228115 
+L 160.036034 151.015562 
+L 166.54145 160.041439 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3b00"/>
+    <path d="M 113.13242 167.275822 
+L 103.153695 170.430028 
+L 108.886409 174.282109 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3f00"/>
+    <path d="M 93.17497 173.584234 
+L 103.153695 170.430028 
+L 98.907684 177.436315 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4300"/>
+    <path d="M 104.640398 181.288396 
+L 108.886409 174.282109 
+L 98.907684 177.436315 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4700"/>
+    <path d="M 103.153695 170.430028 
+L 108.886409 174.282109 
+L 98.907684 177.436315 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4300"/>
+    <path d="M 205.86375 143.34645 
+L 200.615603 149.823818 
+L 195.290427 144.136109 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3800"/>
+    <path d="M 195.367456 156.301185 
+L 200.615603 149.823818 
+L 190.04228 150.613476 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2d00"/>
+    <path d="M 184.717105 144.925767 
+L 195.290427 144.136109 
+L 190.04228 150.613476 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3b00"/>
+    <path d="M 200.615603 149.823818 
+L 195.290427 144.136109 
+L 190.04228 150.613476 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3400"/>
+    <path d="M 186.700092 115.845387 
+L 188.404472 124.559664 
+L 181.548314 123.279899 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffab00"/>
+    <path d="M 190.108852 133.273941 
+L 188.404472 124.559664 
+L 183.252694 131.994176 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7a00"/>
+    <path d="M 176.396537 130.71441 
+L 181.548314 123.279899 
+L 183.252694 131.994176 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8600"/>
+    <path d="M 188.404472 124.559664 
+L 181.548314 123.279899 
+L 183.252694 131.994176 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8d00"/>
+    <path d="M 130.611451 153.111981 
+L 133.588867 146.199669 
+L 138.727876 149.703564 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4e00"/>
+    <path d="M 136.566283 139.287357 
+L 133.588867 146.199669 
+L 141.705292 142.791252 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6000"/>
+    <path d="M 146.844301 146.295147 
+L 138.727876 149.703564 
+L 141.705292 142.791252 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5500"/>
+    <path d="M 133.588867 146.199669 
+L 138.727876 149.703564 
+L 141.705292 142.791252 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5500"/>
+    <path d="M 70.586182 265.248 
+L 70.586182 272.808 
+L 80.320316 265.29665 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00b4ff"/>
+    <path d="M 70.586182 280.368 
+L 70.586182 272.808 
+L 80.320316 272.85665 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #005cff"/>
+    <path d="M 90.05445 265.3453 
+L 80.320316 265.29665 
+L 80.320316 272.85665 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00b0ff"/>
+    <path d="M 70.586182 272.808 
+L 80.320316 265.29665 
+L 80.320316 272.85665 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0094ff"/>
+    <path d="M 208.586377 249.238188 
+L 205.97724 259.758405 
+L 215.077836 255.236602 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #56ffa0"/>
+    <path d="M 203.368103 270.278623 
+L 205.97724 259.758405 
+L 212.468699 265.75682 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00e0fb"/>
+    <path d="M 221.569294 261.235016 
+L 215.077836 255.236602 
+L 212.468699 265.75682 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #26ffd1"/>
+    <path d="M 205.97724 259.758405 
+L 215.077836 255.236602 
+L 212.468699 265.75682 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #29ffce"/>
+    <path d="M 113.560466 264.3168 
+L 104.609939 272.1639 
+L 117.796686 271.834 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00a0ff"/>
+    <path d="M 95.659411 280.011 
+L 104.609939 272.1639 
+L 108.846158 279.6811 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0044ff"/>
+    <path d="M 122.032905 279.3512 
+L 117.796686 271.834 
+L 108.846158 279.6811 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0048ff"/>
+    <path d="M 104.609939 272.1639 
+L 117.796686 271.834 
+L 108.846158 279.6811 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0064ff"/>
+    <path d="M 208.586377 249.238188 
+L 205.97724 259.758405 
+L 197.794577 254.187669 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #56ffa0"/>
+    <path d="M 203.368103 270.278623 
+L 205.97724 259.758405 
+L 195.18544 264.707886 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00e0fb"/>
+    <path d="M 187.002777 259.13715 
+L 197.794577 254.187669 
+L 195.18544 264.707886 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #2cffca"/>
+    <path d="M 205.97724 259.758405 
+L 197.794577 254.187669 
+L 195.18544 264.707886 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #29ffce"/>
+    <path d="M 242.68407 261.001402 
+L 234.555761 269.333524 
+L 247.002702 270.367695 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00dcfe"/>
+    <path d="M 226.427451 277.665646 
+L 234.555761 269.333524 
+L 238.874393 278.699817 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0074ff"/>
+    <path d="M 251.321335 279.733989 
+L 247.002702 270.367695 
+L 238.874393 278.699817 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #006cff"/>
+    <path d="M 234.555761 269.333524 
+L 247.002702 270.367695 
+L 238.874393 278.699817 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0094ff"/>
+    <path d="M 330.309818 265.248 
+L 330.309818 272.808 
+L 321.367716 265.662754 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0ff8e7"/>
+    <path d="M 330.309818 280.368 
+L 330.309818 272.808 
+L 321.367716 273.222754 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0090ff"/>
+    <path d="M 312.425614 266.077509 
+L 321.367716 265.662754 
+L 321.367716 273.222754 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #09f0ee"/>
+    <path d="M 330.309818 272.808 
+L 321.367716 265.662754 
+L 321.367716 273.222754 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00d0ff"/>
+    <path d="M 135.339984 229.015738 
+L 130.480258 238.964769 
+L 142.917265 237.866894 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #caff2c"/>
+    <path d="M 125.620531 248.9138 
+L 130.480258 238.964769 
+L 138.057539 247.815925 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #8aff6d"/>
+    <path d="M 150.494546 246.71805 
+L 142.917265 237.866894 
+L 138.057539 247.815925 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #94ff63"/>
+    <path d="M 130.480258 238.964769 
+L 142.917265 237.866894 
+L 138.057539 247.815925 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a0ff56"/>
+    <path d="M 267.000443 228.961756 
+L 262.457973 239.2232 
+L 273.393099 239.83989 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffe600"/>
+    <path d="M 257.915504 249.484645 
+L 262.457973 239.2232 
+L 268.850629 250.101335 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #b7ff40"/>
+    <path d="M 279.785755 250.718024 
+L 273.393099 239.83989 
+L 268.850629 250.101335 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #baff3c"/>
+    <path d="M 262.457973 239.2232 
+L 273.393099 239.83989 
+L 268.850629 250.101335 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d1ff26"/>
+    <path d="M 163.374017 261.503575 
+L 170.885888 269.263188 
+L 157.738264 270.186737 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00c0ff"/>
+    <path d="M 178.397758 277.0228 
+L 170.885888 269.263188 
+L 165.250135 277.94635 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0068ff"/>
+    <path d="M 152.102511 278.8699 
+L 157.738264 270.186737 
+L 165.250135 277.94635 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #005cff"/>
+    <path d="M 170.885888 269.263188 
+L 157.738264 270.186737 
+L 165.250135 277.94635 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0080ff"/>
+    <path d="M 163.374017 261.503575 
+L 156.934282 254.110813 
+L 168.104673 253.110187 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #3cffba"/>
+    <path d="M 150.494546 246.71805 
+L 156.934282 254.110813 
+L 161.664938 245.717425 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #73ff83"/>
+    <path d="M 172.835329 244.7168 
+L 168.104673 253.110187 
+L 161.664938 245.717425 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #7dff7a"/>
+    <path d="M 156.934282 254.110813 
+L 168.104673 253.110187 
+L 161.664938 245.717425 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #63ff94"/>
+    <path d="M 164.518254 204.793791 
+L 160.19994 211.4421 
+L 167.268644 211.436695 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8d00"/>
+    <path d="M 155.881626 218.090409 
+L 160.19994 211.4421 
+L 162.950331 218.085004 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffae00"/>
+    <path d="M 170.019035 218.079599 
+L 167.268644 211.436695 
+L 162.950331 218.085004 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffab00"/>
+    <path d="M 160.19994 211.4421 
+L 167.268644 211.436695 
+L 162.950331 218.085004 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffa300"/>
+    <path d="M 290.196288 265.488012 
+L 298.226071 272.970749 
+L 285.543877 272.80156 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00c8ff"/>
+    <path d="M 306.255853 280.453486 
+L 298.226071 272.970749 
+L 293.573659 280.284297 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0068ff"/>
+    <path d="M 280.891466 280.115109 
+L 285.543877 272.80156 
+L 293.573659 280.284297 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0068ff"/>
+    <path d="M 298.226071 272.970749 
+L 285.543877 272.80156 
+L 293.573659 280.284297 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0088ff"/>
+    <path d="M 113.560466 264.3168 
+L 101.807458 264.83105 
+L 108.800538 258.7533 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #02e8f4"/>
+    <path d="M 90.05445 265.3453 
+L 101.807458 264.83105 
+L 97.04753 259.26755 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00e4f8"/>
+    <path d="M 104.040609 253.1898 
+L 108.800538 258.7533 
+L 97.04753 259.26755 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #30ffc7"/>
+    <path d="M 101.807458 264.83105 
+L 108.800538 258.7533 
+L 97.04753 259.26755 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0ff8e7"/>
+    <path d="M 135.517091 295.488 
+L 128.774998 287.4196 
+L 143.809801 287.17895 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000a8"/>
+    <path d="M 122.032905 279.3512 
+L 128.774998 287.4196 
+L 137.067708 279.11055 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #000cff"/>
+    <path d="M 152.102511 278.8699 
+L 143.809801 287.17895 
+L 137.067708 279.11055 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0010ff"/>
+    <path d="M 128.774998 287.4196 
+L 143.809801 287.17895 
+L 137.067708 279.11055 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000fa"/>
+    <path d="M 186.023366 225.094146 
+L 179.429347 234.905473 
+L 188.661034 233.999322 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #eeff09"/>
+    <path d="M 172.835329 244.7168 
+L 179.429347 234.905473 
+L 182.067016 243.810648 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #adff49"/>
+    <path d="M 191.298703 242.904497 
+L 188.661034 233.999322 
+L 182.067016 243.810648 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #b7ff40"/>
+    <path d="M 179.429347 234.905473 
+L 188.661034 233.999322 
+L 182.067016 243.810648 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #c7ff30"/>
+    <path d="M 265.378909 295.488 
+L 258.350122 287.610994 
+L 273.135188 287.801554 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000ad"/>
+    <path d="M 251.321335 279.733989 
+L 258.350122 287.610994 
+L 266.1064 279.924549 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #001cff"/>
+    <path d="M 280.891466 280.115109 
+L 273.135188 287.801554 
+L 266.1064 279.924549 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #001cff"/>
+    <path d="M 258.350122 287.610994 
+L 273.135188 287.801554 
+L 266.1064 279.924549 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000ff"/>
+    <path d="M 298.999791 237.369252 
+L 299.374413 245.926914 
+L 306.498309 244.443892 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ebff0c"/>
+    <path d="M 299.749035 254.484576 
+L 299.374413 245.926914 
+L 306.872931 253.001555 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a4ff53"/>
+    <path d="M 313.996828 251.518533 
+L 306.498309 244.443892 
+L 306.872931 253.001555 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #b4ff43"/>
+    <path d="M 299.374413 245.926914 
+L 306.498309 244.443892 
+L 306.872931 253.001555 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #c1ff36"/>
+    <path d="M 164.518254 204.793791 
+L 171.846539 199.152854 
+L 162.084739 197.99342 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6c00"/>
+    <path d="M 179.174824 193.511916 
+L 171.846539 199.152854 
+L 169.413024 192.352483 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5200"/>
+    <path d="M 159.651223 191.193049 
+L 162.084739 197.99342 
+L 169.413024 192.352483 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5500"/>
+    <path d="M 171.846539 199.152854 
+L 162.084739 197.99342 
+L 169.413024 192.352483 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5d00"/>
+    <path d="M 313.858381 95.963238 
+L 314.889873 101.302025 
+L 309.137714 101.047488 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffea00"/>
+    <path d="M 315.921364 106.640811 
+L 314.889873 101.302025 
+L 310.169206 106.386274 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffb600"/>
+    <path d="M 304.417048 106.131737 
+L 309.137714 101.047488 
+L 310.169206 106.386274 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffbd00"/>
+    <path d="M 314.889873 101.302025 
+L 309.137714 101.047488 
+L 310.169206 106.386274 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffc800"/>
+    <path d="M 290.75748 139.764349 
+L 301.321104 134.140413 
+L 302.195547 141.386741 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d10000"/>
+    <path d="M 311.884729 128.516476 
+L 301.321104 134.140413 
+L 312.759171 135.762805 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #e40000"/>
+    <path d="M 313.633613 143.009133 
+L 302.195547 141.386741 
+L 312.759171 135.762805 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #bf0000"/>
+    <path d="M 301.321104 134.140413 
+L 302.195547 141.386741 
+L 312.759171 135.762805 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d10000"/>
+    <path d="M 290.75748 139.764349 
+L 301.321104 134.140413 
+L 293.648241 132.571471 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #e40000"/>
+    <path d="M 311.884729 128.516476 
+L 301.321104 134.140413 
+L 304.211865 126.947535 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f60b00"/>
+    <path d="M 296.539001 125.378593 
+L 293.648241 132.571471 
+L 304.211865 126.947535 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1a00"/>
+    <path d="M 301.321104 134.140413 
+L 293.648241 132.571471 
+L 304.211865 126.947535 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f60b00"/>
+    <path d="M 330.309818 144.288 
+L 322.168723 151.18702 
+L 321.971716 143.648567 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #9f0000"/>
+    <path d="M 314.027627 158.08604 
+L 322.168723 151.18702 
+L 313.83062 150.547587 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #920000"/>
+    <path d="M 313.633613 143.009133 
+L 321.971716 143.648567 
+L 313.83062 150.547587 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a40000"/>
+    <path d="M 322.168723 151.18702 
+L 321.971716 143.648567 
+L 313.83062 150.547587 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #9b0000"/>
+    <path d="M 140.773746 177.431432 
+L 154.410742 176.815036 
+L 148.497003 168.630159 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3800"/>
+    <path d="M 168.047739 176.198641 
+L 154.410742 176.815036 
+L 162.134 168.013764 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3400"/>
+    <path d="M 156.22026 159.828887 
+L 148.497003 168.630159 
+L 162.134 168.013764 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3800"/>
+    <path d="M 154.410742 176.815036 
+L 148.497003 168.630159 
+L 162.134 168.013764 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3800"/>
+    <path d="M 105.499696 199.627051 
+L 97.493629 192.572956 
+L 105.070047 190.457724 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6800"/>
+    <path d="M 89.487562 185.518862 
+L 97.493629 192.572956 
+L 97.06398 183.403629 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5500"/>
+    <path d="M 104.640398 181.288396 
+L 105.070047 190.457724 
+L 97.06398 183.403629 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5200"/>
+    <path d="M 97.493629 192.572956 
+L 105.070047 190.457724 
+L 97.06398 183.403629 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5900"/>
+    <path d="M 163.851807 142.202238 
+L 170.357224 151.228115 
+L 174.284456 143.564003 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4a00"/>
+    <path d="M 176.86264 160.253992 
+L 170.357224 151.228115 
+L 180.789873 152.589879 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3800"/>
+    <path d="M 184.717105 144.925767 
+L 174.284456 143.564003 
+L 180.789873 152.589879 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4300"/>
+    <path d="M 170.357224 151.228115 
+L 174.284456 143.564003 
+L 180.789873 152.589879 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4300"/>
+    <path d="M 163.851807 142.202238 
+L 170.124172 136.458324 
+L 174.284456 143.564003 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5900"/>
+    <path d="M 176.396537 130.71441 
+L 170.124172 136.458324 
+L 180.556821 137.820089 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6c00"/>
+    <path d="M 184.717105 144.925767 
+L 174.284456 143.564003 
+L 180.556821 137.820089 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4e00"/>
+    <path d="M 170.124172 136.458324 
+L 174.284456 143.564003 
+L 180.556821 137.820089 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5d00"/>
+    <path d="M 163.851807 142.202238 
+L 155.858683 138.535643 
+L 155.348054 144.248693 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5900"/>
+    <path d="M 147.86556 134.869048 
+L 155.858683 138.535643 
+L 147.35493 140.582097 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6c00"/>
+    <path d="M 146.844301 146.295147 
+L 155.348054 144.248693 
+L 147.35493 140.582097 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5900"/>
+    <path d="M 155.858683 138.535643 
+L 155.348054 144.248693 
+L 147.35493 140.582097 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6000"/>
+    <path d="M 113.560466 264.3168 
+L 104.609939 272.1639 
+L 101.807458 264.83105 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00b8ff"/>
+    <path d="M 95.659411 280.011 
+L 104.609939 272.1639 
+L 92.856931 272.67815 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0060ff"/>
+    <path d="M 90.05445 265.3453 
+L 101.807458 264.83105 
+L 92.856931 272.67815 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00b4ff"/>
+    <path d="M 104.609939 272.1639 
+L 101.807458 264.83105 
+L 92.856931 272.67815 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0098ff"/>
+    <path d="M 242.68407 261.001402 
+L 234.555761 269.333524 
+L 232.126682 261.118209 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #16ffe1"/>
+    <path d="M 226.427451 277.665646 
+L 234.555761 269.333524 
+L 223.998373 269.450331 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0098ff"/>
+    <path d="M 221.569294 261.235016 
+L 232.126682 261.118209 
+L 223.998373 269.450331 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0ff8e7"/>
+    <path d="M 234.555761 269.333524 
+L 232.126682 261.118209 
+L 223.998373 269.450331 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00d8ff"/>
+    <path d="M 135.517091 295.488 
+L 119.284364 295.488 
+L 128.774998 287.4196 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #000080"/>
+    <path d="M 103.051636 295.488 
+L 119.284364 295.488 
+L 112.542271 287.4196 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #000080"/>
+    <path d="M 122.032905 279.3512 
+L 128.774998 287.4196 
+L 112.542271 287.4196 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000f6"/>
+    <path d="M 119.284364 295.488 
+L 128.774998 287.4196 
+L 112.542271 287.4196 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000a8"/>
+    <path d="M 163.374017 261.503575 
+L 170.885888 269.263188 
+L 175.188397 260.320362 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00e4f8"/>
+    <path d="M 178.397758 277.0228 
+L 170.885888 269.263188 
+L 182.700267 268.079975 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0090ff"/>
+    <path d="M 187.002777 259.13715 
+L 175.188397 260.320362 
+L 182.700267 268.079975 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0cf4eb"/>
+    <path d="M 170.885888 269.263188 
+L 175.188397 260.320362 
+L 182.700267 268.079975 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00ccff"/>
+    <path d="M 265.378909 295.488 
+L 249.146182 295.488 
+L 258.350122 287.610994 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #000084"/>
+    <path d="M 232.913455 295.488 
+L 249.146182 295.488 
+L 242.117395 287.610994 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #000084"/>
+    <path d="M 251.321335 279.733989 
+L 258.350122 287.610994 
+L 242.117395 287.610994 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000ff"/>
+    <path d="M 249.146182 295.488 
+L 258.350122 287.610994 
+L 242.117395 287.610994 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000ad"/>
+    <path d="M 290.196288 265.488012 
+L 298.226071 272.970749 
+L 301.310951 265.78276 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #06ecf1"/>
+    <path d="M 306.255853 280.453486 
+L 298.226071 272.970749 
+L 309.340734 273.265497 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0088ff"/>
+    <path d="M 312.425614 266.077509 
+L 301.310951 265.78276 
+L 309.340734 273.265497 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #06ecf1"/>
+    <path d="M 298.226071 272.970749 
+L 301.310951 265.78276 
+L 309.340734 273.265497 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00ccff"/>
+    <path d="M 163.374017 261.503575 
+L 156.934282 254.110813 
+L 150.870382 262.244537 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #23ffd4"/>
+    <path d="M 150.494546 246.71805 
+L 156.934282 254.110813 
+L 144.430647 254.851775 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #5aff9d"/>
+    <path d="M 138.366747 262.9855 
+L 150.870382 262.244537 
+L 144.430647 254.851775 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #1cffdb"/>
+    <path d="M 156.934282 254.110813 
+L 150.870382 262.244537 
+L 144.430647 254.851775 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #33ffc4"/>
+    <path d="M 290.196288 265.488012 
+L 284.991022 258.103018 
+L 278.426414 264.981332 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #36ffc1"/>
+    <path d="M 279.785755 250.718024 
+L 284.991022 258.103018 
+L 273.221148 257.596338 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #77ff80"/>
+    <path d="M 266.656541 264.474652 
+L 278.426414 264.981332 
+L 273.221148 257.596338 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #36ffc1"/>
+    <path d="M 284.991022 258.103018 
+L 278.426414 264.981332 
+L 273.221148 257.596338 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #49ffad"/>
+    <path d="M 135.517091 295.488 
+L 151.749818 295.488 
+L 143.809801 287.17895 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #000080"/>
+    <path d="M 167.982545 295.488 
+L 151.749818 295.488 
+L 160.042528 287.17895 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #000080"/>
+    <path d="M 152.102511 278.8699 
+L 143.809801 287.17895 
+L 160.042528 287.17895 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000fa"/>
+    <path d="M 151.749818 295.488 
+L 143.809801 287.17895 
+L 160.042528 287.17895 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000a8"/>
+    <path d="M 186.023366 225.094146 
+L 174.278824 228.419826 
+L 179.429347 234.905473 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f8f500"/>
+    <path d="M 162.534283 231.745505 
+L 174.278824 228.419826 
+L 167.684806 238.231153 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #e1ff16"/>
+    <path d="M 172.835329 244.7168 
+L 179.429347 234.905473 
+L 167.684806 238.231153 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #b7ff40"/>
+    <path d="M 174.278824 228.419826 
+L 179.429347 234.905473 
+L 167.684806 238.231153 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #dbff1c"/>
+    <path d="M 186.023366 225.094146 
+L 174.278824 228.419826 
+L 178.0212 221.586873 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffd700"/>
+    <path d="M 162.534283 231.745505 
+L 174.278824 228.419826 
+L 166.276659 224.912552 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #fbf100"/>
+    <path d="M 170.019035 218.079599 
+L 178.0212 221.586873 
+L 166.276659 224.912552 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffc800"/>
+    <path d="M 174.278824 228.419826 
+L 178.0212 221.586873 
+L 166.276659 224.912552 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffdb00"/>
+    <path d="M 265.378909 295.488 
+L 281.611636 295.488 
+L 273.135188 287.801554 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #000084"/>
+    <path d="M 297.844364 295.488 
+L 281.611636 295.488 
+L 289.367915 287.801554 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #000084"/>
+    <path d="M 280.891466 280.115109 
+L 273.135188 287.801554 
+L 289.367915 287.801554 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000ff"/>
+    <path d="M 281.611636 295.488 
+L 273.135188 287.801554 
+L 289.367915 287.801554 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000b2"/>
+    <path d="M 105.779291 235.878849 
+L 97.153331 243.305194 
+L 104.90995 244.534324 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a0ff56"/>
+    <path d="M 88.527371 250.73154 
+L 97.153331 243.305194 
+L 96.28399 251.96067 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #6dff8a"/>
+    <path d="M 104.040609 253.1898 
+L 104.90995 244.534324 
+L 96.28399 251.96067 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #66ff90"/>
+    <path d="M 97.153331 243.305194 
+L 104.90995 244.534324 
+L 96.28399 251.96067 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #7dff7a"/>
+    <path d="M 163.374017 261.503575 
+L 157.738264 270.186737 
+L 150.870382 262.244537 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00d8ff"/>
+    <path d="M 152.102511 278.8699 
+L 157.738264 270.186737 
+L 145.234629 270.9277 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0074ff"/>
+    <path d="M 138.366747 262.9855 
+L 150.870382 262.244537 
+L 145.234629 270.9277 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00d0ff"/>
+    <path d="M 157.738264 270.186737 
+L 150.870382 262.244537 
+L 145.234629 270.9277 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00b4ff"/>
+    <path d="M 208.586377 249.238188 
+L 197.794577 254.187669 
+L 199.94254 246.071343 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #7aff7d"/>
+    <path d="M 187.002777 259.13715 
+L 197.794577 254.187669 
+L 189.15074 251.020823 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #50ffa7"/>
+    <path d="M 191.298703 242.904497 
+L 199.94254 246.071343 
+L 189.15074 251.020823 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #8dff6a"/>
+    <path d="M 197.794577 254.187669 
+L 199.94254 246.071343 
+L 189.15074 251.020823 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #73ff83"/>
+    <path d="M 290.196288 265.488012 
+L 285.543877 272.80156 
+L 278.426414 264.981332 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #06ecf1"/>
+    <path d="M 280.891466 280.115109 
+L 285.543877 272.80156 
+L 273.774003 272.29488 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0088ff"/>
+    <path d="M 266.656541 264.474652 
+L 278.426414 264.981332 
+L 273.774003 272.29488 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #06ecf1"/>
+    <path d="M 285.543877 272.80156 
+L 278.426414 264.981332 
+L 273.774003 272.29488 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00c8ff"/>
+    <path d="M 330.309818 265.248 
+L 321.367716 265.662754 
+L 322.153323 258.383266 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #40ffb7"/>
+    <path d="M 312.425614 266.077509 
+L 321.367716 265.662754 
+L 313.211221 258.798021 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #39ffbe"/>
+    <path d="M 313.996828 251.518533 
+L 322.153323 258.383266 
+L 313.211221 258.798021 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #7dff7a"/>
+    <path d="M 321.367716 265.662754 
+L 322.153323 258.383266 
+L 313.211221 258.798021 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #50ffa7"/>
+    <path d="M 140.773746 177.431432 
+L 154.410742 176.815036 
+L 150.212485 184.312241 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3b00"/>
+    <path d="M 168.047739 176.198641 
+L 154.410742 176.815036 
+L 163.849481 183.695845 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3800"/>
+    <path d="M 159.651223 191.193049 
+L 150.212485 184.312241 
+L 163.849481 183.695845 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4700"/>
+    <path d="M 154.410742 176.815036 
+L 150.212485 184.312241 
+L 163.849481 183.695845 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3f00"/>
+    <path d="M 287.330454 112.615603 
+L 297.30904 114.540178 
+L 295.873751 109.37367 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8600"/>
+    <path d="M 307.287625 116.464752 
+L 297.30904 114.540178 
+L 305.852336 111.298245 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6f00"/>
+    <path d="M 304.417048 106.131737 
+L 295.873751 109.37367 
+L 305.852336 111.298245 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff9800"/>
+    <path d="M 297.30904 114.540178 
+L 295.873751 109.37367 
+L 305.852336 111.298245 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8600"/>
+    <path d="M 330.309818 129.168 
+L 321.097273 128.842238 
+L 321.971716 136.088567 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #e40000"/>
+    <path d="M 311.884729 128.516476 
+L 321.097273 128.842238 
+L 312.759171 135.762805 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #e80000"/>
+    <path d="M 313.633613 143.009133 
+L 321.971716 136.088567 
+L 312.759171 135.762805 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #c40000"/>
+    <path d="M 321.097273 128.842238 
+L 321.971716 136.088567 
+L 312.759171 135.762805 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #da0000"/>
+    <path d="M 311.884729 128.516476 
+L 309.586177 122.490614 
+L 304.211865 126.947535 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1e00"/>
+    <path d="M 307.287625 116.464752 
+L 309.586177 122.490614 
+L 301.913313 120.921673 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4700"/>
+    <path d="M 296.539001 125.378593 
+L 304.211865 126.947535 
+L 301.913313 120.921673 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2d00"/>
+    <path d="M 309.586177 122.490614 
+L 304.211865 126.947535 
+L 301.913313 120.921673 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3000"/>
+    <path d="M 314.027627 158.08604 
+L 307.327275 155.966684 
+L 313.83062 150.547587 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #8d0000"/>
+    <path d="M 300.626923 153.847327 
+L 307.327275 155.966684 
+L 307.130268 148.42823 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #960000"/>
+    <path d="M 313.633613 143.009133 
+L 313.83062 150.547587 
+L 307.130268 148.42823 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a40000"/>
+    <path d="M 307.327275 155.966684 
+L 313.83062 150.547587 
+L 307.130268 148.42823 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #9b0000"/>
+    <path d="M 168.047739 176.198641 
+L 172.455189 168.226316 
+L 162.134 168.013764 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3000"/>
+    <path d="M 176.86264 160.253992 
+L 172.455189 168.226316 
+L 166.54145 160.041439 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2d00"/>
+    <path d="M 156.22026 159.828887 
+L 162.134 168.013764 
+L 166.54145 160.041439 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3400"/>
+    <path d="M 172.455189 168.226316 
+L 162.134 168.013764 
+L 166.54145 160.041439 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3000"/>
+    <path d="M 93.17497 173.584234 
+L 91.331266 179.551548 
+L 98.907684 177.436315 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4300"/>
+    <path d="M 89.487562 185.518862 
+L 91.331266 179.551548 
+L 97.06398 183.403629 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4a00"/>
+    <path d="M 104.640398 181.288396 
+L 98.907684 177.436315 
+L 97.06398 183.403629 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4700"/>
+    <path d="M 91.331266 179.551548 
+L 98.907684 177.436315 
+L 97.06398 183.403629 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4700"/>
+    <path d="M 195.367456 156.301185 
+L 186.115048 158.277588 
+L 190.04228 150.613476 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2900"/>
+    <path d="M 176.86264 160.253992 
+L 186.115048 158.277588 
+L 180.789873 152.589879 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2d00"/>
+    <path d="M 184.717105 144.925767 
+L 190.04228 150.613476 
+L 180.789873 152.589879 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3b00"/>
+    <path d="M 186.115048 158.277588 
+L 190.04228 150.613476 
+L 180.789873 152.589879 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3000"/>
+    <path d="M 190.108852 133.273941 
+L 183.252694 131.994176 
+L 187.412978 139.099854 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6400"/>
+    <path d="M 176.396537 130.71441 
+L 183.252694 131.994176 
+L 180.556821 137.820089 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6f00"/>
+    <path d="M 184.717105 144.925767 
+L 187.412978 139.099854 
+L 180.556821 137.820089 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5200"/>
+    <path d="M 183.252694 131.994176 
+L 187.412978 139.099854 
+L 180.556821 137.820089 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6400"/>
+    <path d="M 136.566283 139.287357 
+L 142.215921 137.078202 
+L 141.705292 142.791252 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6800"/>
+    <path d="M 147.86556 134.869048 
+L 142.215921 137.078202 
+L 147.35493 140.582097 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6f00"/>
+    <path d="M 146.844301 146.295147 
+L 141.705292 142.791252 
+L 147.35493 140.582097 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5d00"/>
+    <path d="M 142.215921 137.078202 
+L 141.705292 142.791252 
+L 147.35493 140.582097 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6800"/>
+    <path d="M 70.586182 280.368 
+L 83.122797 280.1895 
+L 80.320316 272.85665 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0040ff"/>
+    <path d="M 95.659411 280.011 
+L 83.122797 280.1895 
+L 92.856931 272.67815 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0040ff"/>
+    <path d="M 90.05445 265.3453 
+L 80.320316 272.85665 
+L 92.856931 272.67815 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0094ff"/>
+    <path d="M 83.122797 280.1895 
+L 80.320316 272.85665 
+L 92.856931 272.67815 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #005cff"/>
+    <path d="M 203.368103 270.278623 
+L 214.897777 273.972134 
+L 212.468699 265.75682 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00acff"/>
+    <path d="M 226.427451 277.665646 
+L 214.897777 273.972134 
+L 223.998373 269.450331 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0080ff"/>
+    <path d="M 221.569294 261.235016 
+L 212.468699 265.75682 
+L 223.998373 269.450331 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00e4f8"/>
+    <path d="M 214.897777 273.972134 
+L 212.468699 265.75682 
+L 223.998373 269.450331 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00b0ff"/>
+    <path d="M 103.051636 295.488 
+L 99.355524 287.7495 
+L 112.542271 287.4196 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000a4"/>
+    <path d="M 95.659411 280.011 
+L 99.355524 287.7495 
+L 108.846158 279.6811 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0004ff"/>
+    <path d="M 122.032905 279.3512 
+L 112.542271 287.4196 
+L 108.846158 279.6811 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0008ff"/>
+    <path d="M 99.355524 287.7495 
+L 112.542271 287.4196 
+L 108.846158 279.6811 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000f1"/>
+    <path d="M 178.397758 277.0228 
+L 190.88293 273.650711 
+L 182.700267 268.079975 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0080ff"/>
+    <path d="M 203.368103 270.278623 
+L 190.88293 273.650711 
+L 195.18544 264.707886 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00acff"/>
+    <path d="M 187.002777 259.13715 
+L 182.700267 268.079975 
+L 195.18544 264.707886 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #02e8f4"/>
+    <path d="M 190.88293 273.650711 
+L 182.700267 268.079975 
+L 195.18544 264.707886 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00b0ff"/>
+    <path d="M 232.913455 295.488 
+L 229.670453 286.576823 
+L 242.117395 287.610994 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000b2"/>
+    <path d="M 226.427451 277.665646 
+L 229.670453 286.576823 
+L 238.874393 278.699817 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0028ff"/>
+    <path d="M 251.321335 279.733989 
+L 242.117395 287.610994 
+L 238.874393 278.699817 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0020ff"/>
+    <path d="M 229.670453 286.576823 
+L 242.117395 287.610994 
+L 238.874393 278.699817 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000ff"/>
+    <path d="M 306.255853 280.453486 
+L 318.282836 280.410743 
+L 309.340734 273.265497 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0068ff"/>
+    <path d="M 330.309818 280.368 
+L 318.282836 280.410743 
+L 321.367716 273.222754 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #006cff"/>
+    <path d="M 312.425614 266.077509 
+L 309.340734 273.265497 
+L 321.367716 273.222754 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00ccff"/>
+    <path d="M 318.282836 280.410743 
+L 309.340734 273.265497 
+L 321.367716 273.222754 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #008cff"/>
+    <path d="M 125.620531 248.9138 
+L 138.057539 247.815925 
+L 131.993639 255.94965 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #60ff97"/>
+    <path d="M 150.494546 246.71805 
+L 138.057539 247.815925 
+L 144.430647 254.851775 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #6aff8d"/>
+    <path d="M 138.366747 262.9855 
+L 131.993639 255.94965 
+L 144.430647 254.851775 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #29ffce"/>
+    <path d="M 138.057539 247.815925 
+L 131.993639 255.94965 
+L 144.430647 254.851775 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #53ffa4"/>
+    <path d="M 257.915504 249.484645 
+L 268.850629 250.101335 
+L 262.286022 256.979649 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #8aff6d"/>
+    <path d="M 279.785755 250.718024 
+L 268.850629 250.101335 
+L 273.221148 257.596338 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #8aff6d"/>
+    <path d="M 266.656541 264.474652 
+L 262.286022 256.979649 
+L 273.221148 257.596338 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #49ffad"/>
+    <path d="M 268.850629 250.101335 
+L 262.286022 256.979649 
+L 273.221148 257.596338 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #73ff83"/>
+    <path d="M 167.982545 295.488 
+L 173.190152 286.2554 
+L 160.042528 287.17895 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000ad"/>
+    <path d="M 178.397758 277.0228 
+L 173.190152 286.2554 
+L 165.250135 277.94635 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0024ff"/>
+    <path d="M 152.102511 278.8699 
+L 160.042528 287.17895 
+L 165.250135 277.94635 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0014ff"/>
+    <path d="M 173.190152 286.2554 
+L 160.042528 287.17895 
+L 165.250135 277.94635 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000ff"/>
+    <path d="M 150.494546 246.71805 
+L 156.514415 239.231778 
+L 161.664938 245.717425 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #97ff60"/>
+    <path d="M 162.534283 231.745505 
+L 156.514415 239.231778 
+L 167.684806 238.231153 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #c7ff30"/>
+    <path d="M 172.835329 244.7168 
+L 161.664938 245.717425 
+L 167.684806 238.231153 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a0ff56"/>
+    <path d="M 156.514415 239.231778 
+L 161.664938 245.717425 
+L 167.684806 238.231153 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #aaff4d"/>
+    <path d="M 155.881626 218.090409 
+L 159.207955 224.917957 
+L 162.950331 218.085004 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffc400"/>
+    <path d="M 162.534283 231.745505 
+L 159.207955 224.917957 
+L 166.276659 224.912552 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #feed00"/>
+    <path d="M 170.019035 218.079599 
+L 162.950331 218.085004 
+L 166.276659 224.912552 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffc400"/>
+    <path d="M 159.207955 224.917957 
+L 162.950331 218.085004 
+L 166.276659 224.912552 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffd300"/>
+    <path d="M 297.844364 295.488 
+L 302.050108 287.970743 
+L 289.367915 287.801554 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000b2"/>
+    <path d="M 306.255853 280.453486 
+L 302.050108 287.970743 
+L 293.573659 280.284297 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0020ff"/>
+    <path d="M 280.891466 280.115109 
+L 289.367915 287.801554 
+L 293.573659 280.284297 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0020ff"/>
+    <path d="M 302.050108 287.970743 
+L 289.367915 287.801554 
+L 293.573659 280.284297 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0000ff"/>
+    <path d="M 90.05445 265.3453 
+L 89.290911 258.03842 
+L 97.04753 259.26755 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0ff8e7"/>
+    <path d="M 88.527371 250.73154 
+L 89.290911 258.03842 
+L 96.28399 251.96067 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #49ffad"/>
+    <path d="M 104.040609 253.1898 
+L 97.04753 259.26755 
+L 96.28399 251.96067 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #40ffb7"/>
+    <path d="M 89.290911 258.03842 
+L 97.04753 259.26755 
+L 96.28399 251.96067 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #33ffc4"/>
+    <path d="M 122.032905 279.3512 
+L 137.067708 279.11055 
+L 130.199826 271.16835 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0050ff"/>
+    <path d="M 152.102511 278.8699 
+L 137.067708 279.11055 
+L 145.234629 270.9277 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0054ff"/>
+    <path d="M 138.366747 262.9855 
+L 130.199826 271.16835 
+L 145.234629 270.9277 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00acff"/>
+    <path d="M 137.067708 279.11055 
+L 130.199826 271.16835 
+L 145.234629 270.9277 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0070ff"/>
+    <path d="M 187.002777 259.13715 
+L 179.919053 251.926975 
+L 189.15074 251.020823 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #53ffa4"/>
+    <path d="M 172.835329 244.7168 
+L 179.919053 251.926975 
+L 182.067016 243.810648 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #87ff70"/>
+    <path d="M 191.298703 242.904497 
+L 189.15074 251.020823 
+L 182.067016 243.810648 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #90ff66"/>
+    <path d="M 179.919053 251.926975 
+L 189.15074 251.020823 
+L 182.067016 243.810648 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #7aff7d"/>
+    <path d="M 251.321335 279.733989 
+L 266.1064 279.924549 
+L 258.988938 272.10432 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0064ff"/>
+    <path d="M 280.891466 280.115109 
+L 266.1064 279.924549 
+L 273.774003 272.29488 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0064ff"/>
+    <path d="M 266.656541 264.474652 
+L 258.988938 272.10432 
+L 273.774003 272.29488 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #00c8ff"/>
+    <path d="M 266.1064 279.924549 
+L 258.988938 272.10432 
+L 273.774003 272.29488 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #0084ff"/>
+    <path d="M 312.425614 266.077509 
+L 306.087324 260.281043 
+L 313.211221 258.798021 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #49ffad"/>
+    <path d="M 299.749035 254.484576 
+L 306.087324 260.281043 
+L 306.872931 253.001555 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #7dff7a"/>
+    <path d="M 313.996828 251.518533 
+L 313.211221 258.798021 
+L 306.872931 253.001555 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #8dff6a"/>
+    <path d="M 306.087324 260.281043 
+L 313.211221 258.798021 
+L 306.872931 253.001555 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #70ff87"/>
+    <path d="M 168.047739 176.198641 
+L 173.611281 184.855278 
+L 163.849481 183.695845 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3b00"/>
+    <path d="M 179.174824 193.511916 
+L 173.611281 184.855278 
+L 169.413024 192.352483 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4700"/>
+    <path d="M 159.651223 191.193049 
+L 163.849481 183.695845 
+L 169.413024 192.352483 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4a00"/>
+    <path d="M 173.611281 184.855278 
+L 163.849481 183.695845 
+L 169.413024 192.352483 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4300"/>
+    <path d="M 307.287625 116.464752 
+L 311.604495 111.552782 
+L 305.852336 111.298245 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7300"/>
+    <path d="M 315.921364 106.640811 
+L 311.604495 111.552782 
+L 310.169206 106.386274 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff9800"/>
+    <path d="M 304.417048 106.131737 
+L 305.852336 111.298245 
+L 310.169206 106.386274 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff9f00"/>
+    <path d="M 311.604495 111.552782 
+L 305.852336 111.298245 
+L 310.169206 106.386274 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8d00"/>
+    <path d="M 261.206458 168.893794 
+L 278.057725 170.72696 
+L 272.647631 162.215954 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ad0000"/>
+    <path d="M 294.908991 172.560125 
+L 278.057725 170.72696 
+L 289.498898 164.04912 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #9b0000"/>
+    <path d="M 284.088804 155.538114 
+L 272.647631 162.215954 
+L 289.498898 164.04912 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a40000"/>
+    <path d="M 278.057725 170.72696 
+L 272.647631 162.215954 
+L 289.498898 164.04912 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a40000"/>
+    <path d="M 248.022952 115.210555 
+L 255.879455 127.45058 
+L 258.918165 117.422947 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7700"/>
+    <path d="M 263.735957 139.690605 
+L 255.879455 127.45058 
+L 266.774668 129.662972 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2d00"/>
+    <path d="M 269.813378 119.635339 
+L 258.918165 117.422947 
+L 266.774668 129.662972 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5d00"/>
+    <path d="M 255.879455 127.45058 
+L 258.918165 117.422947 
+L 266.774668 129.662972 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5500"/>
+    <path d="M 263.735957 139.690605 
+L 277.246719 139.727477 
+L 272.769442 133.941267 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ed0400"/>
+    <path d="M 290.75748 139.764349 
+L 277.246719 139.727477 
+L 286.280204 133.978139 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #df0000"/>
+    <path d="M 281.802928 128.191929 
+L 272.769442 133.941267 
+L 286.280204 133.978139 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1600"/>
+    <path d="M 277.246719 139.727477 
+L 272.769442 133.941267 
+L 286.280204 133.978139 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f10800"/>
+    <path d="M 140.773746 177.431432 
+L 126.953083 172.353627 
+L 131.164062 181.572005 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3f00"/>
+    <path d="M 113.13242 167.275822 
+L 126.953083 172.353627 
+L 117.343399 176.4942 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3f00"/>
+    <path d="M 121.554378 185.712578 
+L 131.164062 181.572005 
+L 117.343399 176.4942 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4700"/>
+    <path d="M 126.953083 172.353627 
+L 131.164062 181.572005 
+L 117.343399 176.4942 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4300"/>
+    <path d="M 140.773746 177.431432 
+L 135.692598 165.271707 
+L 148.497003 168.630159 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3b00"/>
+    <path d="M 130.611451 153.111981 
+L 135.692598 165.271707 
+L 143.415855 156.470434 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4300"/>
+    <path d="M 156.22026 159.828887 
+L 148.497003 168.630159 
+L 143.415855 156.470434 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3b00"/>
+    <path d="M 135.692598 165.271707 
+L 148.497003 168.630159 
+L 143.415855 156.470434 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3f00"/>
+    <path d="M 200.296129 176.831059 
+L 200.807573 190.749402 
+L 189.735477 185.171488 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2d00"/>
+    <path d="M 201.319018 204.667744 
+L 200.807573 190.749402 
+L 190.246921 199.08983 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5200"/>
+    <path d="M 179.174824 193.511916 
+L 189.735477 185.171488 
+L 190.246921 199.08983 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4700"/>
+    <path d="M 200.807573 190.749402 
+L 189.735477 185.171488 
+L 190.246921 199.08983 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3f00"/>
+    <path d="M 135.339984 229.015738 
+L 120.559638 232.447293 
+L 130.480258 238.964769 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d4ff23"/>
+    <path d="M 105.779291 235.878849 
+L 120.559638 232.447293 
+L 115.699911 242.396324 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #beff39"/>
+    <path d="M 125.620531 248.9138 
+L 130.480258 238.964769 
+L 115.699911 242.396324 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #94ff63"/>
+    <path d="M 120.559638 232.447293 
+L 130.480258 238.964769 
+L 115.699911 242.396324 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #b7ff40"/>
+    <path d="M 267.000443 228.961756 
+L 283.000117 233.165504 
+L 273.393099 239.83989 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffd000"/>
+    <path d="M 298.999791 237.369252 
+L 283.000117 233.165504 
+L 289.392773 244.043638 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffe600"/>
+    <path d="M 279.785755 250.718024 
+L 273.393099 239.83989 
+L 289.392773 244.043638 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ceff29"/>
+    <path d="M 283.000117 233.165504 
+L 273.393099 239.83989 
+L 289.392773 244.043638 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #fbf100"/>
+    <path d="M 294.908991 172.560125 
+L 289.498898 164.04912 
+L 297.767957 163.203726 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #960000"/>
+    <path d="M 284.088804 155.538114 
+L 289.498898 164.04912 
+L 292.357863 154.692721 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #9f0000"/>
+    <path d="M 300.626923 153.847327 
+L 297.767957 163.203726 
+L 292.357863 154.692721 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #960000"/>
+    <path d="M 289.498898 164.04912 
+L 297.767957 163.203726 
+L 292.357863 154.692721 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #9b0000"/>
+    <path d="M 263.735957 139.690605 
+L 266.774668 129.662972 
+L 272.769442 133.941267 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1a00"/>
+    <path d="M 269.813378 119.635339 
+L 266.774668 129.662972 
+L 275.808153 123.913634 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4a00"/>
+    <path d="M 281.802928 128.191929 
+L 272.769442 133.941267 
+L 275.808153 123.913634 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2d00"/>
+    <path d="M 266.774668 129.662972 
+L 272.769442 133.941267 
+L 275.808153 123.913634 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3000"/>
+    <path d="M 290.75748 139.764349 
+L 286.280204 133.978139 
+L 293.648241 132.571471 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #e80000"/>
+    <path d="M 281.802928 128.191929 
+L 286.280204 133.978139 
+L 289.170964 126.785261 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1e00"/>
+    <path d="M 296.539001 125.378593 
+L 293.648241 132.571471 
+L 289.170964 126.785261 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1e00"/>
+    <path d="M 286.280204 133.978139 
+L 293.648241 132.571471 
+L 289.170964 126.785261 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1300"/>
+    <path d="M 113.13242 167.275822 
+L 117.343399 176.4942 
+L 108.886409 174.282109 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4300"/>
+    <path d="M 121.554378 185.712578 
+L 117.343399 176.4942 
+L 113.097388 183.500487 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4a00"/>
+    <path d="M 104.640398 181.288396 
+L 108.886409 174.282109 
+L 113.097388 183.500487 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4700"/>
+    <path d="M 117.343399 176.4942 
+L 108.886409 174.282109 
+L 113.097388 183.500487 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4700"/>
+    <path d="M 130.611451 153.111981 
+L 143.415855 156.470434 
+L 138.727876 149.703564 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4700"/>
+    <path d="M 156.22026 159.828887 
+L 143.415855 156.470434 
+L 151.532281 153.062017 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3f00"/>
+    <path d="M 146.844301 146.295147 
+L 138.727876 149.703564 
+L 151.532281 153.062017 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4e00"/>
+    <path d="M 143.415855 156.470434 
+L 138.727876 149.703564 
+L 151.532281 153.062017 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4700"/>
+    <path d="M 201.319018 204.667744 
+L 190.246921 199.08983 
+L 191.429194 207.314131 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6000"/>
+    <path d="M 179.174824 193.511916 
+L 190.246921 199.08983 
+L 180.357097 201.736217 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5900"/>
+    <path d="M 181.53937 209.960518 
+L 191.429194 207.314131 
+L 180.357097 201.736217 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7700"/>
+    <path d="M 190.246921 199.08983 
+L 191.429194 207.314131 
+L 180.357097 201.736217 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6400"/>
+    <path d="M 105.779291 235.878849 
+L 115.699911 242.396324 
+L 104.90995 244.534324 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a4ff53"/>
+    <path d="M 125.620531 248.9138 
+L 115.699911 242.396324 
+L 114.83057 251.0518 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #7aff7d"/>
+    <path d="M 104.040609 253.1898 
+L 104.90995 244.534324 
+L 114.83057 251.0518 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #66ff90"/>
+    <path d="M 115.699911 242.396324 
+L 104.90995 244.534324 
+L 114.83057 251.0518 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #80ff77"/>
+    <path d="M 298.999791 237.369252 
+L 289.392773 244.043638 
+L 299.374413 245.926914 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #e7ff0f"/>
+    <path d="M 279.785755 250.718024 
+L 289.392773 244.043638 
+L 289.767395 252.6013 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #b1ff46"/>
+    <path d="M 299.749035 254.484576 
+L 299.374413 245.926914 
+L 289.767395 252.6013 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a4ff53"/>
+    <path d="M 289.392773 244.043638 
+L 299.374413 245.926914 
+L 289.767395 252.6013 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #c1ff36"/>
+    <path d="M 290.75748 139.764349 
+L 287.423142 147.651232 
+L 295.692201 146.805838 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #bf0000"/>
+    <path d="M 284.088804 155.538114 
+L 287.423142 147.651232 
+L 292.357863 154.692721 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a80000"/>
+    <path d="M 300.626923 153.847327 
+L 295.692201 146.805838 
+L 292.357863 154.692721 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a40000"/>
+    <path d="M 287.423142 147.651232 
+L 295.692201 146.805838 
+L 292.357863 154.692721 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ad0000"/>
+    <path d="M 287.330454 112.615603 
+L 278.571916 116.125471 
+L 284.566691 120.403766 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6f00"/>
+    <path d="M 269.813378 119.635339 
+L 278.571916 116.125471 
+L 275.808153 123.913634 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6000"/>
+    <path d="M 281.802928 128.191929 
+L 284.566691 120.403766 
+L 275.808153 123.913634 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4300"/>
+    <path d="M 278.571916 116.125471 
+L 284.566691 120.403766 
+L 275.808153 123.913634 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5900"/>
+    <path d="M 287.330454 112.615603 
+L 284.566691 120.403766 
+L 291.934727 118.997098 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6400"/>
+    <path d="M 281.802928 128.191929 
+L 284.566691 120.403766 
+L 289.170964 126.785261 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3800"/>
+    <path d="M 296.539001 125.378593 
+L 291.934727 118.997098 
+L 289.170964 126.785261 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3800"/>
+    <path d="M 284.566691 120.403766 
+L 291.934727 118.997098 
+L 289.170964 126.785261 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4700"/>
+    <path d="M 105.499696 199.627051 
+L 113.527037 192.669814 
+L 105.070047 190.457724 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6800"/>
+    <path d="M 121.554378 185.712578 
+L 113.527037 192.669814 
+L 113.097388 183.500487 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5200"/>
+    <path d="M 104.640398 181.288396 
+L 105.070047 190.457724 
+L 113.097388 183.500487 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5200"/>
+    <path d="M 113.527037 192.669814 
+L 105.070047 190.457724 
+L 113.097388 183.500487 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5900"/>
+    <path d="M 163.851807 142.202238 
+L 160.036034 151.015562 
+L 155.348054 144.248693 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5200"/>
+    <path d="M 156.22026 159.828887 
+L 160.036034 151.015562 
+L 151.532281 153.062017 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3f00"/>
+    <path d="M 146.844301 146.295147 
+L 155.348054 144.248693 
+L 151.532281 153.062017 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4e00"/>
+    <path d="M 160.036034 151.015562 
+L 155.348054 144.248693 
+L 151.532281 153.062017 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4a00"/>
+    <path d="M 164.518254 204.793791 
+L 171.846539 199.152854 
+L 173.028812 207.377155 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7300"/>
+    <path d="M 179.174824 193.511916 
+L 171.846539 199.152854 
+L 180.357097 201.736217 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5d00"/>
+    <path d="M 181.53937 209.960518 
+L 173.028812 207.377155 
+L 180.357097 201.736217 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7a00"/>
+    <path d="M 171.846539 199.152854 
+L 173.028812 207.377155 
+L 180.357097 201.736217 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6f00"/>
+    <path d="M 113.560466 264.3168 
+L 119.590499 256.6153 
+L 108.800538 258.7533 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #19ffde"/>
+    <path d="M 125.620531 248.9138 
+L 119.590499 256.6153 
+L 114.83057 251.0518 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #56ffa0"/>
+    <path d="M 104.040609 253.1898 
+L 108.800538 258.7533 
+L 114.83057 251.0518 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #46ffb1"/>
+    <path d="M 119.590499 256.6153 
+L 108.800538 258.7533 
+L 114.83057 251.0518 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #3cffba"/>
+    <path d="M 290.196288 265.488012 
+L 284.991022 258.103018 
+L 294.972661 259.986294 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #46ffb1"/>
+    <path d="M 279.785755 250.718024 
+L 284.991022 258.103018 
+L 289.767395 252.6013 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #87ff70"/>
+    <path d="M 299.749035 254.484576 
+L 294.972661 259.986294 
+L 289.767395 252.6013 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #7dff7a"/>
+    <path d="M 284.991022 258.103018 
+L 294.972661 259.986294 
+L 289.767395 252.6013 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #6dff8a"/>
+    <path d="M 70.586182 174.528 
+L 81.880576 174.056117 
+L 79.893149 167.366309 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3f00"/>
+    <path d="M 93.17497 173.584234 
+L 81.880576 174.056117 
+L 91.187543 166.894426 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3f00"/>
+    <path d="M 89.200116 160.204618 
+L 79.893149 167.366309 
+L 91.187543 166.894426 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4300"/>
+    <path d="M 81.880576 174.056117 
+L 79.893149 167.366309 
+L 91.187543 166.894426 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3f00"/>
+    <path d="M 205.86375 143.34645 
+L 197.986301 138.310196 
+L 205.48475 136.267809 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4a00"/>
+    <path d="M 190.108852 133.273941 
+L 197.986301 138.310196 
+L 197.6073 131.231554 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6000"/>
+    <path d="M 205.105749 129.189167 
+L 205.48475 136.267809 
+L 197.6073 131.231554 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6400"/>
+    <path d="M 197.986301 138.310196 
+L 205.48475 136.267809 
+L 197.6073 131.231554 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5900"/>
+    <path d="M 135.259776 120.865083 
+L 128.92888 127.763475 
+L 135.91303 130.07622 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffa700"/>
+    <path d="M 122.597984 134.661867 
+L 128.92888 127.763475 
+L 129.582134 136.974612 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8600"/>
+    <path d="M 136.566283 139.287357 
+L 135.91303 130.07622 
+L 129.582134 136.974612 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7a00"/>
+    <path d="M 128.92888 127.763475 
+L 135.91303 130.07622 
+L 129.582134 136.974612 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8d00"/>
+    <path d="M 164.518254 204.793791 
+L 173.028812 207.377155 
+L 167.268644 211.436695 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8600"/>
+    <path d="M 181.53937 209.960518 
+L 173.028812 207.377155 
+L 175.779203 214.020059 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8d00"/>
+    <path d="M 170.019035 218.079599 
+L 167.268644 211.436695 
+L 175.779203 214.020059 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffa300"/>
+    <path d="M 173.028812 207.377155 
+L 167.268644 211.436695 
+L 175.779203 214.020059 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff9100"/>
+    <path d="M 330.309818 114.048 
+L 330.309818 106.488 
+L 323.115591 110.344406 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8200"/>
+    <path d="M 330.309818 98.928 
+L 330.309818 106.488 
+L 323.115591 102.784406 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffc400"/>
+    <path d="M 315.921364 106.640811 
+L 323.115591 110.344406 
+L 323.115591 102.784406 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffa300"/>
+    <path d="M 330.309818 106.488 
+L 323.115591 110.344406 
+L 323.115591 102.784406 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffa300"/>
+    <path d="M 113.13242 167.275822 
+L 103.153695 170.430028 
+L 101.166268 163.74022 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3f00"/>
+    <path d="M 93.17497 173.584234 
+L 103.153695 170.430028 
+L 91.187543 166.894426 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3f00"/>
+    <path d="M 89.200116 160.204618 
+L 101.166268 163.74022 
+L 91.187543 166.894426 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4300"/>
+    <path d="M 103.153695 170.430028 
+L 101.166268 163.74022 
+L 91.187543 166.894426 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3f00"/>
+    <path d="M 186.700092 115.845387 
+L 188.404472 124.559664 
+L 195.902921 122.517277 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffab00"/>
+    <path d="M 190.108852 133.273941 
+L 188.404472 124.559664 
+L 197.6073 131.231554 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7a00"/>
+    <path d="M 205.105749 129.189167 
+L 195.902921 122.517277 
+L 197.6073 131.231554 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7e00"/>
+    <path d="M 188.404472 124.559664 
+L 195.902921 122.517277 
+L 197.6073 131.231554 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8900"/>
+    <path d="M 130.611451 153.111981 
+L 126.604717 143.886924 
+L 133.588867 146.199669 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5500"/>
+    <path d="M 122.597984 134.661867 
+L 126.604717 143.886924 
+L 129.582134 136.974612 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6f00"/>
+    <path d="M 136.566283 139.287357 
+L 133.588867 146.199669 
+L 129.582134 136.974612 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6800"/>
+    <path d="M 126.604717 143.886924 
+L 133.588867 146.199669 
+L 129.582134 136.974612 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6400"/>
+    <path d="M 186.023366 225.094146 
+L 183.781368 217.527332 
+L 178.0212 221.586873 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffc100"/>
+    <path d="M 181.53937 209.960518 
+L 183.781368 217.527332 
+L 175.779203 214.020059 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff9c00"/>
+    <path d="M 170.019035 218.079599 
+L 178.0212 221.586873 
+L 175.779203 214.020059 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffb200"/>
+    <path d="M 183.781368 217.527332 
+L 178.0212 221.586873 
+L 175.779203 214.020059 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffae00"/>
+    <path d="M 313.858381 95.963238 
+L 322.0841 97.445619 
+L 314.889873 101.302025 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f8f500"/>
+    <path d="M 330.309818 98.928 
+L 322.0841 97.445619 
+L 323.115591 102.784406 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffe200"/>
+    <path d="M 315.921364 106.640811 
+L 314.889873 101.302025 
+L 323.115591 102.784406 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffc100"/>
+    <path d="M 322.0841 97.445619 
+L 314.889873 101.302025 
+L 323.115591 102.784406 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffdb00"/>
+    <path d="M 113.13242 167.275822 
+L 107.856787 154.639784 
+L 101.166268 163.74022 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4300"/>
+    <path d="M 102.581153 142.003745 
+L 107.856787 154.639784 
+L 95.890634 151.104182 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5900"/>
+    <path d="M 89.200116 160.204618 
+L 101.166268 163.74022 
+L 95.890634 151.104182 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4700"/>
+    <path d="M 107.856787 154.639784 
+L 101.166268 163.74022 
+L 95.890634 151.104182 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4a00"/>
+    <path d="M 186.700092 115.845387 
+L 201.769105 114.087481 
+L 195.902921 122.517277 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffb900"/>
+    <path d="M 216.838119 112.329574 
+L 201.769105 114.087481 
+L 210.971934 120.759371 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffb900"/>
+    <path d="M 205.105749 129.189167 
+L 195.902921 122.517277 
+L 210.971934 120.759371 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8d00"/>
+    <path d="M 201.769105 114.087481 
+L 195.902921 122.517277 
+L 210.971934 120.759371 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffab00"/>
+    <path d="M 102.581153 142.003745 
+L 116.596302 147.557863 
+L 112.589569 138.332806 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6400"/>
+    <path d="M 130.611451 153.111981 
+L 116.596302 147.557863 
+L 126.604717 143.886924 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5500"/>
+    <path d="M 122.597984 134.661867 
+L 112.589569 138.332806 
+L 126.604717 143.886924 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6f00"/>
+    <path d="M 116.596302 147.557863 
+L 112.589569 138.332806 
+L 126.604717 143.886924 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6400"/>
+    <path d="M 201.319018 204.667744 
+L 193.671192 214.880945 
+L 191.429194 207.314131 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7a00"/>
+    <path d="M 186.023366 225.094146 
+L 193.671192 214.880945 
+L 183.781368 217.527332 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffb200"/>
+    <path d="M 181.53937 209.960518 
+L 191.429194 207.314131 
+L 183.781368 217.527332 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8d00"/>
+    <path d="M 193.671192 214.880945 
+L 191.429194 207.314131 
+L 183.781368 217.527332 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff9400"/>
+    <path d="M 330.309818 83.808 
+L 322.0841 89.885619 
+L 330.309818 91.368 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #9aff5d"/>
+    <path d="M 313.858381 95.963238 
+L 322.0841 89.885619 
+L 322.0841 97.445619 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d4ff23"/>
+    <path d="M 330.309818 98.928 
+L 330.309818 91.368 
+L 322.0841 97.445619 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #e4ff13"/>
+    <path d="M 322.0841 89.885619 
+L 330.309818 91.368 
+L 322.0841 97.445619 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #c7ff30"/>
+    <path d="M 261.206458 168.893794 
+L 262.471208 154.2922 
+L 272.647631 162.215954 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #bb0000"/>
+    <path d="M 263.735957 139.690605 
+L 262.471208 154.2922 
+L 273.91238 147.61436 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d60000"/>
+    <path d="M 284.088804 155.538114 
+L 272.647631 162.215954 
+L 273.91238 147.61436 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #b20000"/>
+    <path d="M 262.471208 154.2922 
+L 272.647631 162.215954 
+L 273.91238 147.61436 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #c40000"/>
+    <path d="M 330.309818 174.528 
+L 312.609405 173.544062 
+L 322.168723 166.30702 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #800000"/>
+    <path d="M 294.908991 172.560125 
+L 312.609405 173.544062 
+L 304.468309 165.323082 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #890000"/>
+    <path d="M 314.027627 158.08604 
+L 322.168723 166.30702 
+L 304.468309 165.323082 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #840000"/>
+    <path d="M 312.609405 173.544062 
+L 322.168723 166.30702 
+L 304.468309 165.323082 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #840000"/>
+    <path d="M 205.86375 143.34645 
+L 217.232723 140.148205 
+L 205.48475 136.267809 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3f00"/>
+    <path d="M 228.601695 136.949959 
+L 217.232723 140.148205 
+L 216.853722 133.069563 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff3f00"/>
+    <path d="M 205.105749 129.189167 
+L 205.48475 136.267809 
+L 216.853722 133.069563 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5d00"/>
+    <path d="M 217.232723 140.148205 
+L 205.48475 136.267809 
+L 216.853722 133.069563 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4a00"/>
+    <path d="M 70.586182 235.008 
+L 70.586182 250.128 
+L 79.556777 242.86977 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #97ff60"/>
+    <path d="M 70.586182 265.248 
+L 70.586182 250.128 
+L 79.556777 257.98977 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #26ffd1"/>
+    <path d="M 88.527371 250.73154 
+L 79.556777 242.86977 
+L 79.556777 257.98977 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #60ff97"/>
+    <path d="M 70.586182 250.128 
+L 79.556777 242.86977 
+L 79.556777 257.98977 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #60ff97"/>
+    <path d="M 209.018025 229.970423 
+L 208.802201 239.604306 
+L 200.158364 236.43746 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #e1ff16"/>
+    <path d="M 208.586377 249.238188 
+L 208.802201 239.604306 
+L 199.94254 246.071343 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a0ff56"/>
+    <path d="M 191.298703 242.904497 
+L 200.158364 236.43746 
+L 199.94254 246.071343 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #b4ff43"/>
+    <path d="M 208.802201 239.604306 
+L 200.158364 236.43746 
+L 199.94254 246.071343 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #baff3c"/>
+    <path d="M 330.309818 235.008 
+L 330.309818 250.128 
+L 322.153323 243.263266 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #eeff09"/>
+    <path d="M 330.309818 265.248 
+L 330.309818 250.128 
+L 322.153323 258.383266 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #6dff8a"/>
+    <path d="M 313.996828 251.518533 
+L 322.153323 243.263266 
+L 322.153323 258.383266 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #aaff4d"/>
+    <path d="M 330.309818 250.128 
+L 322.153323 243.263266 
+L 322.153323 258.383266 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #adff49"/>
+    <path d="M 267.000443 228.961756 
+L 250.87935 235.691323 
+L 262.457973 239.2232 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffde00"/>
+    <path d="M 234.758257 242.420891 
+L 250.87935 235.691323 
+L 246.336881 245.952768 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d4ff23"/>
+    <path d="M 257.915504 249.484645 
+L 262.457973 239.2232 
+L 246.336881 245.952768 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #beff39"/>
+    <path d="M 250.87935 235.691323 
+L 262.457973 239.2232 
+L 246.336881 245.952768 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #deff19"/>
+    <path d="M 208.586377 249.238188 
+L 221.672317 245.82954 
+L 215.077836 255.236602 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #80ff77"/>
+    <path d="M 234.758257 242.420891 
+L 221.672317 245.82954 
+L 228.163776 251.827954 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a0ff56"/>
+    <path d="M 221.569294 261.235016 
+L 215.077836 255.236602 
+L 228.163776 251.827954 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #50ffa7"/>
+    <path d="M 221.672317 245.82954 
+L 215.077836 255.236602 
+L 228.163776 251.827954 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #7aff7d"/>
+    <path d="M 70.586182 174.528 
+L 70.586182 159.408 
+L 79.893149 167.366309 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4300"/>
+    <path d="M 70.586182 144.288 
+L 70.586182 159.408 
+L 79.893149 152.246309 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5200"/>
+    <path d="M 89.200116 160.204618 
+L 79.893149 167.366309 
+L 79.893149 152.246309 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4700"/>
+    <path d="M 70.586182 159.408 
+L 79.893149 167.366309 
+L 79.893149 152.246309 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4700"/>
+    <path d="M 70.586182 174.528 
+L 70.586182 189.648 
+L 80.036872 180.023431 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4a00"/>
+    <path d="M 70.586182 204.768 
+L 70.586182 189.648 
+L 80.036872 195.143431 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6f00"/>
+    <path d="M 89.487562 185.518862 
+L 80.036872 180.023431 
+L 80.036872 195.143431 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5500"/>
+    <path d="M 70.586182 189.648 
+L 80.036872 180.023431 
+L 80.036872 195.143431 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5900"/>
+    <path d="M 140.773746 177.431432 
+L 139.95449 190.168813 
+L 150.212485 184.312241 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4a00"/>
+    <path d="M 139.135233 202.906194 
+L 139.95449 190.168813 
+L 149.393228 197.049621 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6800"/>
+    <path d="M 159.651223 191.193049 
+L 150.212485 184.312241 
+L 149.393228 197.049621 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5200"/>
+    <path d="M 139.95449 190.168813 
+L 150.212485 184.312241 
+L 149.393228 197.049621 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5500"/>
+    <path d="M 135.339984 229.015738 
+L 137.237609 215.960966 
+L 145.610805 223.553073 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffdb00"/>
+    <path d="M 139.135233 202.906194 
+L 137.237609 215.960966 
+L 147.50843 210.498301 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff9800"/>
+    <path d="M 155.881626 218.090409 
+L 145.610805 223.553073 
+L 147.50843 210.498301 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffb900"/>
+    <path d="M 137.237609 215.960966 
+L 145.610805 223.553073 
+L 147.50843 210.498301 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffb900"/>
+    <path d="M 140.773746 177.431432 
+L 139.95449 190.168813 
+L 131.164062 181.572005 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4700"/>
+    <path d="M 139.135233 202.906194 
+L 139.95449 190.168813 
+L 130.344806 194.309386 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6800"/>
+    <path d="M 121.554378 185.712578 
+L 131.164062 181.572005 
+L 130.344806 194.309386 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5200"/>
+    <path d="M 139.95449 190.168813 
+L 131.164062 181.572005 
+L 130.344806 194.309386 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5500"/>
+    <path d="M 135.259776 120.865083 
+L 123.22815 118.810934 
+L 128.92888 127.763475 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffb600"/>
+    <path d="M 111.196524 116.756784 
+L 123.22815 118.810934 
+L 116.897254 125.709326 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffc100"/>
+    <path d="M 122.597984 134.661867 
+L 128.92888 127.763475 
+L 116.897254 125.709326 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff9800"/>
+    <path d="M 123.22815 118.810934 
+L 128.92888 127.763475 
+L 116.897254 125.709326 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffae00"/>
+    <path d="M 287.330454 112.615603 
+L 290.666884 105.321192 
+L 295.873751 109.37367 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff9f00"/>
+    <path d="M 294.003313 98.026781 
+L 290.666884 105.321192 
+L 299.210181 102.079259 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffde00"/>
+    <path d="M 304.417048 106.131737 
+L 295.873751 109.37367 
+L 299.210181 102.079259 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffb600"/>
+    <path d="M 290.666884 105.321192 
+L 295.873751 109.37367 
+L 299.210181 102.079259 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffb900"/>
+    <path d="M 248.022952 115.210555 
+L 259.523547 108.263121 
+L 258.918165 117.422947 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff9c00"/>
+    <path d="M 271.024142 101.315687 
+L 259.523547 108.263121 
+L 270.41876 110.475513 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffc800"/>
+    <path d="M 269.813378 119.635339 
+L 258.918165 117.422947 
+L 270.41876 110.475513 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8600"/>
+    <path d="M 259.523547 108.263121 
+L 258.918165 117.422947 
+L 270.41876 110.475513 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffa300"/>
+    <path d="M 200.296129 176.831059 
+L 208.108956 167.372165 
+L 197.831793 166.566122 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1a00"/>
+    <path d="M 215.921782 157.913271 
+L 208.108956 167.372165 
+L 205.644619 157.107228 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1300"/>
+    <path d="M 195.367456 156.301185 
+L 197.831793 166.566122 
+L 205.644619 157.107228 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1e00"/>
+    <path d="M 208.108956 167.372165 
+L 197.831793 166.566122 
+L 205.644619 157.107228 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1a00"/>
+    <path d="M 135.259776 120.865083 
+L 147.362972 121.466293 
+L 141.562668 127.867066 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffae00"/>
+    <path d="M 159.466167 122.067503 
+L 147.362972 121.466293 
+L 153.665863 128.468276 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffa700"/>
+    <path d="M 147.86556 134.869048 
+L 141.562668 127.867066 
+L 153.665863 128.468276 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8d00"/>
+    <path d="M 147.362972 121.466293 
+L 141.562668 127.867066 
+L 153.665863 128.468276 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff9f00"/>
+    <path d="M 186.700092 115.845387 
+L 173.08313 118.956445 
+L 181.548314 123.279899 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffb600"/>
+    <path d="M 159.466167 122.067503 
+L 173.08313 118.956445 
+L 167.931352 126.390957 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffab00"/>
+    <path d="M 176.396537 130.71441 
+L 181.548314 123.279899 
+L 167.931352 126.390957 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff9100"/>
+    <path d="M 173.08313 118.956445 
+L 181.548314 123.279899 
+L 167.931352 126.390957 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffa700"/>
+    <path d="M 263.735957 139.690605 
+L 277.246719 139.727477 
+L 273.91238 147.61436 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #da0000"/>
+    <path d="M 290.75748 139.764349 
+L 277.246719 139.727477 
+L 287.423142 147.651232 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #cd0000"/>
+    <path d="M 284.088804 155.538114 
+L 273.91238 147.61436 
+L 287.423142 147.651232 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #b60000"/>
+    <path d="M 277.246719 139.727477 
+L 273.91238 147.61436 
+L 287.423142 147.651232 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #cd0000"/>
+    <path d="M 330.309818 174.528 
+L 330.309818 159.408 
+L 322.168723 166.30702 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #800000"/>
+    <path d="M 330.309818 144.288 
+L 330.309818 159.408 
+L 322.168723 151.18702 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #960000"/>
+    <path d="M 314.027627 158.08604 
+L 322.168723 166.30702 
+L 322.168723 151.18702 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #890000"/>
+    <path d="M 330.309818 159.408 
+L 322.168723 166.30702 
+L 322.168723 151.18702 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #890000"/>
+    <path d="M 228.601695 136.949959 
+L 222.719907 124.639767 
+L 216.853722 133.069563 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5500"/>
+    <path d="M 216.838119 112.329574 
+L 222.719907 124.639767 
+L 210.971934 120.759371 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff9f00"/>
+    <path d="M 205.105749 129.189167 
+L 216.853722 133.069563 
+L 210.971934 120.759371 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7300"/>
+    <path d="M 222.719907 124.639767 
+L 216.853722 133.069563 
+L 210.971934 120.759371 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7a00"/>
+    <path d="M 70.586182 235.008 
+L 88.182737 235.443424 
+L 79.556777 242.86977 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #baff3c"/>
+    <path d="M 105.779291 235.878849 
+L 88.182737 235.443424 
+L 97.153331 243.305194 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #b4ff43"/>
+    <path d="M 88.527371 250.73154 
+L 79.556777 242.86977 
+L 97.153331 243.305194 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #83ff73"/>
+    <path d="M 88.182737 235.443424 
+L 79.556777 242.86977 
+L 97.153331 243.305194 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a7ff50"/>
+    <path d="M 209.018025 229.970423 
+L 197.520695 227.532285 
+L 200.158364 236.43746 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #fbf100"/>
+    <path d="M 186.023366 225.094146 
+L 197.520695 227.532285 
+L 188.661034 233.999322 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffea00"/>
+    <path d="M 191.298703 242.904497 
+L 200.158364 236.43746 
+L 188.661034 233.999322 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #caff2c"/>
+    <path d="M 197.520695 227.532285 
+L 200.158364 236.43746 
+L 188.661034 233.999322 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ebff0c"/>
+    <path d="M 330.309818 235.008 
+L 314.654804 236.188626 
+L 322.153323 243.263266 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffd300"/>
+    <path d="M 298.999791 237.369252 
+L 314.654804 236.188626 
+L 306.498309 244.443892 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffe600"/>
+    <path d="M 313.996828 251.518533 
+L 322.153323 243.263266 
+L 306.498309 244.443892 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #d1ff26"/>
+    <path d="M 314.654804 236.188626 
+L 322.153323 243.263266 
+L 306.498309 244.443892 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f8f500"/>
+    <path d="M 242.68407 261.001402 
+L 238.721163 251.711146 
+L 250.299787 255.243023 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #5dff9a"/>
+    <path d="M 234.758257 242.420891 
+L 238.721163 251.711146 
+L 246.336881 245.952768 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #a7ff50"/>
+    <path d="M 257.915504 249.484645 
+L 250.299787 255.243023 
+L 246.336881 245.952768 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #94ff63"/>
+    <path d="M 238.721163 251.711146 
+L 250.299787 255.243023 
+L 246.336881 245.952768 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #87ff70"/>
+    <path d="M 242.68407 261.001402 
+L 238.721163 251.711146 
+L 232.126682 261.118209 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #49ffad"/>
+    <path d="M 234.758257 242.420891 
+L 238.721163 251.711146 
+L 228.163776 251.827954 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #94ff63"/>
+    <path d="M 221.569294 261.235016 
+L 232.126682 261.118209 
+L 228.163776 251.827954 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #43ffb4"/>
+    <path d="M 238.721163 251.711146 
+L 232.126682 261.118209 
+L 228.163776 251.827954 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #60ff97"/>
+    <path d="M 102.581153 142.003745 
+L 86.583667 143.145873 
+L 95.890634 151.104182 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5d00"/>
+    <path d="M 70.586182 144.288 
+L 86.583667 143.145873 
+L 79.893149 152.246309 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5900"/>
+    <path d="M 89.200116 160.204618 
+L 95.890634 151.104182 
+L 79.893149 152.246309 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff4e00"/>
+    <path d="M 86.583667 143.145873 
+L 95.890634 151.104182 
+L 79.893149 152.246309 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5500"/>
+    <path d="M 105.499696 199.627051 
+L 88.042939 202.197526 
+L 97.493629 192.572956 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6f00"/>
+    <path d="M 70.586182 204.768 
+L 88.042939 202.197526 
+L 80.036872 195.143431 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7700"/>
+    <path d="M 89.487562 185.518862 
+L 97.493629 192.572956 
+L 80.036872 195.143431 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5d00"/>
+    <path d="M 88.042939 202.197526 
+L 97.493629 192.572956 
+L 80.036872 195.143431 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6c00"/>
+    <path d="M 164.518254 204.793791 
+L 151.826744 203.849992 
+L 162.084739 197.99342 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7300"/>
+    <path d="M 139.135233 202.906194 
+L 151.826744 203.849992 
+L 149.393228 197.049621 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7300"/>
+    <path d="M 159.651223 191.193049 
+L 162.084739 197.99342 
+L 149.393228 197.049621 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5d00"/>
+    <path d="M 151.826744 203.849992 
+L 162.084739 197.99342 
+L 149.393228 197.049621 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6c00"/>
+    <path d="M 164.518254 204.793791 
+L 151.826744 203.849992 
+L 160.19994 211.4421 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8600"/>
+    <path d="M 139.135233 202.906194 
+L 151.826744 203.849992 
+L 147.50843 210.498301 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8200"/>
+    <path d="M 155.881626 218.090409 
+L 160.19994 211.4421 
+L 147.50843 210.498301 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffa300"/>
+    <path d="M 151.826744 203.849992 
+L 160.19994 211.4421 
+L 147.50843 210.498301 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8d00"/>
+    <path d="M 105.499696 199.627051 
+L 122.317465 201.266622 
+L 113.527037 192.669814 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6f00"/>
+    <path d="M 139.135233 202.906194 
+L 122.317465 201.266622 
+L 130.344806 194.309386 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6f00"/>
+    <path d="M 121.554378 185.712578 
+L 113.527037 192.669814 
+L 130.344806 194.309386 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff5900"/>
+    <path d="M 122.317465 201.266622 
+L 113.527037 192.669814 
+L 130.344806 194.309386 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6800"/>
+    <path d="M 102.581153 142.003745 
+L 106.888838 129.380265 
+L 112.589569 138.332806 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7a00"/>
+    <path d="M 111.196524 116.756784 
+L 106.888838 129.380265 
+L 116.897254 125.709326 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffb200"/>
+    <path d="M 122.597984 134.661867 
+L 112.589569 138.332806 
+L 116.897254 125.709326 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8900"/>
+    <path d="M 106.888838 129.380265 
+L 112.589569 138.332806 
+L 116.897254 125.709326 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff9100"/>
+    <path d="M 294.003313 98.026781 
+L 303.930847 96.99501 
+L 299.210181 102.079259 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f8f500"/>
+    <path d="M 313.858381 95.963238 
+L 303.930847 96.99501 
+L 309.137714 101.047488 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #f4f802"/>
+    <path d="M 304.417048 106.131737 
+L 299.210181 102.079259 
+L 309.137714 101.047488 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffcc00"/>
+    <path d="M 303.930847 96.99501 
+L 299.210181 102.079259 
+L 309.137714 101.047488 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffea00"/>
+    <path d="M 287.330454 112.615603 
+L 279.177298 106.965645 
+L 278.571916 116.125471 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff9100"/>
+    <path d="M 271.024142 101.315687 
+L 279.177298 106.965645 
+L 270.41876 110.475513 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ffc800"/>
+    <path d="M 269.813378 119.635339 
+L 278.571916 116.125471 
+L 270.41876 110.475513 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff8200"/>
+    <path d="M 279.177298 106.965645 
+L 278.571916 116.125471 
+L 270.41876 110.475513 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff9f00"/>
+    <path d="M 205.86375 143.34645 
+L 210.892766 150.629861 
+L 200.615603 149.823818 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2d00"/>
+    <path d="M 215.921782 157.913271 
+L 210.892766 150.629861 
+L 205.644619 157.107228 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff1600"/>
+    <path d="M 195.367456 156.301185 
+L 200.615603 149.823818 
+L 205.644619 157.107228 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2200"/>
+    <path d="M 210.892766 150.629861 
+L 200.615603 149.823818 
+L 205.644619 157.107228 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff2200"/>
+    <path d="M 163.851807 142.202238 
+L 161.658987 132.134871 
+L 155.858683 138.535643 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6800"/>
+    <path d="M 159.466167 122.067503 
+L 161.658987 132.134871 
+L 153.665863 128.468276 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff9400"/>
+    <path d="M 147.86556 134.869048 
+L 155.858683 138.535643 
+L 153.665863 128.468276 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7a00"/>
+    <path d="M 161.658987 132.134871 
+L 155.858683 138.535643 
+L 153.665863 128.468276 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7e00"/>
+    <path d="M 163.851807 142.202238 
+L 161.658987 132.134871 
+L 170.124172 136.458324 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff6c00"/>
+    <path d="M 159.466167 122.067503 
+L 161.658987 132.134871 
+L 167.931352 126.390957 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff9800"/>
+    <path d="M 176.396537 130.71441 
+L 170.124172 136.458324 
+L 167.931352 126.390957 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7e00"/>
+    <path d="M 161.658987 132.134871 
+L 170.124172 136.458324 
+L 167.931352 126.390957 
+z
+" clip-path="url(#pf8b6ae8f57)" style="fill: #ff7e00"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m18a2a0e31d" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m18a2a0e31d" x="70.586182" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0.0 -->
+      <g transform="translate(62.634619 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m18a2a0e31d" x="122.530909" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 0.2 -->
+      <g transform="translate(114.579347 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m18a2a0e31d" x="174.475636" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 0.4 -->
+      <g transform="translate(166.524074 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m18a2a0e31d" x="226.420364" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 0.6 -->
+      <g transform="translate(218.468801 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m18a2a0e31d" x="278.365091" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 0.8 -->
+      <g transform="translate(270.413528 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m18a2a0e31d" x="330.309818" y="307.584" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 1.0 -->
+      <g transform="translate(322.358256 322.182437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_7">
+     <!-- underlying -->
+     <g transform="translate(173.723781 335.860562) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-75"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(63.378906 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(126.757812 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(190.234375 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(251.757812 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(292.871094 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(320.654297 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(379.833984 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(407.617188 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(470.996094 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_7">
+      <defs>
+       <path id="m192603274b" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m192603274b" x="57.6" y="295.488" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0.0 -->
+      <g transform="translate(34.696875 299.287219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m192603274b" x="57.6" y="247.104" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 0.2 -->
+      <g transform="translate(34.696875 250.903219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m192603274b" x="57.6" y="198.72" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 0.4 -->
+      <g transform="translate(34.696875 202.519219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m192603274b" x="57.6" y="150.336" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 0.6 -->
+      <g transform="translate(34.696875 154.135219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m192603274b" x="57.6" y="101.952" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 0.8 -->
+      <g transform="translate(34.696875 105.751219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m192603274b" x="57.6" y="53.568" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 1.0 -->
+      <g transform="translate(34.696875 57.367219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_14">
+     <!-- variance -->
+     <g transform="translate(28.617187 196.054563) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-76"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(59.179688 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(120.458984 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(161.572266 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(189.355469 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(250.634766 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(314.013672 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(368.994141 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 57.6 307.584 
+L 57.6 41.472 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 343.296 307.584 
+L 343.296 41.472 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 57.6 307.584 
+L 343.296 307.584 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 57.6 41.472 
+L 343.296 41.472 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_15">
+    <!-- Adaptive solution -->
+    <g transform="translate(148.2255 35.472) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-41" d="M 2188 4044 
+L 1331 1722 
+L 3047 1722 
+L 2188 4044 
+z
+M 1831 4666 
+L 2547 4666 
+L 4325 0 
+L 3669 0 
+L 3244 1197 
+L 1141 1197 
+L 716 0 
+L 50 0 
+L 1831 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-41"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(66.658203 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(130.134766 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(191.414062 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(254.890625 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(294.099609 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(321.882812 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(381.0625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(442.585938 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(474.373047 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(526.472656 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(587.654297 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(615.4375 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(678.816406 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(718.025391 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(745.808594 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(806.990234 0)"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_7">
+    <path d="M 361.152 307.584 
+L 374.4576 307.584 
+L 374.4576 41.472 
+L 361.152 41.472 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFxCAYAAAB+2fgXAAABsElEQVR4nO2a263CQBQDT8jS9+2b1y3B+RhF1mpcgMV42CwIjpm/3wBZM4vomQfSMjNr5kkViZaLmFdEbiRaLupDK3tnb4xWqV+0XCRayMZobpTTh3bM/JDP2RiaRTlrDqroZIpANOaozYJOCIkGvSKt5WxsDRu7caM+/Vq7rWhja40btT3YvI5ytHalyAdbLvI6SmlE89DeVtSoX7QUH7U5fdYa9YuWi7yOUhqtcUXIbwfoRp+uIg7tcb6ZovVsQzspa1QRiUZZwzZ61G00FBpURKJR+gvRtJaKKGuVG22MVqZ/Y2vY2NxGHtorRVoLqbSm/lS0tX6thVRaU38q2lq/1kIqrak/FW2tX2shG1vze39OJZqHNmRjax7anEo0D20IaO1Dob2pQ/v5IkXgRgwZV8ShHYz9WdCZJf83QlkrRGuz5kY5vrNztHalyI1yEbRRI5rWUhrR3Oi2Iq+jHK1dKXKjXNSHprVc1IfWdkG6UU4jmtZSGtHc6LYir6McrV0oelEbQT8dgRu9qI0K0TBrTA+J1lbEoVFjcxttrF+0GNFy+p5HO28kWoxoOX1o/wruuU+DL8oYAAAAAElFTkSuQmCC" id="imagec0102b7e8d" transform="scale(1 -1) translate(0 -265.68)" x="361.44" y="-41.76" width="12.96" height="265.68"/>
+   <g id="matplotlib.axis_3"/>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_7">
+     <g id="line2d_13">
+      <defs>
+       <path id="m44176760bc" d="M 0 0 
+L 3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m44176760bc" x="374.4576" y="285.790696" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 0.02 -->
+      <g transform="translate(381.4576 289.589915) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m44176760bc" x="374.4576" y="255.25233" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 0.04 -->
+      <g transform="translate(381.4576 259.051549) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m44176760bc" x="374.4576" y="224.713964" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 0.06 -->
+      <g transform="translate(381.4576 228.513183) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m44176760bc" x="374.4576" y="194.175598" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- 0.08 -->
+      <g transform="translate(381.4576 197.974816) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m44176760bc" x="374.4576" y="163.637232" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- 0.10 -->
+      <g transform="translate(381.4576 167.43645) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m44176760bc" x="374.4576" y="133.098865" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 0.12 -->
+      <g transform="translate(381.4576 136.898084) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#m44176760bc" x="374.4576" y="102.560499" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 0.14 -->
+      <g transform="translate(381.4576 106.359718) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m44176760bc" x="374.4576" y="72.022133" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 0.16 -->
+      <g transform="translate(381.4576 75.821352) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#m44176760bc" x="374.4576" y="41.483767" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_24">
+      <!-- 0.18 -->
+      <g transform="translate(381.4576 45.282986) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-38" transform="translate(159.033203 0)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="LineCollection_1"/>
+   <g id="patch_8">
+    <path d="M 361.152 307.584 
+L 367.8048 307.584 
+L 374.4576 307.584 
+L 374.4576 41.472 
+L 367.8048 41.472 
+L 361.152 41.472 
+L 361.152 307.584 
+z
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pf8b6ae8f57">
+   <rect x="57.6" y="41.472" width="285.696" height="266.112"/>
+  </clipPath>
+ </defs>
+</svg>


### PR DESCRIPTION
## Summary
- add quickstart example to README
- show adaptive mesh output using lightweight SVG to avoid binary files

## Testing
- no tests run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68a142b6bdf08326b022287f13488f25