### PR TITLE
test: consume QuantProblemSpec fixture in FEM adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements.txt -c constraints.txt
           pip install -e .
       - name: Run pydocstyle
         run: pydocstyle src

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This reproduces the same call option pricing workflow in a standalone file.
 - Market data handled via pandas DataFrames and solution snapshots via xarray
 - CSV/Parquet serialisation utilities for reproducible experiments
 - Experimental FEniCSx solver for Black-Scholes PDE
+- Public-synthetic QuantProblemSpec FEM adapter manifest and `fem-bs-001` Black-Scholes parity fixture for cross-repo Haircut Engine compatibility checks
 
 ## Installation
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,3 @@
+# CI/test dependency constraints for known transitive compatibility gaps.
+# PyMC imports ArviZ during calibration tests; ArviZ 1.x currently lacks the concat API PyMC 5.26 uses.
+arviz>=0.23,<1

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -320,6 +320,8 @@ The adapter:
 
 The adapter cannot import Haircut domain/application, PDP, UI or calibration code. It advertises only capabilities backed by repository-local tests and shared parity #64.
 
+Issue #64 adds the transitional `src/contracts/backend_capabilities.py` and `src/validation/black_scholes_parity.py` modules as executable FEM adapter evidence. `FEMRouteRequest.from_quant_problem_spec` consumes the same public-synthetic vanilla-call JSON fixture validated by Haircut Engine and finite_difference_options, preserves schema version, measure, numeraire, units, valuation/vintage timing, time-domain or maturity information, boundary details, mesh/element policy, linear solver policy and requested outputs, and fails closed before mesh/weak-form allocation for unsupported dimensions, variational terms, boundaries, exercise styles, outputs or controls. The default manifest intentionally advertises only the validated one-dimensional uniform-line/Lagrange-P2/theta/SciPy-direct route; higher-dimensional, adaptive, American, jump and HJB/control capabilities remain unsupported until their own parity evidence lands. The `fem-bs-001` parity fixture solves the public-synthetic Black-Scholes call against the Haircut analytical oracle with named endpoint boundary enforcement, value/Delta/Gamma error evidence, deterministic mesh/time refinement evidence and no private data.
+
 ## 17. Ownership cleanup
 
 | Existing concern | Target treatment |

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -170,6 +170,8 @@ After package and typed-interface foundations are stable, publish an optional en
 
 Owner: #49.
 
+Issue #64 provides the first executable Project #5 compatibility slice before the full entry-point plugin: a public-synthetic QuantProblemSpec adapter manifest, fail-closed route diagnostics and the `fem-bs-001` Black-Scholes parity fixture. This slice is deliberately narrow and validates only the one-dimensional uniform-line/Lagrange-P2/theta/SciPy-direct route against the Haircut analytical oracle with named endpoint boundary enforcement and value/Delta/Gamma error evidence; unsupported dimensions, adaptive meshes, unvalidated elements, American exercise, jump terms and HJB/control terms fail before mesh or weak-form allocation.
+
 ### FR-FEM-012 — Module ownership and duplicate retirement
 
 The stable package owns FEM numerical mechanics. The embedded FD implementation, full application/product workflows, duplicate examples and heavy UI/calibration responsibilities must be classified as core, optional, example, compatibility, migrate or delete.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ jax
 aleatory
 statsmodels
 pymc
+# PyMC imports ArviZ during calibration tests; constrain the transitive dependency to a known concat-compatible range.
 arviz>=0.23,<1
 pandas
 xarray

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ jax
 aleatory
 statsmodels
 pymc
+arviz>=0.23,<1
 pandas
 xarray
 pyarrow

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,6 @@ jax
 aleatory
 statsmodels
 pymc
-# PyMC imports ArviZ during calibration tests; constrain the transitive dependency to a known concat-compatible range.
-arviz>=0.23,<1
 pandas
 xarray
 pyarrow

--- a/src/contracts/__init__.py
+++ b/src/contracts/__init__.py
@@ -1,0 +1,25 @@
+"""Finite-element backend contracts and diagnostics."""
+
+from .backend_capabilities import (
+    CapabilityStatus,
+    DEFAULT_FEM_CAPABILITY_MANIFEST,
+    FEMCapabilityManifest,
+    FEMRouteRequest,
+    UnsupportedReason,
+    UnsupportedRouteDiagnostic,
+    UnsupportedRouteError,
+    diagnose_unsupported_route,
+    ensure_route_supported,
+)
+
+__all__ = [
+    "CapabilityStatus",
+    "DEFAULT_FEM_CAPABILITY_MANIFEST",
+    "FEMCapabilityManifest",
+    "FEMRouteRequest",
+    "UnsupportedReason",
+    "UnsupportedRouteDiagnostic",
+    "UnsupportedRouteError",
+    "diagnose_unsupported_route",
+    "ensure_route_supported",
+]

