### PR TITLE
feat: conform dynamics models to protocol

### DIFF
--- a/src/core/dynamics_black_scholes.py
+++ b/src/core/dynamics_black_scholes.py
@@ -1,9 +1,18 @@
 """Black-Scholes dynamics in 1D."""
 
 import pydantic as pyd
+import skfem as fem
+
+from .interfaces import DynamicsModel, Payoff
 
 
-class DynamicsParametersBlackScholes(pyd.BaseModel):
+class _ModelDynamicsMeta(type(pyd.BaseModel), type(DynamicsModel)):
+    """Metaclass combining ``BaseModel`` and ``DynamicsModel`` protocols."""
+
+
+class DynamicsParametersBlackScholes(
+    pyd.BaseModel, DynamicsModel, metaclass=_ModelDynamicsMeta
+):
     """Parameters for the one-dimensional Black-Scholes model."""
 
     r: float
@@ -25,3 +34,12 @@ class DynamicsParametersBlackScholes(pyd.BaseModel):
     def b(self, s):
         """Drift vector in the Feynman–Kac formulation."""
         return [(self.r - self.q) * s]
+
+    def boundary_term(self, is_call: bool, payoff: Payoff) -> fem.LinearForm:  # pylint: disable=unused-argument
+        """Return the natural boundary contribution, which is zero."""
+
+        @fem.LinearForm
+        def zero(_v, _w):  # pylint: disable=unused-argument
+            return 0.0
+
+        return zero


### PR DESCRIPTION
## Summary
- make Black-Scholes, Heston, and 3D Heston parameter classes implement `DynamicsModel`
- expose zero-valued `boundary_term` stubs to satisfy protocol
- combine metaclasses so Pydantic models conform structurally

## Testing
- `pydocstyle src/core/dynamics_black_scholes.py src/core/dynamics_heston.py src/core/dynamics_heston_3d.py`
- `mypy src` *(fails: Found 76 errors in 24 files)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a269b8b58883268b3337f4719c5ae5