### PR TITLE
docs: add basic usage example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@
   dimension handling.
 - Introduced an experimental `FenicsSolver` using FEniCSx/UFL with optional
   dependency and benchmarking scaffolding against scikit-fem.
+- Added a basic usage example script and documentation for running it.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ PY
 The snippet solves a one-dimensional Black–Scholes problem using default
 parameters and prints the final price grid.
 
+Alternatively, run the bundled example script:
+
+```bash
+python examples/basic_usage.py
+```
+
+This reproduces the same call option pricing workflow in a standalone file.
+
 ## Features
 
 - Black-Scholes option pricer with call and put payoffs

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -1,0 +1,13 @@
+"""Basic usage examples for the finite_element_options package."""
+
+from src.examples.bs_1d import price_call
+
+
+def main() -> None:
+    """Run a simple Black–Scholes call option pricing example."""
+    grid = price_call()
+    print(grid[-1])  # option values at maturity
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add simple script demonstrating Black–Scholes call pricing
- document example in README and changelog

## Testing
- `pydocstyle` *(fails: Missing docstring in public module CONFIG.py; Missing docstring in public function b_lin in demo_adaptive.py; Missing docstring in public function a_bil in demo_adaptive.py; Missing docstring in public module main.py; Missing docstring in public module setup.py)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a146a665588326b4cd372c8f3cc978