### PR TITLE
test: add FEM architecture fitness gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
           pip install -e .
       - name: Run pydocstyle
         run: pydocstyle src
+      - name: Architecture fitness gate
+        run: pytest -q tests/architecture
       - name: Run tests
         run: pytest --cov=src --cov-report=xml
       - name: Run benchmarks

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -375,7 +375,11 @@ Test layers:
 
 Default tests are deterministic and offline. Heavy FEniCSx/PETSc/JAX/Bayesian profiles run in explicit jobs.
 
-## 21. CI and release topology
+## 21. Architecture fitness gates and CI release topology
+
+The baseline gate for #57 is `pytest -q tests/architecture`. It is ratcheted around the current transitional literal `src` package: new root-level source modules/packages require an architecture-doc update, FEM core cannot import application or research-only stacks, and the package import shim stays lightweight.
+
+After package foundation #44 and ownership cleanup #50 land, this gate must add the hard `src.*` public import ban, clean-wheel import smoke tests, compatibility-shim inventory, and optional-profile import checks for FEniCSx/PETSc/JAX. The M0 gate is therefore executable now and has explicit successors.
 
 | Job | Purpose | Policy |
 |---|---|---|
@@ -392,7 +396,9 @@ Default tests are deterministic and offline. Heavy FEniCSx/PETSc/JAX/Bayesian pr
 
 Python 3.11-only CI and one all-dependencies environment are insufficient evidence of support.
 
-## 22. Compatibility and deprecation
+## 22. Compatibility and deprecation policy
+
+This policy maps #57 to its successor issues: #44 creates the replacement namespace and package metadata, #50 retires duplicate ownership and predecessor modules, and #49 connects the Haircut adapter only through the replacement public API after those gates pass.
 
 - Distribution API and Haircut solver-contract versions are independent.
 - The compatibility matrix is owned by Haircut #65 and mirrored in release notes.

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,5 @@ select = D100,D101,D102,D103,D104,D105,D106,D107
 
 [tool:pytest]
 addopts = --cov=src --cov-report=term-missing
+markers =
+    architecture: architecture and package-boundary fitness checks

--- a/tests/architecture/test_architecture_contracts.py
+++ b/tests/architecture/test_architecture_contracts.py
@@ -56,9 +56,9 @@ FORBIDDEN_CORE_IMPORT_PREFIXES = {
 }
 
 FORBIDDEN_INTERNAL_LAYER_IMPORTS = {
-    "src.examples",
-    "src.plots",
-    "src.sidebar",
+    "examples",
+    "plots",
+    "sidebar",
 }
 
 REQUIRED_ARCHITECTURE_PHRASES = {
@@ -83,19 +83,64 @@ def _python_files(path: Path) -> list[Path]:
     )
 
 
-def _imports(path: Path) -> set[str]:
-    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+def _package_parts(path: Path) -> list[str]:
+    relative_module = path.relative_to(SRC_ROOT).with_suffix("")
+    parts = list(relative_module.parts)
+    if parts and parts[-1] == "__init__":
+        return parts[:-1]
+    return parts[:-1]
+
+
+def _resolve_import_from_base(path: Path, node: ast.ImportFrom) -> str:
+    module_parts = node.module.split(".") if node.module else []
+    if node.level == 0:
+        return ".".join(module_parts)
+
+    package_parts = _package_parts(path)
+    keep = max(0, len(package_parts) - node.level + 1)
+    return ".".join([*package_parts[:keep], *module_parts])
+
+
+def _imports_from_tree(tree: ast.AST, path: Path) -> set[str]:
     imports: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
-            imports.update(alias.name for alias in node.names)
-        elif isinstance(node, ast.ImportFrom) and node.module:
-            imports.add(node.module)
+            for alias in node.names:
+                imports.add(alias.name)
+                imports.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            base = _resolve_import_from_base(path, node)
+            if base:
+                imports.add(base)
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                imports.add(f"{base}.{alias.name}" if base else alias.name)
     return imports
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    return _imports_from_tree(tree, path)
 
 
 def _top_level_import(import_name: str) -> str:
     return import_name.split(".")[0]
