### PR TITLE
refactor(space): centralise payoff projection

### DIFF
--- a/src/space/solver.py
+++ b/src/space/solver.py
@@ -67,21 +67,49 @@ class SpaceSolver:
             dynamics=dynamics,
             transform=self.transform,
         )
+        self._mean_variance_supports_config = (
+            "config" in dynamics.mean_variance.__code__.co_varnames
+        )
         self.mass = self.forms.id_bil().assemble(self.Vh)
         self.stiffness = self.forms.l_bil().assemble(self.Vh)
 
+    def _projected_payoff(
+        self, x: np.ndarray, *, th_phys: float | None = None
+    ) -> np.ndarray:
+        """Return projected payoff or boundary values for coordinates ``x``.
+
+        The helper performs :meth:`~src.transform.CoordinateTransform.untransform_state` once and reuses
+        the extracted variance inputs when computing mean-variance terms.
+        """
+
+        state = self.transform.untransform_state(x)
+        spot = state[0]
+        variance_inputs = state[1] if state.shape[0] > 1 else None
+
+        if self.is_call:
+            payoff_fn = self.payoff.call_payoff
+            price_fn = self.payoff.call
+        else:
+            payoff_fn = self.payoff.put_payoff
+            price_fn = self.payoff.put
+
+        if th_phys is None:
+            return payoff_fn(spot)
+
+        variance_seed = (
+            variance_inputs if variance_inputs is not None else np.zeros_like(spot)
+        )
+        kwargs = {"config": self.config} if self._mean_variance_supports_config else {}
+        mean_variance = self.dynamics.mean_variance(
+            th_phys,
+            variance_seed,
+            **kwargs,
+        )
+        return price_fn(th_phys, spot, mean_variance)
+
     def initial_condition(self) -> np.ndarray:
         """Initial spatial values from the payoff."""
-        return self.Vh.project(
-            lambda x: self.payoff.call_payoff(
-                self.transform.untransform_state(x)[0]
-            )
-            * self.is_call
-            + self.payoff.put_payoff(
-                self.transform.untransform_state(x)[0]
-            )
-            * (not self.is_call)
-        )
+        return self.Vh.project(lambda x: self._projected_payoff(x))
 
     def matrices(self, theta: float, dt: float):
         """Return the system matrices for the θ-scheme."""
@@ -98,29 +126,7 @@ class SpaceSolver:
         """Return Dirichlet values at time ``th``."""
         th_phys = self.transform.untransform_time(th)
 
-        return self.Vh.project(
-            lambda x: (
-                self.payoff.call(
-                    th_phys,
-                    self.transform.untransform_state(x)[0],
-                    self.dynamics.mean_variance(
-                        th_phys,
-                        self.transform.untransform_state(x)[1],
-                        config=self.config,
-                    ),
-                )
-                if self.is_call
-                else self.payoff.put(
-                    th_phys,
-                    self.transform.untransform_state(x)[0],
-                    self.dynamics.mean_variance(
-                        th_phys,
-                        self.transform.untransform_state(x)[1],
-                        config=self.config,
-                    ),
-                )
-            )
-        )
+        return self.Vh.project(lambda x: self._projected_payoff(x, th_phys=th_phys))
 
     def apply_dirichlet(self, A, b, dirichlet_bcs, u_dirichlet):
         """Apply Dirichlet boundary conditions to ``A`` and ``b``."""

--- a/tests/test_black_scholes_1d.py
+++ b/tests/test_black_scholes_1d.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 import numpy as np
 import pytest
 
@@ -33,3 +34,40 @@ def test_black_scholes_price():
     price_exact = bsopt.call(t[-1], s0, dh.sig ** 2)
 
     assert price_num == pytest.approx(price_exact, rel=1e-2)