--- a/src/contracts/backend_capabilities.py
+++ b/src/contracts/backend_capabilities.py
@@ -1,0 +1,434 @@
+"""Finite-element backend capability manifest and route diagnostics.
+
+This module is deliberately domain-neutral.  It maps the shared
+QuantProblemSpec vocabulary into a FEM adapter-screening envelope before any
+mesh, basis, weak-form, or linear-solver work is allocated.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class CapabilityStatus(str, Enum):
+    """Maturity of one advertised backend capability."""
+
+    PRODUCTION = "production"
+    VALIDATED = "validated"
+    EXPERIMENTAL = "experimental"
+    UNSUPPORTED = "unsupported"
+
+
+class UnsupportedReason(str, Enum):
+    """Stable diagnostic codes for unsupported FEM route requests."""
+
+    UNSUPPORTED_DIMENSION = "unsupported_dimension"
+    UNSUPPORTED_MESH = "unsupported_mesh_family"
+    UNSUPPORTED_ELEMENT = "unsupported_element_family"
+    UNSUPPORTED_TERM = "unsupported_pde_term"
+    UNSUPPORTED_BOUNDARY = "unsupported_boundary_condition"
+    UNSUPPORTED_EXERCISE = "unsupported_exercise_style"
+    UNSUPPORTED_OUTPUT = "unsupported_output"
+    UNSUPPORTED_STABILITY_CONTROL = "unsupported_stability_control"
+    UNSUPPORTED_LINEAR_SOLVER = "unsupported_linear_solver"
+    MISSING_CONVENTION = "missing_convention"
+
+
+@dataclass(frozen=True)
+class UnsupportedRouteDiagnostic:
+    """Actionable reason why a FEM route request is unsupported."""
+
+    reason: UnsupportedReason
+    field: str
+    value: str
+    supported: tuple[str, ...]
+    message: str
+
+
+@dataclass(frozen=True)
+class FEMCapabilityManifest:
+    """Declarative finite-element backend support matrix.
+
+    The manifest intentionally advertises only the validated transitional route
+    used by the Project #5 QuantProblemSpec fixture: one-dimensional
+    Black-Scholes/GBM, uniform line mesh, Lagrange P2 elements, theta stepping,
+    and SciPy direct solves.  Higher-dimensional/adaptive/research capabilities
+    must land with their own evidence before being added here.
+    """
+
+    backend_id: str
+    contract_version: str
+    status: CapabilityStatus
+    supported_dimensions: tuple[int, ...]
+    mesh_families: tuple[str, ...]
+    element_families: tuple[str, ...]
+    pde_terms: tuple[str, ...]
+    boundary_conditions: tuple[str, ...]
+    exercise_styles: tuple[str, ...]
+    outputs: tuple[str, ...]
+    stability_controls: tuple[str, ...]
+    linear_solvers: tuple[str, ...]
+    required_conventions: tuple[str, ...]
+    diagnostics: tuple[str, ...]
+    notes: tuple[str, ...] = ()
+
+    def supports(self, request: FEMRouteRequest) -> bool:
+        """Return ``True`` only when no fail-closed diagnostics are produced."""
+
+        return not diagnose_unsupported_route(request, self)
+
+
+@dataclass(frozen=True)
+class FEMRouteRequest:
+    """FEM adapter request distilled from a QuantProblemSpec-like payload.
+
+    This is the capability-screening envelope, not the assembled weak form.  It
+    preserves conventions agents must not drop: measure, numeraire, units,
+    valuation/maturity timing, boundary classes, requested outputs, mesh/element
+    policy and solver controls.
+    """
+
+    dimension: int
+    mesh_family: str
+    element_family: str
+    pde_terms: tuple[str, ...]
+    boundary_conditions: tuple[str, ...]
+    exercise_style: str
+    requested_outputs: tuple[str, ...]
+    stability_controls: tuple[str, ...]
+    linear_solver: str
+    measure: str | None
+    numeraire: str | None
+    units: Mapping[str, str] = field(default_factory=dict)
+    boundary_details: Mapping[str, str] = field(default_factory=dict)
+    valuation_date: str | None = None
+    maturity_date: str | None = None
+    time_domain: str | None = None
+    source_schema_version: str | None = None
+
+    @classmethod
+    def from_quant_problem_spec(cls, payload: Mapping[str, Any]) -> FEMRouteRequest:
+        """Map a shared QuantProblemSpec-like mapping to a FEM route request."""
+
+        math = _mapping(payload.get("mathematical_problem"))
+        solver = _mapping(payload.get("solver_plan"))
+        context = _mapping(payload.get("valuation_context"))
+        conventions = _mapping(payload.get("conventions"))
+        vintage = _mapping(payload.get("vintage"))
+        domain = _mapping(math.get("domain"))
+        boundary_details = _mapping(math.get("boundary_conditions"))
+
+        dimension = int(
+            _first_present(
+                math,
+                ("dimension", "dimensions", "state_dimension"),
+                default=_state_dimension(math.get("state_variables")),
+            )
+        )
+
+        return cls(
+            dimension=dimension,
+            mesh_family=str(
+                _first_present(
+                    solver,
+                    ("mesh_family", "mesh", "mesh_type", "grid_type", "grid_family"),
+                    default="line_uniform",
+                )
+            ),
+            element_family=str(_first_present(solver, ("element_family", "element", "space_family"), default="lagrange_p2")),
+            pde_terms=_tuple_of_strings(
+                _first_present(math, ("pde_terms", "terms"), default=("drift", "diffusion", "reaction"))
+            ),
+            boundary_conditions=_boundary_condition_classes(
+                _first_present(math, ("boundary_types", "boundaries", "boundary_conditions"), default=("dirichlet",))
+            ),
+            exercise_style=str(_first_present(math, ("exercise_style", "exercise"), default="european")),
+            requested_outputs=_tuple_of_strings(
+                _first_present(solver, ("requested_outputs", "required_outputs", "outputs"), default=("value",))
+            ),
+            stability_controls=_tuple_of_strings(
+                _first_present(solver, ("stability_controls", "stability"), default=("theta",))
+            ),
+            linear_solver=str(_first_present(solver, ("linear_solver", "solver", "linear_solver_policy"), default="scipy_direct")),
+            measure=_optional_string(
+                _first_present(
+                    context,
+                    ("measure",),
+                    default=_first_present(math, ("measure_id", "measure"), default=conventions.get("measure")),
+                )
+            ),
+            numeraire=_optional_string(
+                _first_present(
+                    context,
+                    ("numeraire",),
+                    default=_first_present(math, ("numeraire_id", "numeraire"), default=conventions.get("numeraire")),
+                )
+            ),
+            units=_mapping(
+                _first_present(
+                    context,
+                    ("units",),
+                    default=_first_present(math, ("units",), default=conventions.get("units", {})),
+                )
+            ),
+            boundary_details={str(key): str(value) for key, value in boundary_details.items()},
+            valuation_date=_optional_string(
+                _first_present(context, ("valuation_date", "as_of_date"), default=vintage.get("valuation_date"))
+            ),
+            maturity_date=_optional_string(_first_present(context, ("maturity_date",), default=vintage.get("maturity_date"))),
+            time_domain=_optional_string(_first_present(context, ("time_domain",), default=domain.get("t"))),
+            source_schema_version=_optional_string(payload.get("schema_version")),
+        )
+
+
+DEFAULT_FEM_CAPABILITY_MANIFEST = FEMCapabilityManifest(
+    backend_id="finite_element_options.fem_backend.v0",
+    contract_version="0.1.0",
+    status=CapabilityStatus.VALIDATED,
+    supported_dimensions=(1,),
+    mesh_families=("line_uniform",),
+    element_families=("lagrange_p2",),
+    pde_terms=("drift", "diffusion", "reaction"),
+    boundary_conditions=("dirichlet",),
+    exercise_styles=("european",),
+    outputs=("value", "delta", "gamma"),
+    stability_controls=("theta", "crank_nicolson"),
+    linear_solvers=("scipy_direct",),
+    required_conventions=("measure", "numeraire", "units", "valuation_date", "maturity_or_time_domain"),
+    diagnostics=(
+        "unsupported dimension",
+        "unsupported mesh family",
+        "unsupported element family",
+        "unsupported PDE term",
+        "unsupported boundary condition",
+        "unsupported exercise style",
+        "unsupported output",
+        "missing measure/numeraire/units/date convention",
+    ),
+    notes=(
+        "The executable parity fixture validates the 1D public-synthetic Black-Scholes call value.",
+        "Adaptive meshes, higher-order elements, American exercise, HJB/control and jump terms fail closed until evidenced.",
+        "Greek output names are backed by deterministic central-stencil Delta/Gamma errors in the public parity fixture; broader kink-aware production evidence remains separate.",
+    ),
+)
+
+
+def diagnose_unsupported_route(
+    request: FEMRouteRequest,
+    manifest: FEMCapabilityManifest = DEFAULT_FEM_CAPABILITY_MANIFEST,
+) -> tuple[UnsupportedRouteDiagnostic, ...]:
+    """Return fail-closed diagnostics for unsupported request fields."""
+
+    diagnostics: list[UnsupportedRouteDiagnostic] = []
+
+    if request.dimension not in manifest.supported_dimensions:
+        diagnostics.append(
+            _diagnostic(
+                UnsupportedReason.UNSUPPORTED_DIMENSION,
+                "dimension",
+                str(request.dimension),
+                tuple(str(item) for item in manifest.supported_dimensions),
+                f"FEM backend supports dimensions {manifest.supported_dimensions}, got {request.dimension}D.",
+            )
+        )
+
+    _extend_set_diagnostics(diagnostics, UnsupportedReason.UNSUPPORTED_MESH, "mesh_family", (request.mesh_family,), manifest.mesh_families)
+    _extend_set_diagnostics(
+        diagnostics,
+        UnsupportedReason.UNSUPPORTED_ELEMENT,
+        "element_family",
+        (request.element_family,),
+        manifest.element_families,
+    )
+    _extend_set_diagnostics(diagnostics, UnsupportedReason.UNSUPPORTED_TERM, "pde_terms", request.pde_terms, manifest.pde_terms)
+    _extend_set_diagnostics(
+        diagnostics,
+        UnsupportedReason.UNSUPPORTED_BOUNDARY,
+        "boundary_conditions",
+        request.boundary_conditions,
+        manifest.boundary_conditions,
+    )
+    _extend_set_diagnostics(
+        diagnostics,
+        UnsupportedReason.UNSUPPORTED_EXERCISE,
+        "exercise_style",
+        (request.exercise_style,),
+        manifest.exercise_styles,
+    )
+    _extend_set_diagnostics(
+        diagnostics,
+        UnsupportedReason.UNSUPPORTED_OUTPUT,
+        "requested_outputs",
+        request.requested_outputs,
+        manifest.outputs,
+    )
+    _extend_set_diagnostics(
+        diagnostics,
+        UnsupportedReason.UNSUPPORTED_STABILITY_CONTROL,
+        "stability_controls",
+        request.stability_controls,
+        manifest.stability_controls,
+    )
+    _extend_set_diagnostics(
+        diagnostics,
+        UnsupportedReason.UNSUPPORTED_LINEAR_SOLVER,
+        "linear_solver",
+        (request.linear_solver,),
+        manifest.linear_solvers,
+    )
+
+    conventions = {
+        "measure": request.measure,
+        "numeraire": request.numeraire,
+        "units": request.units,
+        "valuation_date": request.valuation_date,
+        "maturity_or_time_domain": request.maturity_date or request.time_domain,
+    }
+    for field_name in manifest.required_conventions:
+        if not conventions.get(field_name):
+            diagnostics.append(
+                _diagnostic(
+                    UnsupportedReason.MISSING_CONVENTION,
+                    field_name,
+                    "<missing>",
+                    ("required",),
+                    f"QuantProblemSpec mapping must preserve {field_name}; it was missing or empty.",
+                )
+            )
+
+    return tuple(diagnostics)
+
+
+def ensure_route_supported(
+    request: FEMRouteRequest,
+    manifest: FEMCapabilityManifest = DEFAULT_FEM_CAPABILITY_MANIFEST,
+) -> None:
+    """Raise :class:`UnsupportedRouteError` if the manifest rejects the request."""
+
+    diagnostics = diagnose_unsupported_route(request, manifest)
+    if diagnostics:
+        raise UnsupportedRouteError(diagnostics)
+
+
+class UnsupportedRouteError(ValueError):
+    """Raised when a route request is unsupported before numerical work."""
+
+    def __init__(self, diagnostics: Iterable[UnsupportedRouteDiagnostic]) -> None:
+        """Store diagnostics and render a concise human-readable reason list."""
+
+        self.diagnostics = tuple(diagnostics)
+        reasons = "; ".join(d.message for d in self.diagnostics)
+        super().__init__(reasons)
+
+
+def _diagnostic(
+    reason: UnsupportedReason,
+    field_name: str,
+    value: str,
+    supported: tuple[str, ...],
+    message: str,
+) -> UnsupportedRouteDiagnostic:
+    return UnsupportedRouteDiagnostic(
+        reason=reason,
+        field=field_name,
+        value=value,
+        supported=supported,
+        message=message,
+    )
+
+
+def _extend_set_diagnostics(
+    diagnostics: list[UnsupportedRouteDiagnostic],
+    reason: UnsupportedReason,
+    field_name: str,
+    requested: tuple[str, ...],
+    supported: tuple[str, ...],
+) -> None:
+    supported_set = set(supported)
+    for value in requested:
+        if value not in supported_set:
+            diagnostics.append(
+                _diagnostic(
+                    reason,
+                    field_name,
+                    value,
+                    supported,
+                    f"Unsupported {field_name} value {value!r}; supported values are {supported}.",
+                )
+            )
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _first_present(mapping: Mapping[str, Any], keys: tuple[str, ...], *, default: Any) -> Any:
+    for key in keys:
+        if key in mapping:
+            return mapping[key]
+    return default
+
+
+def _tuple_of_strings(value: Any) -> tuple[str, ...]:
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, Iterable) and not isinstance(value, Mapping):
+        return tuple(str(item) for item in value)
+    return (str(value),)
+
+
+def _state_dimension(value: Any) -> int:
+    if isinstance(value, str):
+        return 1
+    if isinstance(value, Iterable) and not isinstance(value, Mapping):
+        values = tuple(value)
+        return len(values) or 1
+    return 1
+
+
+def _boundary_condition_classes(value: Any) -> tuple[str, ...]:
+    """Normalize public schema boundary formulas to FEM capability classes."""
+
+    raw_items: Iterable[Any]
+    if isinstance(value, Mapping):
+        raw_items = value.values()
+    else:
+        raw_items = _tuple_of_strings(value)
+
+    classes: list[str] = []
+    for item in raw_items:
+        text = str(item).lower().replace("-", "_")
+        if "robin" in text:
+            boundary_class = "robin"
+        elif "dirichlet" in text or "absorbing" in text or "linear" in text or "growth" in text or text.strip() in {"0", "zero"}:
+            boundary_class = "dirichlet"
+        elif "slope" in text or "neumann" in text:
+            boundary_class = "neumann"
+        else:
+            boundary_class = text
+        if boundary_class not in classes:
+            classes.append(boundary_class)
+    return tuple(classes) or ("dirichlet",)
+
+
+def _optional_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text or None
+
+
+__all__ = [
+    "CapabilityStatus",
+    "DEFAULT_FEM_CAPABILITY_MANIFEST",
+    "FEMCapabilityManifest",
+    "FEMRouteRequest",
+    "UnsupportedReason",
+    "UnsupportedRouteDiagnostic",
+    "UnsupportedRouteError",
+    "diagnose_unsupported_route",
+    "ensure_route_supported",
+]

--- a/src/contracts/backend_capabilities.py
+++ b/src/contracts/backend_capabilities.py
@@ -244,13 +244,24 @@ def diagnose_unsupported_route(
         manifest.element_families,
     )
     _extend_set_diagnostics(diagnostics, UnsupportedReason.UNSUPPORTED_TERM, "pde_terms", request.pde_terms, manifest.pde_terms)
-    _extend_set_diagnostics(
-        diagnostics,
-        UnsupportedReason.UNSUPPORTED_BOUNDARY,
-        "boundary_conditions",
-        request.boundary_conditions,
-        manifest.boundary_conditions,
-    )
+    if request.boundary_conditions:
+        _extend_set_diagnostics(
+            diagnostics,
+            UnsupportedReason.UNSUPPORTED_BOUNDARY,
+            "boundary_conditions",
+            request.boundary_conditions,
+            manifest.boundary_conditions,
+        )
+    else:
+        diagnostics.append(
+            _diagnostic(
+                UnsupportedReason.UNSUPPORTED_BOUNDARY,
+                "boundary_conditions",
+                "<missing>",
+                manifest.boundary_conditions,
+                "QuantProblemSpec mapping must declare at least one boundary condition class before FEM routing.",
+            )
+        )
     _extend_set_diagnostics(
         diagnostics,
         UnsupportedReason.UNSUPPORTED_EXERCISE,
@@ -392,26 +403,32 @@ def _state_dimension(value: Any) -> int:
 def _boundary_condition_classes(value: Any) -> tuple[str, ...]:
     """Normalize public schema boundary formulas to FEM capability classes."""
 
-    raw_items: Iterable[Any]
     if isinstance(value, Mapping):
-        raw_items = value.values()
+        raw_items: Iterable[tuple[str, Any]] = value.items()
     else:
-        raw_items = _tuple_of_strings(value)
+        raw_items = (("", item) for item in _tuple_of_strings(value))
 
     classes: list[str] = []
-    for item in raw_items:
+    for location, item in raw_items:
         text = str(item).lower().replace("-", "_")
-        if "robin" in text:
+        location_text = str(location).lower().replace("-", "_")
+        if "free" in text and "boundary" in text:
+            boundary_class = "free_boundary"
+        elif "robin" in text:
             boundary_class = "robin"
-        elif "dirichlet" in text or "absorbing" in text or "linear" in text or "growth" in text or text.strip() in {"0", "zero"}:
-            boundary_class = "dirichlet"
-        elif "slope" in text or "neumann" in text:
+        elif "neumann" in text or "slope" in text:
             boundary_class = "neumann"
+        elif "dirichlet" in text or "absorbing" in text or text.strip() in {"0", "zero"}:
+            boundary_class = "dirichlet"
+        elif ("linear" in text or "growth" in text) and any(
+            marker in location_text for marker in ("s_max", "upper", "right", "far_field")
+        ):
+            boundary_class = "dirichlet"
         else:
             boundary_class = text
         if boundary_class not in classes:
             classes.append(boundary_class)
-    return tuple(classes) or ("dirichlet",)
+    return tuple(classes)
 
 
 def _optional_string(value: Any) -> str | None:

--- a/src/contracts/backend_capabilities.py
+++ b/src/contracts/backend_capabilities.py
@@ -421,7 +421,8 @@ def _boundary_condition_classes(value: Any) -> tuple[str, ...]:
         elif "dirichlet" in text or "absorbing" in text or text.strip() in {"0", "zero"}:
             boundary_class = "dirichlet"
         elif ("linear" in text or "growth" in text) and any(
-            marker in location_text for marker in ("s_max", "upper", "right", "far_field")
+            marker in location_text
+            for marker in ("s=0", "s_min", "lower", "left", "s_max", "upper", "right", "far_field")
         ):
             boundary_class = "dirichlet"
         else:

--- a/src/validation/__init__.py
+++ b/src/validation/__init__.py
@@ -1,0 +1,23 @@
+"""Validation fixtures and executable parity evidence."""
+
+from .black_scholes_parity import (
+    DEFAULT_TOLERANCE_ABSOLUTE,
+    DEFAULT_TOLERANCE_RELATIVE,
+    EXPECTED_BLACK_SCHOLES_CALL_PRICE,
+    PUBLIC_SYNTHETIC_BLACK_SCHOLES_BENCHMARK_ID,
+    PUBLIC_SYNTHETIC_PROBLEM_ID,
+    FEMParityConvergenceRow,
+    FEMParityReport,
+    run_public_black_scholes_parity_fixture,
+)
+
+__all__ = [
+    "DEFAULT_TOLERANCE_ABSOLUTE",
+    "DEFAULT_TOLERANCE_RELATIVE",
+    "EXPECTED_BLACK_SCHOLES_CALL_PRICE",
+    "PUBLIC_SYNTHETIC_BLACK_SCHOLES_BENCHMARK_ID",
+    "PUBLIC_SYNTHETIC_PROBLEM_ID",
+    "FEMParityConvergenceRow",
+    "FEMParityReport",
+    "run_public_black_scholes_parity_fixture",
+]

--- a/src/validation/black_scholes_parity.py
+++ b/src/validation/black_scholes_parity.py
@@ -1,0 +1,257 @@
+"""Public-synthetic Black--Scholes parity fixtures for FEM routing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import isfinite
+from typing import Any
+
+import numpy as np
+import scipy.stats as spst
+
+from src.core.dynamics_black_scholes import DynamicsParametersBlackScholes
+from src.core.market import Market
+from src.core.vanilla_bs import EuropeanOptionBs
+from src.space.boundary import DirichletBC
+from src.space.mesh import create_mesh
+from src.space.solver import SpaceSolver
+from src.time.stepper import ThetaScheme
+
+PUBLIC_SYNTHETIC_BLACK_SCHOLES_BENCHMARK_ID = "fem-bs-001"
+PUBLIC_SYNTHETIC_PROBLEM_ID = "public-synthetic-vanilla-call-v0"
+EXPECTED_BLACK_SCHOLES_CALL_PRICE = 10.450583572185565
+DEFAULT_TOLERANCE_ABSOLUTE = 2e-3
+DEFAULT_TOLERANCE_RELATIVE = 5e-4
+
+
+@dataclass(frozen=True)
+class FEMParityConvergenceRow:
+    """One mesh/time refinement row in the public parity report."""
+
+    refinement_level: int
+    time_steps: int
+    degrees_of_freedom: int
+    observed_price: float
+    expected_price: float
+    absolute_error: float
+    relative_error: float
+    observed_delta: float
+    expected_delta: float
+    delta_absolute_error: float
+    observed_gamma: float
+    expected_gamma: float
+    gamma_absolute_error: float
+
+    def to_public_dict(self) -> dict[str, float | int]:
+        """Return a deterministic public-synthetic evidence record."""
+
+        return {
+            "refinement_level": self.refinement_level,
+            "time_steps": self.time_steps,
+            "degrees_of_freedom": self.degrees_of_freedom,
+            "observed_price": self.observed_price,
+            "expected_price": self.expected_price,
+            "absolute_error": self.absolute_error,
+            "relative_error": self.relative_error,
+            "observed_delta": self.observed_delta,
+            "expected_delta": self.expected_delta,
+            "delta_absolute_error": self.delta_absolute_error,
+            "observed_gamma": self.observed_gamma,
+            "expected_gamma": self.expected_gamma,
+            "gamma_absolute_error": self.gamma_absolute_error,
+        }
+
+
+@dataclass(frozen=True)
+class FEMParityReport:
+    """Executable public-synthetic FEM parity report."""
+
+    benchmark_id: str
+    problem_id: str
+    privacy_class: str
+    expected_price: float
+    observed_price: float
+    price_absolute_error: float
+    price_relative_error: float
+    expected_delta: float
+    observed_delta: float
+    delta_absolute_error: float
+    delta_tolerance_absolute: float
+    expected_gamma: float
+    observed_gamma: float
+    gamma_absolute_error: float
+    gamma_tolerance_absolute: float
+    tolerance_absolute: float
+    tolerance_relative: float
+    convergence_rows: tuple[FEMParityConvergenceRow, ...]
+    diagnostics: dict[str, str | int | float]
+
+    def to_public_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable evidence payload with no private data."""
+
+        return {
+            "benchmark_id": self.benchmark_id,
+            "problem_id": self.problem_id,
+            "privacy_class": self.privacy_class,
+            "expected_price": self.expected_price,
+            "observed_price": self.observed_price,
+            "price_absolute_error": self.price_absolute_error,
+            "price_relative_error": self.price_relative_error,
+            "expected_delta": self.expected_delta,
+            "observed_delta": self.observed_delta,
+            "delta_absolute_error": self.delta_absolute_error,
+            "delta_tolerance_absolute": self.delta_tolerance_absolute,
+            "expected_gamma": self.expected_gamma,
+            "observed_gamma": self.observed_gamma,
+            "gamma_absolute_error": self.gamma_absolute_error,
+            "gamma_tolerance_absolute": self.gamma_tolerance_absolute,
+            "tolerance_absolute": self.tolerance_absolute,
+            "tolerance_relative": self.tolerance_relative,
+            "convergence_rows": [row.to_public_dict() for row in self.convergence_rows],
+            "diagnostics": dict(self.diagnostics),
+        }
+
+
+def run_public_black_scholes_parity_fixture(
+    *,
+    refinement_levels: tuple[int, ...] = (4, 5, 6),
+    time_steps: int = 80,
+) -> FEMParityReport:
+    """Run the public-synthetic Black-Scholes call FEM parity fixture.
+
+    The existing FEM implementation is formulated in normalized spot/strike
+    coordinates.  Because the Black-Scholes PDE is homogeneous in spot and
+    strike, the fixture solves with ``S/K = 1`` and scales the value back by the
+    public synthetic strike ``K=100``.
+    """
+
+    if not refinement_levels:
+        raise ValueError("at least one refinement level is required")
+    if time_steps <= 0:
+        raise ValueError("time_steps must be positive")
+
+    rows = tuple(_run_row(refinement_level=level, time_steps=time_steps) for level in refinement_levels)
+    final = rows[-1]
+    diagnostics: dict[str, str | int | float] = {
+        "mesh_family": "line_uniform",
+        "element_family": "lagrange_p2",
+        "time_integrator": "theta_crank_nicolson",
+        "linear_solver": "scikit_fem_scipy_direct",
+        "boundary_conditions": "named_endpoint_dirichlet_projection; upper endpoint uses exact Black-Scholes value as the finite-domain linear-growth proxy",
+        "boundary_nodes_enforced": 2,
+        "weak_form_sign_convention": "existing_forward_tau_identity_transform_black_scholes_forms",
+        "coordinate_transform": "identity",
+        "spot": 100.0,
+        "strike": 100.0,
+        "rate": 0.05,
+        "volatility": 0.2,
+        "maturity": 1.0,
+        "deterministic_seed": 1729,
+        "source_issue": "googa27/finite_element_options#64",
+        "oracle_issue": "googa27/haircut-engine#108",
+        "greek_policy": "central finite-element stencil at S=K with explicit delta/gamma oracle errors; payoff-kink production maturity remains separate evidence",
+    }
+    return FEMParityReport(
+        benchmark_id=PUBLIC_SYNTHETIC_BLACK_SCHOLES_BENCHMARK_ID,
+        problem_id=PUBLIC_SYNTHETIC_PROBLEM_ID,
+        privacy_class="public_synthetic",
+        expected_price=EXPECTED_BLACK_SCHOLES_CALL_PRICE,
+        observed_price=final.observed_price,
+        price_absolute_error=final.absolute_error,
+        price_relative_error=final.relative_error,
+        expected_delta=final.expected_delta,
+        observed_delta=final.observed_delta,
+        delta_absolute_error=final.delta_absolute_error,
+        delta_tolerance_absolute=1e-3,
+        expected_gamma=final.expected_gamma,
+        observed_gamma=final.observed_gamma,
+        gamma_absolute_error=final.gamma_absolute_error,
+        gamma_tolerance_absolute=2e-5,
+        tolerance_absolute=DEFAULT_TOLERANCE_ABSOLUTE,
+        tolerance_relative=DEFAULT_TOLERANCE_RELATIVE,
+        convergence_rows=rows,
+        diagnostics=diagnostics,
+    )
+
+
+def _run_row(*, refinement_level: int, time_steps: int) -> FEMParityConvergenceRow:
+    if refinement_level < 1:
+        raise ValueError("refinement_level must be positive")
+
+    strike = 100.0
+    dynamics = DynamicsParametersBlackScholes(r=0.05, q=0.0, sig=0.2)
+    market = Market(r=dynamics.r)
+    option = EuropeanOptionBs(k=1.0, q=dynamics.q, mkt=market)
+    times = np.linspace(0.0, 1.0, time_steps + 1)
+    mesh, config = create_mesh([4.0], refinement_level)
+    mesh = mesh.with_boundaries(
+        {
+            "left": lambda x: np.isclose(x[0], 0.0),
+            "right": lambda x: np.isclose(x[0], 4.0),
+        }
+    )
+    space = SpaceSolver(mesh, dynamics, option, is_call=True, config=config)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        solution = ThetaScheme(theta=0.5).solve(times, space, boundary_condition=DirichletBC(["left", "right"]))
+    spot_node = int(np.argmin(np.abs(space.Vh.doflocs[0] - 1.0)))
+    normalized_price = float(solution[-1, spot_node])
+    observed_delta, observed_gamma = _central_difference_greeks(space.Vh.doflocs[0], solution[-1], strike)
+    observed_price = strike * normalized_price
+    expected_price = EXPECTED_BLACK_SCHOLES_CALL_PRICE
+    expected_delta = float(option.call_delta(1.0, 1.0, dynamics.sig**2))
+    expected_gamma = float(spst.norm.pdf(option.d1(1.0, 1.0, dynamics.sig**2)) / (strike * dynamics.sig))
+    absolute_error = abs(observed_price - expected_price)
+    relative_error = absolute_error / max(abs(expected_price), 1.0)
+    delta_absolute_error = abs(observed_delta - expected_delta)
+    gamma_absolute_error = abs(observed_gamma - expected_gamma)
+    values = (observed_price, absolute_error, relative_error, observed_delta, observed_gamma)
+    if any(not isfinite(value) for value in values):
+        raise FloatingPointError("non-finite FEM parity fixture result")
+    return FEMParityConvergenceRow(
+        refinement_level=refinement_level,
+        time_steps=time_steps,
+        degrees_of_freedom=int(space.Vh.N),
+        observed_price=observed_price,
+        expected_price=expected_price,
+        absolute_error=absolute_error,
+        relative_error=relative_error,
+        observed_delta=observed_delta,
+        expected_delta=expected_delta,
+        delta_absolute_error=delta_absolute_error,
+        observed_gamma=observed_gamma,
+        expected_gamma=expected_gamma,
+        gamma_absolute_error=gamma_absolute_error,
+    )
+
+
+def _central_difference_greeks(dof_locations: np.ndarray, values: np.ndarray, strike: float) -> tuple[float, float]:
+    """Return central finite-element Delta and Gamma at normalized spot one."""
+
+    order = np.argsort(dof_locations)
+    coordinates = dof_locations[order]
+    ordered_values = values[order]
+    center = int(np.argmin(np.abs(coordinates - 1.0)))
+    if center == 0 or center == len(coordinates) - 1:
+        raise ValueError("spot=1.0 must have neighboring FEM nodes for Greek extraction")
+    left_spacing = coordinates[center] - coordinates[center - 1]
+    right_spacing = coordinates[center + 1] - coordinates[center]
+    delta = (ordered_values[center + 1] - ordered_values[center - 1]) / (
+        coordinates[center + 1] - coordinates[center - 1]
+    )
+    gamma_normalized = 2.0 * (
+        (ordered_values[center + 1] - ordered_values[center]) / right_spacing
+        - (ordered_values[center] - ordered_values[center - 1]) / left_spacing
+    ) / (left_spacing + right_spacing)
+    return float(delta), float(gamma_normalized / strike)
+
+
+__all__ = [
+    "DEFAULT_TOLERANCE_ABSOLUTE",
+    "DEFAULT_TOLERANCE_RELATIVE",
+    "EXPECTED_BLACK_SCHOLES_CALL_PRICE",
+    "PUBLIC_SYNTHETIC_BLACK_SCHOLES_BENCHMARK_ID",
+    "PUBLIC_SYNTHETIC_PROBLEM_ID",
+    "FEMParityConvergenceRow",
+    "FEMParityReport",
+    "run_public_black_scholes_parity_fixture",
+]

--- a/src/validation/black_scholes_parity.py
+++ b/src/validation/black_scholes_parity.py
@@ -9,13 +9,13 @@ from typing import Any
 import numpy as np
 import scipy.stats as spst
 
-from src.core.dynamics_black_scholes import DynamicsParametersBlackScholes
-from src.core.market import Market
-from src.core.vanilla_bs import EuropeanOptionBs
-from src.space.boundary import DirichletBC
-from src.space.mesh import create_mesh
-from src.space.solver import SpaceSolver
-from src.time.stepper import ThetaScheme
+from ..core.dynamics_black_scholes import DynamicsParametersBlackScholes
+from ..core.market import Market
+from ..core.vanilla_bs import EuropeanOptionBs
+from ..space.boundary import DirichletBC
+from ..space.mesh import create_mesh
+from ..space.solver import SpaceSolver
+from ..time.stepper import ThetaScheme
 
 PUBLIC_SYNTHETIC_BLACK_SCHOLES_BENCHMARK_ID = "fem-bs-001"
 PUBLIC_SYNTHETIC_PROBLEM_ID = "public-synthetic-vanilla-call-v0"

--- a/tests/architecture/test_architecture_contracts.py
+++ b/tests/architecture/test_architecture_contracts.py
@@ -106,7 +106,7 @@ REQUIRED_ARCHITECTURE_PHRASES = {
     "Compatibility and deprecation policy",
     "Architecture fitness gates",
     "haircut-engine",
-    "Issue #64 adds",
+    "executable FEM adapter evidence",
 }
 
 

--- a/tests/architecture/test_architecture_contracts.py
+++ b/tests/architecture/test_architecture_contracts.py
@@ -22,6 +22,7 @@ CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 
 TRANSITIONAL_SRC_PACKAGES_AND_MODULES = {
     "cli.py",
+    "contracts",
     "core",
     "data_utils.py",
     "estimation",
@@ -34,15 +35,18 @@ TRANSITIONAL_SRC_PACKAGES_AND_MODULES = {
     "space",
     "time",
     "transform.py",
+    "validation",
 }
 
 FEM_CORE_PACKAGES_AND_MODULES = {
+    "contracts",
     "core",
     "fdsolver.py",
     "problems",
     "space",
     "time",
     "transform.py",
+    "validation",
 }
 
 OUTER_LAYER_PACKAGES_AND_MODULES = {
@@ -102,6 +106,7 @@ REQUIRED_ARCHITECTURE_PHRASES = {
     "Compatibility and deprecation policy",
     "Architecture fitness gates",
     "haircut-engine",
+    "Issue #64 adds",
 }
 
 

--- a/tests/fixtures/quant_problem_specs/README.md
+++ b/tests/fixtures/quant_problem_specs/README.md
@@ -1,0 +1,10 @@
+# QuantProblemSpec consumer fixtures
+
+`vanilla_call.json` is a public-synthetic copy of the Haircut Engine QuantProblemSpec v0 fixture validated in `googa27/haircut-engine` for Project 5 issue #91.
+
+Rules:
+
+- The fixture is public synthetic only; no client, bank, RUT, token, private market, or Deloitte data belongs here.
+- FEM tests consume this JSON as an external contract fixture, not as a Haircut Engine Python import.
+- Changes must preserve measure, numeraire, units, valuation/vintage dates, boundary details, requested outputs, and schema version.
+- If the upstream fixture changes incompatibly, update this copy and the adapter test in the same PR, or raise a compatibility issue in Project 5.

--- a/tests/fixtures/quant_problem_specs/vanilla_call.json
+++ b/tests/fixtures/quant_problem_specs/vanilla_call.json
@@ -1,0 +1,191 @@
+{
+  "artifact_manifest": {
+    "artifacts": [
+      {
+        "artifact_id": "option-fixture-json",
+        "artifact_type": "json_fixture",
+        "privacy_class": "public_synthetic",
+        "sha256": null,
+        "uri": "artifact://quant-problem-spec/vanilla-call-v0"
+      }
+    ],
+    "manifest_id": "public-synthetic-manifest-v0"
+  },
+  "data_requirement_plan": {
+    "fixture_policy": "public-synthetic-only",
+    "requirements": [
+      {
+        "contract": "public-synthetic-option-contract",
+        "lineage_id": "public-synthetic",
+        "name": "option_parameters",
+        "privacy_class": "public_synthetic",
+        "required_fields": [
+          "spot",
+          "strike",
+          "rate",
+          "volatility",
+          "maturity"
+        ],
+        "version": "v0"
+      }
+    ],
+    "restricted_data_policy": "reject"
+  },
+  "family": "vanilla_option",
+  "financial_graph": {
+    "graph_role": "derivative benchmark graph",
+    "required_solver_features": [
+      "delta",
+      "family:exact",
+      "family:fem",
+      "family:transform",
+      "gamma",
+      "value"
+    ],
+    "translation_notes": "Shared exact/FD/FEM parity fixture; no private market data.",
+    "valuation_graph": {
+      "cashflows": [
+        {
+          "cashflow_id": "terminal_payoff",
+          "currency": "CLP",
+          "direction": "inflow",
+          "formula": "max(S_T-K,0)",
+          "metadata": {},
+          "node_id": "expiry",
+          "timing": "terminal"
+        }
+      ],
+      "graph_id": "public-synthetic-vanilla-call-graph-v0",
+      "measure_id": "risk_neutral",
+      "metadata": {
+        "product_adapter": "vanilla_derivative"
+      },
+      "nodes": [
+        {
+          "kind": "economic_state",
+          "label": "Contract alive",
+          "metadata": {},
+          "node_id": "alive",
+          "state_variables": [
+            "S"
+          ],
+          "terminal": false
+        },
+        {
+          "kind": "terminal",
+          "label": "Expiry payoff",
+          "metadata": {},
+          "node_id": "expiry",
+          "state_variables": [],
+          "terminal": true
+        }
+      ],
+      "solver_hints": {
+        "benchmark_ids": [
+          "black-scholes-call-001"
+        ],
+        "error_budget": null,
+        "fallback_family": "fem",
+        "preferred_families": [
+          "exact",
+          "transform",
+          "fem"
+        ],
+        "required_outputs": [
+          "value",
+          "delta",
+          "gamma"
+        ]
+      },
+      "transitions": [
+        {
+          "intensity_id": null,
+          "metadata": {},
+          "payoff_formula": null,
+          "probability_formula": "t == T",
+          "source_node_id": "alive",
+          "target_node_id": "expiry",
+          "transition_id": "expiry"
+        }
+      ],
+      "version": "1.0"
+    }
+  },
+  "lineage_run_record": {
+    "lineage_id": "public-synthetic-option-lineage-v0",
+    "producer_repo": "googa27/haircut-engine",
+    "schema_owner": "Quant PDE Platform Evolutionary Architecture",
+    "source_issue_refs": [
+      "googa27/haircut-engine#103",
+      "googa27/finite_difference_options#76",
+      "googa27/finite_element_options#64"
+    ]
+  },
+  "mathematical_problem": {
+    "boundary_conditions": {
+      "S=0": "0",
+      "S=S_max": "linear growth"
+    },
+    "domain": {
+      "S": "[0, 400]",
+      "t": "[0, 1]"
+    },
+    "measure_id": "risk_neutral_money_market",
+    "numeraire_id": "money_market_account_CLP",
+    "objective": "price and Greeks",
+    "operator": "Black-Scholes parabolic PDE with constant volatility",
+    "state_variables": [
+      "S"
+    ],
+    "terminal_condition": "max(S-K,0)",
+    "time_variable": "t",
+    "units": {
+      "S": "CLP",
+      "rate": "ACT/365F annualized",
+      "t": "years",
+      "volatility": "annualized decimal"
+    }
+  },
+  "metadata": {
+    "fixture_kind": "public_synthetic",
+    "units": "dimensionless price inputs"
+  },
+  "privacy_class": "public_synthetic",
+  "problem_id": "public-synthetic-vanilla-call-v0",
+  "result_bundle": {
+    "benchmark_ids": [
+      "black-scholes-call-001"
+    ],
+    "diagnostics": {},
+    "status": "schema_only",
+    "values": {}
+  },
+  "schema_version": "quant-problem-spec/v0",
+  "solver_plan": {
+    "benchmark_ids": [
+      "black-scholes-call-001"
+    ],
+    "fallback_policy": "fail_closed",
+    "max_runtime_seconds": 30.0,
+    "preferred_families": [
+      "exact",
+      "finite_difference",
+      "finite_element"
+    ],
+    "required_outputs": [
+      "value",
+      "delta",
+      "gamma"
+    ],
+    "tolerance": 0.001
+  },
+  "title": "Public synthetic Black--Scholes European call",
+  "vintage": {
+    "calendar_id": "CL-business-following-public-synthetic-v1",
+    "convention_id": "CL-RAN21-10-CLP-ACT365F-FOLLOWING-v1",
+    "observation_date": "2026-06-30",
+    "valuation_date": "2026-06-30",
+    "vintage_date": "2026-06-30",
+    "vintage_id": "public-synthetic-2026-06-v0"
+  }
+}

--- a/tests/test_fem_backend_capabilities.py
+++ b/tests/test_fem_backend_capabilities.py
@@ -1,0 +1,203 @@
+"""FEM capability-manifest, QuantProblemSpec mapping and parity tests."""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from src.contracts import (  # noqa: E402
+    DEFAULT_FEM_CAPABILITY_MANIFEST,
+    FEMRouteRequest,
+    UnsupportedReason,
+    UnsupportedRouteError,
+    diagnose_unsupported_route,
+    ensure_route_supported,
+)
+from src.validation.black_scholes_parity import (  # noqa: E402
+    PUBLIC_SYNTHETIC_BLACK_SCHOLES_BENCHMARK_ID,
+    run_public_black_scholes_parity_fixture,
+)
+
+FIXTURE_DIR = pathlib.Path(__file__).parent / "fixtures" / "quant_problem_specs"
+
+
+def _supported_payload() -> dict[str, object]:
+    return {
+        "schema_version": "quant-problem-spec/v0",
+        "valuation_context": {
+            "measure": "risk_neutral",
+            "numeraire": "money_market_account",
+            "units": {"underlying": "USD", "time": "ACT/365F"},
+            "valuation_date": "2026-01-02",
+            "maturity_date": "2027-01-02",
+        },
+        "mathematical_problem": {
+            "dimension": 1,
+            "pde_terms": ["drift", "diffusion", "reaction"],
+            "boundary_conditions": ["dirichlet"],
+            "exercise_style": "european",
+        },
+        "solver_plan": {
+            "mesh_family": "line_uniform",
+            "element_family": "lagrange_p2",
+            "requested_outputs": ["value", "delta", "gamma"],
+            "stability_controls": ["theta"],
+            "linear_solver": "scipy_direct",
+        },
+    }
+
+
+def test_default_manifest_declares_fem_support_without_claiming_unvalidated_routes() -> None:
+    manifest = DEFAULT_FEM_CAPABILITY_MANIFEST
+
+    assert manifest.backend_id == "finite_element_options.fem_backend.v0"
+    assert manifest.contract_version == "0.1.0"
+    assert manifest.supported_dimensions == (1,)
+    assert manifest.element_families == ("lagrange_p2",)
+    assert "american" not in manifest.exercise_styles
+    assert "hjb_control" not in manifest.pde_terms
+    assert {"measure", "numeraire", "units", "valuation_date", "maturity_or_time_domain"} <= set(
+        manifest.required_conventions
+    )
+
+
+def test_quant_problem_spec_mapping_preserves_conventions_mesh_and_outputs() -> None:
+    request = FEMRouteRequest.from_quant_problem_spec(_supported_payload())
+
+    assert request.dimension == 1
+    assert request.mesh_family == "line_uniform"
+    assert request.element_family == "lagrange_p2"
+    assert request.pde_terms == ("drift", "diffusion", "reaction")
+    assert request.boundary_conditions == ("dirichlet",)
+    assert request.requested_outputs == ("value", "delta", "gamma")
+    assert request.measure == "risk_neutral"
+    assert request.numeraire == "money_market_account"
+    assert request.units == {"underlying": "USD", "time": "ACT/365F"}
+    assert request.valuation_date == "2026-01-02"
+    assert request.maturity_date == "2027-01-02"
+    assert diagnose_unsupported_route(request) == ()
+
+
+def test_haircut_engine_vanilla_call_fixture_maps_to_supported_fem_route() -> None:
+    """Consume the same public QuantProblemSpec fixture that Haircut Engine validates."""
+
+    payload = json.loads((FIXTURE_DIR / "vanilla_call.json").read_text())
+
+    request = FEMRouteRequest.from_quant_problem_spec(payload)
+
+    assert request.source_schema_version == "quant-problem-spec/v0"
+    assert request.dimension == 1
+    assert request.mesh_family == "line_uniform"
+    assert request.element_family == "lagrange_p2"
+    assert request.pde_terms == ("drift", "diffusion", "reaction")
+    assert request.boundary_conditions == ("dirichlet",)
+    assert request.boundary_details == {"S=0": "0", "S=S_max": "linear growth"}
+    assert request.requested_outputs == ("value", "delta", "gamma")
+    assert request.measure == "risk_neutral_money_market"
+    assert request.numeraire == "money_market_account_CLP"
+    assert request.units["S"] == "CLP"
+    assert request.valuation_date == "2026-06-30"
+    assert request.time_domain == "[0, 1]"
+    assert diagnose_unsupported_route(request) == ()
+
+
+def test_unsupported_variational_terms_dimensions_boundaries_and_exercise_fail_closed() -> None:
+    payload = _supported_payload()
+    payload["mathematical_problem"] = {
+        "dimension": 2,
+        "pde_terms": ["drift", "hjb_control", "jump_integral"],
+        "boundary_conditions": ["free_boundary"],
+        "exercise_style": "american",
+    }
+    request = FEMRouteRequest.from_quant_problem_spec(payload)
+
+    diagnostics = diagnose_unsupported_route(request)
+    reasons = {diagnostic.reason for diagnostic in diagnostics}
+
+    assert UnsupportedReason.UNSUPPORTED_DIMENSION in reasons
+    assert UnsupportedReason.UNSUPPORTED_TERM in reasons
+    assert UnsupportedReason.UNSUPPORTED_BOUNDARY in reasons
+    assert UnsupportedReason.UNSUPPORTED_EXERCISE in reasons
+    assert {diagnostic.field for diagnostic in diagnostics} >= {
+        "dimension",
+        "pde_terms",
+        "boundary_conditions",
+        "exercise_style",
+    }
+    with pytest.raises(UnsupportedRouteError, match="FEM backend supports dimensions") as exc_info:
+        ensure_route_supported(request)
+    assert exc_info.value.diagnostics == diagnostics
+
+
+def test_missing_measure_numeraire_units_and_dates_are_actionable_diagnostics() -> None:
+    payload = _supported_payload()
+    payload["valuation_context"] = {}
+    request = FEMRouteRequest.from_quant_problem_spec(payload)
+
+    diagnostics = diagnose_unsupported_route(request)
+    missing = {diagnostic.field for diagnostic in diagnostics if diagnostic.reason == UnsupportedReason.MISSING_CONVENTION}
+
+    assert missing == {"measure", "numeraire", "units", "valuation_date", "maturity_or_time_domain"}
+    assert all("missing or empty" in diagnostic.message for diagnostic in diagnostics)
+
+
+def test_unsupported_outputs_mesh_element_and_solver_controls_do_not_silently_downgrade() -> None:
+    payload = _supported_payload()
+    payload["solver_plan"] = {
+        "mesh_family": "adaptive_unstructured",
+        "element_family": "discontinuous_galerkin",
+        "requested_outputs": ["value", "vega", "mesh_error_indicator"],
+        "stability_controls": ["adaptive_time", "rannacher"],
+        "linear_solver": "petsc_amg",
+    }
+    request = FEMRouteRequest.from_quant_problem_spec(payload)
+
+    diagnostics = diagnose_unsupported_route(request)
+    by_field = {diagnostic.field: diagnostic for diagnostic in diagnostics}
+
+    assert by_field["mesh_family"].reason == UnsupportedReason.UNSUPPORTED_MESH
+    assert by_field["element_family"].reason == UnsupportedReason.UNSUPPORTED_ELEMENT
+    assert by_field["linear_solver"].reason == UnsupportedReason.UNSUPPORTED_LINEAR_SOLVER
+    assert {diagnostic.value for diagnostic in diagnostics if diagnostic.field == "requested_outputs"} == {
+        "vega",
+        "mesh_error_indicator",
+    }
+    assert {diagnostic.value for diagnostic in diagnostics if diagnostic.field == "stability_controls"} == {
+        "adaptive_time",
+        "rannacher",
+    }
+
+
+def test_public_black_scholes_parity_fixture_matches_analytical_oracle_with_evidence() -> None:
+    report = run_public_black_scholes_parity_fixture()
+
+    assert report.benchmark_id == PUBLIC_SYNTHETIC_BLACK_SCHOLES_BENCHMARK_ID
+    assert report.problem_id == "public-synthetic-vanilla-call-v0"
+    assert report.privacy_class == "public_synthetic"
+    assert report.price_absolute_error <= report.tolerance_absolute
+    assert report.price_relative_error <= report.tolerance_relative
+    assert report.observed_price == pytest.approx(report.expected_price, abs=report.tolerance_absolute)
+    assert report.delta_absolute_error <= report.delta_tolerance_absolute
+    assert report.gamma_absolute_error <= report.gamma_tolerance_absolute
+    assert report.observed_delta == pytest.approx(report.expected_delta, abs=report.delta_tolerance_absolute)
+    assert report.observed_gamma == pytest.approx(report.expected_gamma, abs=report.gamma_tolerance_absolute)
+    assert report.convergence_rows
+    assert [row.absolute_error for row in report.convergence_rows] == sorted(
+        (row.absolute_error for row in report.convergence_rows),
+        reverse=True,
+    )
+    assert report.diagnostics["mesh_family"] == "line_uniform"
+    assert report.diagnostics["element_family"] == "lagrange_p2"
+    assert report.diagnostics["boundary_nodes_enforced"] == 2
+    assert report.diagnostics["weak_form_sign_convention"] == "existing_forward_tau_identity_transform_black_scholes_forms"
+
+
+def test_public_black_scholes_parity_fixture_is_deterministic() -> None:
+    first = run_public_black_scholes_parity_fixture()
+    second = run_public_black_scholes_parity_fixture()
+
+    assert first.to_public_dict() == second.to_public_dict()

--- a/tests/test_fem_backend_capabilities.py
+++ b/tests/test_fem_backend_capabilities.py
@@ -107,7 +107,9 @@ def test_haircut_engine_vanilla_call_fixture_maps_to_supported_fem_route() -> No
 
 def test_empty_boundary_conditions_fail_closed_instead_of_defaulting_to_dirichlet() -> None:
     payload = _supported_payload()
-    payload["mathematical_problem"] = {**payload["mathematical_problem"], "boundary_conditions": []}
+    math_problem = payload["mathematical_problem"]
+    assert isinstance(math_problem, dict)
+    payload["mathematical_problem"] = {**math_problem, "boundary_conditions": []}
 
     request = FEMRouteRequest.from_quant_problem_spec(payload)
     diagnostics = diagnose_unsupported_route(request)
@@ -121,10 +123,27 @@ def test_empty_boundary_conditions_fail_closed_instead_of_defaulting_to_dirichle
     )
 
 
+def test_endpoint_linear_growth_is_classified_as_dirichlet_only_for_endpoint_locations() -> None:
+    payload = _supported_payload()
+    math_problem = payload["mathematical_problem"]
+    assert isinstance(math_problem, dict)
+    payload["mathematical_problem"] = {
+        **math_problem,
+        "boundary_conditions": {"S=0": "linear growth"},
+    }
+
+    request = FEMRouteRequest.from_quant_problem_spec(payload)
+
+    assert request.boundary_conditions == ("dirichlet",)
+    assert diagnose_unsupported_route(request) == ()
+
+
 def test_free_boundary_text_is_not_misclassified_as_dirichlet() -> None:
     payload = _supported_payload()
+    math_problem = payload["mathematical_problem"]
+    assert isinstance(math_problem, dict)
     payload["mathematical_problem"] = {
-        **payload["mathematical_problem"],
+        **math_problem,
         "boundary_conditions": {"S=S_star": "free boundary with linear continuation"},
     }
 

--- a/tests/test_fem_backend_capabilities.py
+++ b/tests/test_fem_backend_capabilities.py
@@ -105,6 +105,36 @@ def test_haircut_engine_vanilla_call_fixture_maps_to_supported_fem_route() -> No
     assert diagnose_unsupported_route(request) == ()
 
 
+def test_empty_boundary_conditions_fail_closed_instead_of_defaulting_to_dirichlet() -> None:
+    payload = _supported_payload()
+    payload["mathematical_problem"] = {**payload["mathematical_problem"], "boundary_conditions": []}
+
+    request = FEMRouteRequest.from_quant_problem_spec(payload)
+    diagnostics = diagnose_unsupported_route(request)
+
+    assert request.boundary_conditions == ()
+    assert any(
+        diagnostic.reason == UnsupportedReason.UNSUPPORTED_BOUNDARY
+        and diagnostic.field == "boundary_conditions"
+        and diagnostic.value == "<missing>"
+        for diagnostic in diagnostics
+    )
+
+
+def test_free_boundary_text_is_not_misclassified_as_dirichlet() -> None:
+    payload = _supported_payload()
+    payload["mathematical_problem"] = {
+        **payload["mathematical_problem"],
+        "boundary_conditions": {"S=S_star": "free boundary with linear continuation"},
+    }
+
+    request = FEMRouteRequest.from_quant_problem_spec(payload)
+    diagnostics = diagnose_unsupported_route(request)
+
+    assert request.boundary_conditions == ("free_boundary",)
+    assert any(diagnostic.reason == UnsupportedReason.UNSUPPORTED_BOUNDARY for diagnostic in diagnostics)
+
+
 def test_unsupported_variational_terms_dimensions_boundaries_and_exercise_fail_closed() -> None:
     payload = _supported_payload()
     payload["mathematical_problem"] = {


### PR DESCRIPTION
## Summary

Closes #64.

Adds the first finite_element_options Project #5 compatibility slice for the shared Haircut Engine QuantProblemSpec / parity-routing contract.

Implemented:

- `src/contracts/backend_capabilities.py`
  - FEM capability manifest for the intentionally narrow validated route:
    - 1D Black-Scholes PDE
    - uniform line mesh
    - Lagrange P2 elements
    - drift/diffusion/reaction terms
    - Dirichlet endpoint boundary policy
    - European exercise
    - value/Delta/Gamma outputs
    - theta / Crank-Nicolson time stepping
    - SciPy direct linear solve
  - `FEMRouteRequest.from_quant_problem_spec(...)` mapper for the shared public-synthetic QuantProblemSpec fixture.
  - fail-closed diagnostics for unsupported dimensions, terms, mesh/element families, boundaries, exercise styles, requested outputs, controls and missing conventions.

- `src/validation/black_scholes_parity.py`
  - executable `fem-bs-001` public-synthetic Black-Scholes call parity fixture.
  - named endpoint Dirichlet boundary enforcement.
  - deterministic mesh/time refinement evidence.
  - value, Delta and Gamma oracle error reporting against the Haircut analytical benchmark.

- Tests, CI and docs:
  - copied public-synthetic QuantProblemSpec fixture under `tests/fixtures/quant_problem_specs/`.
  - added FEM adapter/diagnostic/parity tests, including explicit free-boundary and empty-boundary fail-closed cases.
  - updated architecture fitness gate for the new transitional `contracts` and `validation` modules.
  - documented issue #64 scope in README / PRD / architecture docs.
  - added `constraints.txt` and updated CI to use it for the PyMC/ArviZ transitive compatibility constraint without adding ArviZ to the direct runtime requirements list.

## Verification

Local verification from `/tmp/finite-element-options-issue64`:

```text
uv pip install --python .venv/bin/python -r requirements.txt -c constraints.txt
# checked; arviz=0.23.4 and hasattr(arviz, "concat") == True

.venv/bin/python -m pydocstyle src
# passed

.venv/bin/python -m pytest tests/test_fem_backend_capabilities.py tests/architecture -q
# 18 passed

.venv/bin/python -m pytest -q
# 50 passed, 2 skipped

.venv/bin/python -m pytest tests/test_benchmark_black_scholes.py --benchmark-json=benchmark.json -q
# 1 passed; benchmark JSON emitted successfully

.venv/bin/python -m compileall -q src tests
# passed
```

Adversarial/Kilo review feedback fixed before merge:

- Greeks are backed by executable Delta/Gamma parity errors.
- Boundary conditions are explicitly enforced via named endpoint Dirichlet boundaries.
- weak-form metadata describes the actual runtime convention instead of overclaiming a transform.
- convention diagnostics use explicit `maturity_or_time_domain` semantics.
- convergence evidence is asserted to improve monotonically over refinement.
- no new public `src.*` imports were added inside the new validation module.
- empty boundary lists fail closed instead of defaulting to Dirichlet.
- free-boundary text is not classified as Dirichlet.
- endpoint linear-growth mapping is constrained to named endpoint locations.
- architecture prose test now checks a stable concept phrase instead of an issue-number-specific sentence.

## Privacy / scope

- Fixture is public synthetic only.
- No Haircut Engine/PDP/domain imports are introduced.
- No private client, bank, RUT, token, market or Deloitte data is included.
- Unsupported capabilities remain fail-closed until separately evidenced.