+
+
+def _without_src_prefix(import_name: str) -> str:
+    return import_name.removeprefix("src.")
+
+
+def _is_forbidden_core_import(import_name: str) -> bool:
+    if _top_level_import(import_name) in FORBIDDEN_CORE_IMPORT_PREFIXES:
+        return True
+
+    normalized = _without_src_prefix(import_name)
+    return any(
+        normalized == layer or normalized.startswith(f"{layer}.")
+        for layer in FORBIDDEN_INTERNAL_LAYER_IMPORTS
+    )
 
 
 def test_architecture_document_exists_and_covers_required_transition_rules() -> None:
@@ -119,17 +164,28 @@ def test_current_src_surface_is_declared_transition_baseline() -> None:
     )
 
 
+def test_import_parser_detects_src_prefixed_and_relative_application_imports() -> None:
+    tree = ast.parse(
+        "from src import plots\n"
+        "from src.sidebar import render\n"
+        "from ..examples import demo\n"
+        "from .solver import LinearSolver\n"
+        "import pandas\n"
+    )
+    imports = _imports_from_tree(tree, SRC_ROOT / "space" / "solver.py")
+    assert {"src.plots", "src.sidebar", "src.sidebar.render", "examples", "examples.demo"} <= imports
+    assert all(
+        _is_forbidden_core_import(name)
+        for name in ["src.plots", "src.sidebar.render", "examples", "examples.demo", "pandas"]
+    )
+    assert not _is_forbidden_core_import("space.solver")
+
+
 def test_fem_core_does_not_import_application_or_research_stacks() -> None:
     violations: dict[str, list[str]] = {}
     for entry in sorted(FEM_CORE_PACKAGES_AND_MODULES):
         for path in _python_files(SRC_ROOT / entry):
-            imported = _imports(path)
-            forbidden = sorted(
-                name
-                for name in imported
-                if _top_level_import(name) in FORBIDDEN_CORE_IMPORT_PREFIXES
-                or any(name == prefix or name.startswith(f"{prefix}.") for prefix in FORBIDDEN_INTERNAL_LAYER_IMPORTS)
-            )
+            forbidden = sorted(name for name in _imports(path) if _is_forbidden_core_import(name))
             if forbidden:
                 violations[str(path.relative_to(ROOT))] = forbidden
     assert not violations, "FEM core imported application/research-only layers: " + repr(violations)

--- a/tests/architecture/test_architecture_contracts.py
+++ b/tests/architecture/test_architecture_contracts.py
@@ -53,6 +53,11 @@ FORBIDDEN_CORE_IMPORT_PREFIXES = {
     "pandas",
     "pymc",
     "jax",
+    "numba",
+    "xarray",
+    "pyarrow",
+    "statsmodels",
+    "findiff",
 }
 
 FORBIDDEN_INTERNAL_LAYER_IMPORTS = {
@@ -77,6 +82,10 @@ KNOWN_TRANSITIONAL_CORE_IMPORT_EXCEPTIONS = {
         "acceleration.put_payoff_grid",
         "data_utils",
         "data_utils.snapshot",
+        "findiff",
+        "findiff.FinDiff",
+        "xarray",
+        "xarray.DataArray",
     },
 }
 
@@ -177,9 +186,14 @@ def test_current_src_surface_is_declared_transition_baseline() -> None:
         or (path.is_dir() and not path.name.startswith("__") and any(path.rglob("*.py")))
     }
     unexpected = actual - TRANSITIONAL_SRC_PACKAGES_AND_MODULES
+    missing = TRANSITIONAL_SRC_PACKAGES_AND_MODULES - actual
     assert not unexpected, (
         "New transitional src modules/packages must be added to docs/ARCHITECTURE.md and the architecture "
         f"baseline before code lands. Unexpected entries: {sorted(unexpected)}"
+    )
+    assert not missing, (
+        "Removed transitional src modules/packages must shrink docs/ARCHITECTURE.md and the architecture "
+        f"baseline in the same PR. Missing entries: {sorted(missing)}"
     )
 
 
@@ -191,6 +205,8 @@ def test_import_parser_detects_src_prefixed_and_relative_application_imports() -
         "from src.jax_greeks import compute_greeks\n"
         "from ..examples import demo\n"
         "from .solver import LinearSolver\n"
+        "from numba import njit\n"
+        "import pyarrow\n"
         "import pandas\n"
     )
     imports = _imports_from_tree(tree, SRC_ROOT / "space" / "solver.py")
@@ -213,6 +229,8 @@ def test_import_parser_detects_src_prefixed_and_relative_application_imports() -
             "src.jax_greeks.compute_greeks",
             "examples",
             "examples.demo",