+
+
+def test_black_scholes_initial_condition_matches_payoff():
+    dh = DynamicsParametersBlackScholes(r=0.03, q=0.0, sig=0.2)
+    mkt = Market(r=dh.r)
+    bsopt = EuropeanOptionBs(k=1.0, q=dh.q, mkt=mkt)
+    mesh, cfg = create_mesh([2.0], 2)
+    space = SpaceSolver(mesh, dh, bsopt, is_call=True, config=cfg)
+
+    initial = space.initial_condition()
+    expected = space.Vh.project(
+        lambda x: bsopt.call_payoff(space.transform.untransform_state(x)[0])
+    )
+    np.testing.assert_allclose(initial, expected)
+
+
+def test_black_scholes_dirichlet_matches_price():
+    dh = DynamicsParametersBlackScholes(r=0.03, q=0.0, sig=0.2)
+    mkt = Market(r=dh.r)
+    bsopt = EuropeanOptionBs(k=1.0, q=dh.q, mkt=mkt)
+    mesh, cfg = create_mesh([2.0], 2)
+    space = SpaceSolver(mesh, dh, bsopt, is_call=True, config=cfg)
+
+    th = 0.5
+    dirichlet_vals = space.dirichlet(th)
+    th_phys = space.transform.untransform_time(th)
+    expected = space.Vh.project(
+        lambda x: bsopt.call(
+            th_phys,
+            space.transform.untransform_state(x)[0],
+            dh.mean_variance(
+                th_phys,
+                np.zeros_like(space.transform.untransform_state(x)[0]),
+            ),
+        )
+    )
+    np.testing.assert_allclose(dirichlet_vals, expected)

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -1,6 +1,23 @@
+"""Regression tests for the spatial solver interfaces.
+
+```mermaid
+flowchart TD
+    X[Transformed coordinates] --> U[untransform_state]
+    U --> S[Spot grid]
+    U --> V[Variance seed]
+    S --> B{Call option?}
+    B -->|Yes| C[call/payoff branch]
+    B -->|No| P[put/payoff branch]
+    C --> R[Projected value]
+    P --> R
+```
+"""
+
 import os
 import sys
+
 import numpy as np
+import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
@@ -13,16 +30,56 @@ from src.space.boundary import DirichletBC  # noqa: E402
 from src.time.stepper import ThetaScheme  # noqa: E402
 
 
-def test_solver_runs():
+def _build_space_solver(is_call: bool):
     dh = DynamicsParametersHeston(
         r=0.03, q=0.03, kappa=0.5, theta=0.5, sig=0.2, rho=0.5
     )
-    mkt = Market(r=0.03)
+    mkt = Market(r=dh.r)
     bsopt = EuropeanOptionBs(k=0.4, q=dh.q, mkt=mkt)
-    t = np.linspace(0.0, 1.0, 3)
     mesh, cfg = create_mesh([1.0, 1.0], 1)
-    space = SpaceSolver(mesh, dh, bsopt, is_call=True, config=cfg)
+    space = SpaceSolver(mesh, dh, bsopt, is_call=is_call, config=cfg)
+    return space, dh, bsopt
+
+
+def test_solver_runs():
+    space, _, _ = _build_space_solver(is_call=True)
+    t = np.linspace(0.0, 1.0, 3)
     stepper = ThetaScheme(theta=0.5)
     bc = DirichletBC([])
     v_tsv = stepper.solve(t, space, boundary_condition=bc)
     assert v_tsv.shape[0] == 3
+
+
+@pytest.mark.parametrize(
+    ("is_call", "payoff_attr"),
+    [(True, "call_payoff"), (False, "put_payoff")],
+)
+def test_initial_condition_matches_intrinsic(is_call, payoff_attr):
+    space, _, payoff = _build_space_solver(is_call=is_call)
+    initial = space.initial_condition()
+    expected = space.Vh.project(
+        lambda x: getattr(payoff, payoff_attr)(
+            space.transform.untransform_state(x)[0]
+        )
+    )
+    np.testing.assert_allclose(initial, expected)
+
+
+@pytest.mark.parametrize(("is_call", "price_attr"), [(True, "call"), (False, "put")])
+def test_dirichlet_matches_model_prices(is_call, price_attr):
+    space, dynamics, payoff = _build_space_solver(is_call=is_call)
+    th = 0.25
+    values = space.dirichlet(th)
+    th_phys = space.transform.untransform_time(th)
+    supports_config = "config" in dynamics.mean_variance.__code__.co_varnames
+
+    def _expected(x):
+        state = space.transform.untransform_state(x)
+        spots = state[0]
+        variance_seed = state[1] if state.shape[0] > 1 else np.zeros_like(spots)
+        kwargs = {"config": space.config} if supports_config else {}
+        mean_var = dynamics.mean_variance(th_phys, variance_seed, **kwargs)
+        return getattr(payoff, price_attr)(th_phys, spots, mean_var)
+
+    expected = space.Vh.project(_expected)
+    np.testing.assert_allclose(values, expected)


### PR DESCRIPTION
## Summary
- add a `_projected_payoff` helper to SpaceSolver so the payoff projection logic only untransforms states once and reuses variance inputs
- reuse the helper from `initial_condition` and `dirichlet`, including optional config handling for mean-variance calls
- extend solver regression tests with call/put coverage, mermaid planning notes, and matching checks for the 1D Black-Scholes solver

## Testing
- pytest tests/test_solver.py tests/test_black_scholes_1d.py

------
https://chatgpt.com/codex/tasks/task_e_68cb28808f2883268301ad9524034014