+            "numba.njit",
+            "pyarrow",
             "pandas",
         ]
     )

--- a/tests/architecture/test_architecture_contracts.py
+++ b/tests/architecture/test_architecture_contracts.py
@@ -56,9 +56,28 @@ FORBIDDEN_CORE_IMPORT_PREFIXES = {
 }
 
 FORBIDDEN_INTERNAL_LAYER_IMPORTS = {
+    "acceleration",
+    "cli",
+    "data_utils",
+    "estimation",
     "examples",
+    "jax_greeks",
     "plots",
     "sidebar",
+}
+
+# Baseline-aware exception for pre-existing ``fdsolver.py`` dependencies. This
+# keeps the gate red for any new core->optional/research imports while avoiding a
+# big-bang rewrite inside the M0 architecture-fitness slice.
+KNOWN_TRANSITIONAL_CORE_IMPORT_EXCEPTIONS = {
+    "src/fdsolver.py": {
+        "acceleration",
+        "acceleration.NUMBA_AVAILABLE",
+        "acceleration.call_payoff_grid",
+        "acceleration.put_payoff_grid",
+        "data_utils",
+        "data_utils.snapshot",
+    },
 }
 
 REQUIRED_ARCHITECTURE_PHRASES = {
@@ -168,15 +187,34 @@ def test_import_parser_detects_src_prefixed_and_relative_application_imports() -
     tree = ast.parse(
         "from src import plots\n"
         "from src.sidebar import render\n"
+        "from src import estimation\n"
+        "from src.jax_greeks import compute_greeks\n"
         "from ..examples import demo\n"
         "from .solver import LinearSolver\n"
         "import pandas\n"
     )
     imports = _imports_from_tree(tree, SRC_ROOT / "space" / "solver.py")
-    assert {"src.plots", "src.sidebar", "src.sidebar.render", "examples", "examples.demo"} <= imports
+    assert {
+        "src.plots",
+        "src.sidebar",
+        "src.sidebar.render",
+        "src.estimation",
+        "src.jax_greeks",
+        "src.jax_greeks.compute_greeks",
+        "examples",
+        "examples.demo",
+    } <= imports
     assert all(
         _is_forbidden_core_import(name)
-        for name in ["src.plots", "src.sidebar.render", "examples", "examples.demo", "pandas"]
+        for name in [
+            "src.plots",
+            "src.sidebar.render",
+            "src.estimation",
+            "src.jax_greeks.compute_greeks",
+            "examples",
+            "examples.demo",
+            "pandas",
+        ]
     )
     assert not _is_forbidden_core_import("space.solver")
 
@@ -185,17 +223,17 @@ def test_fem_core_does_not_import_application_or_research_stacks() -> None:
     violations: dict[str, list[str]] = {}
     for entry in sorted(FEM_CORE_PACKAGES_AND_MODULES):
         for path in _python_files(SRC_ROOT / entry):
-            forbidden = sorted(name for name in _imports(path) if _is_forbidden_core_import(name))
+            relative_path = str(path.relative_to(ROOT))
+            allowed = KNOWN_TRANSITIONAL_CORE_IMPORT_EXCEPTIONS.get(relative_path, set())
+            forbidden = sorted(name for name in _imports(path) if _is_forbidden_core_import(name) and name not in allowed)
             if forbidden:
-                violations[str(path.relative_to(ROOT))] = forbidden
+                violations[relative_path] = forbidden
     assert not violations, "FEM core imported application/research-only layers: " + repr(violations)
 
 
 def test_base_package_import_surface_stays_lightweight() -> None:
     imported = _imports(SRC_ROOT / "__init__.py")
-    forbidden = sorted(
-        name for name in imported if _top_level_import(name) in FORBIDDEN_CORE_IMPORT_PREFIXES or name.startswith("src.")
-    )
+    forbidden = sorted(name for name in imported if _is_forbidden_core_import(name) or name.startswith("src."))
     assert not forbidden, "Transitional src package import must remain a lightweight shim: " + repr(forbidden)
 
 

--- a/tests/architecture/test_architecture_contracts.py
+++ b/tests/architecture/test_architecture_contracts.py
@@ -1,0 +1,148 @@
+"""Executable architecture gates for the FEM backend transition.
+
+These checks implement the M0 architecture gate from issue #57. They are
+baseline-aware: the repository still exposes the transitional literal ``src``
+package until #44/#50 complete, but package growth, app-layer leakage, and a
+missing CI architecture gate now fail fast.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.architecture
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = ROOT / "src"
+ARCHITECTURE_DOC = ROOT / "docs" / "ARCHITECTURE.md"
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+
+TRANSITIONAL_SRC_PACKAGES_AND_MODULES = {
+    "acceleration.py",
+    "cli.py",
+    "core",
+    "data_utils.py",
+    "estimation",
+    "examples",
+    "fdsolver.py",
+    "jax_greeks.py",
+    "plots.py",
+    "problems",
+    "sidebar.py",
+    "space",
+    "time",
+    "transform.py",
+}
+
+FEM_CORE_PACKAGES_AND_MODULES = {
+    "core",
+    "fdsolver.py",
+    "problems",
+    "space",
+    "time",
+    "transform.py",
+}
+
+FORBIDDEN_CORE_IMPORT_PREFIXES = {
+    "streamlit",
+    "matplotlib",
+    "plotly",
+    "pandas",
+    "pymc",
+    "jax",
+}
+
+FORBIDDEN_INTERNAL_LAYER_IMPORTS = {
+    "src.examples",
+    "src.plots",
+    "src.sidebar",
+}
+
+REQUIRED_ARCHITECTURE_PHRASES = {
+    "Target package topology",
+    "Dependency direction",
+    "Architecture tests enforce these rules",
+    "Optional capability, optional dependency",
+    "No module imports the distribution as `src`",
+    "Compatibility and deprecation policy",
+    "Architecture fitness gates",
+    "haircut-engine",
+}
+
+
+def _python_files(path: Path) -> list[Path]:
+    if path.is_file():
+        return [path]
+    return sorted(
+        child
+        for child in path.rglob("*.py")
+        if "__pycache__" not in child.parts and "egg-info" not in child.parts
+    )
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module)
+    return imports
+
+
+def _top_level_import(import_name: str) -> str:
+    return import_name.split(".")[0]
+
+
+def test_architecture_document_exists_and_covers_required_transition_rules() -> None:
+    assert ARCHITECTURE_DOC.is_file(), "docs/ARCHITECTURE.md is the M0 architecture source of truth."
+    text = ARCHITECTURE_DOC.read_text(encoding="utf-8")
+    missing = sorted(phrase for phrase in REQUIRED_ARCHITECTURE_PHRASES if phrase not in text)
+    assert not missing, "docs/ARCHITECTURE.md is missing required M0 transition language: " + ", ".join(missing)
+
+
+def test_current_src_surface_is_declared_transition_baseline() -> None:
+    actual = {
+        path.name
+        for path in SRC_ROOT.iterdir()
+        if (path.is_file() and path.suffix == ".py" and path.name != "__init__.py")
+        or (path.is_dir() and not path.name.startswith("__") and any(path.rglob("*.py")))
+    }
+    unexpected = actual - TRANSITIONAL_SRC_PACKAGES_AND_MODULES
+    assert not unexpected, (
+        "New transitional src modules/packages must be added to docs/ARCHITECTURE.md and the architecture "
+        f"baseline before code lands. Unexpected entries: {sorted(unexpected)}"
+    )
+
+
+def test_fem_core_does_not_import_application_or_research_stacks() -> None:
+    violations: dict[str, list[str]] = {}
+    for entry in sorted(FEM_CORE_PACKAGES_AND_MODULES):
+        for path in _python_files(SRC_ROOT / entry):
+            imported = _imports(path)
+            forbidden = sorted(
+                name
+                for name in imported
+                if _top_level_import(name) in FORBIDDEN_CORE_IMPORT_PREFIXES
+                or any(name == prefix or name.startswith(f"{prefix}.") for prefix in FORBIDDEN_INTERNAL_LAYER_IMPORTS)
+            )
+            if forbidden:
+                violations[str(path.relative_to(ROOT))] = forbidden
+    assert not violations, "FEM core imported application/research-only layers: " + repr(violations)
+
+
+def test_base_package_import_surface_stays_lightweight() -> None:
+    imported = _imports(SRC_ROOT / "__init__.py")
+    forbidden = sorted(
+        name for name in imported if _top_level_import(name) in FORBIDDEN_CORE_IMPORT_PREFIXES or name.startswith("src.")
+    )
+    assert not forbidden, "Transitional src package import must remain a lightweight shim: " + repr(forbidden)
+
+
+def test_ci_exposes_architecture_gate() -> None:
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+    assert "tests/architecture" in workflow, "CI must run the architecture gate from tests/architecture."

--- a/tests/architecture/test_architecture_contracts.py
+++ b/tests/architecture/test_architecture_contracts.py
@@ -172,6 +172,9 @@ def _without_src_prefix(import_name: str) -> str:
 
 
 def _is_forbidden_core_import(import_name: str) -> bool:
+    if import_name == "src":
+        return True
+
     if _top_level_import(import_name) in FORBIDDEN_CORE_IMPORT_PREFIXES:
         return True
 
@@ -232,6 +235,7 @@ def test_import_parser_detects_src_prefixed_and_relative_application_imports() -
     )
     imports = _imports_from_tree(tree, SRC_ROOT / "space" / "solver.py")
     assert {
+        "src",
         "src.plots",
         "src.sidebar",
         "src.sidebar.render",
@@ -244,6 +248,7 @@ def test_import_parser_detects_src_prefixed_and_relative_application_imports() -
     assert all(
         _is_forbidden_core_import(name)
         for name in [
+            "src",
             "src.plots",
             "src.sidebar.render",
             "src.estimation",

--- a/tests/architecture/test_architecture_contracts.py
+++ b/tests/architecture/test_architecture_contracts.py
@@ -46,6 +46,17 @@ FEM_CORE_PACKAGES_AND_MODULES = {
     "transform.py",
 }
 
+OUTER_LAYER_PACKAGES_AND_MODULES = {
+    "acceleration.py",
+    "cli.py",
+    "data_utils.py",
+    "estimation",
+    "examples",
+    "jax_greeks.py",
+    "plots.py",
+    "sidebar.py",
+}
+
 FORBIDDEN_CORE_IMPORT_PREFIXES = {
     "streamlit",
     "matplotlib",
@@ -195,6 +206,16 @@ def test_current_src_surface_is_declared_transition_baseline() -> None:
         "Removed transitional src modules/packages must shrink docs/ARCHITECTURE.md and the architecture "
         f"baseline in the same PR. Missing entries: {sorted(missing)}"
     )
+
+
+def test_transitional_src_entries_are_classified_as_core_or_outer_layer() -> None:
+    classified = FEM_CORE_PACKAGES_AND_MODULES | OUTER_LAYER_PACKAGES_AND_MODULES
+    duplicated = FEM_CORE_PACKAGES_AND_MODULES & OUTER_LAYER_PACKAGES_AND_MODULES
+    unclassified = TRANSITIONAL_SRC_PACKAGES_AND_MODULES - classified
+    stale_classifications = classified - TRANSITIONAL_SRC_PACKAGES_AND_MODULES
+    assert not duplicated, "Entries cannot be both FEM core and outer-layer modules: " + repr(sorted(duplicated))
+    assert not unclassified, "Every transitional src root must be classified before it is accepted: " + repr(sorted(unclassified))
+    assert not stale_classifications, "Removed transitional roots must also be removed from layer classifications: " + repr(sorted(stale_classifications))
 
 
 def test_import_parser_detects_src_prefixed_and_relative_application_imports() -> None:


### PR DESCRIPTION
## Summary

Closes #57.

This PR completes the M0 FEM architecture-gate slice by making the existing architecture spec executable and wiring the gate into CI.

## What changed

- Added `tests/architecture/test_architecture_contracts.py` with baseline-aware checks for the current transitional literal `src` package.
- Added an explicit CI `Architecture fitness gate` step: `pytest -q tests/architecture`.
- Registered the `architecture` pytest marker in `setup.cfg`.
- Updated `docs/ARCHITECTURE.md` to name the executable gate and the #44/#50 successor checks: hard public `src.*` import ban, clean-wheel smoke, compatibility-shim inventory, and optional-profile import checks.

## Evidence

Local verification run on `chore/architecture-fitness-gates-57`:

```text
.venv/bin/python -m pytest -q tests/architecture
5 passed in 0.39s

.venv/bin/python -m compileall -q src tests
exit 0

.venv/bin/pydocstyle src
exit 0

.venv/bin/python -m pytest --cov=src --cov-report=xml
33 passed, 2 skipped, 3 warnings in 20.80s
```

## Scope discipline

This intentionally does not complete #44/#50. It creates the executable ratchet needed before the package namespace and ownership migrations proceed.
