### PR TITLE
test: add Pinares problem-spec fixture for FEM backend

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -181,7 +181,7 @@ while the mass form is
 m(u,v)=\int_\Omega vu\,dx.
 \]
 
-The exact signs depend on the declared strong-form convention; code and fixtures must agree. Product adapters cannot silently reinterpret them.
+The exact signs depend on the declared strong-form convention; code and fixtures must agree. Product adapters cannot silently reinterpret them. Problem identity/hash is distinct from FEM method controls so Pinares, Haircut, and other consumers can ask FD/FEM/analytical methods to solve the same claim without rewriting its economics.
 
 ## 8. Native contract model
 
@@ -212,7 +212,7 @@ FEMResult
 └── version and reproducibility metadata
 ```
 
-Public contracts are immutable or snapshot-able and serialization-tested.
+Public contracts are immutable or snapshot-able and serialization-tested. `tests/fixtures/quant_problem_specs/pinares_fixed_price_proxy.json` is the public-synthetic compatibility smoke for the Pinares fixed-price option proxy: it verifies that Pinares owns the financial problem and this backend owns only mesh/element/weak-form/linear-solver controls.
 
 ## 9. Meshes and spaces
 

--- a/src/contracts/backend_capabilities.py
+++ b/src/contracts/backend_capabilities.py
@@ -34,6 +34,7 @@ class UnsupportedReason(str, Enum):
     UNSUPPORTED_OUTPUT = "unsupported_output"
     UNSUPPORTED_STABILITY_CONTROL = "unsupported_stability_control"
     UNSUPPORTED_LINEAR_SOLVER = "unsupported_linear_solver"
+    UNSUPPORTED_BACKEND = "unsupported_backend"
     MISSING_CONVENTION = "missing_convention"
 
 
@@ -108,6 +109,7 @@ class FEMRouteRequest:
     maturity_date: str | None = None
     time_domain: str | None = None
     source_schema_version: str | None = None
+    backend_id: str | None = None
 
     @classmethod
     def from_quant_problem_spec(cls, payload: Mapping[str, Any]) -> FEMRouteRequest:
@@ -181,6 +183,7 @@ class FEMRouteRequest:
             maturity_date=_optional_string(_first_present(context, ("maturity_date",), default=vintage.get("maturity_date"))),
             time_domain=_optional_string(_first_present(context, ("time_domain",), default=domain.get("t"))),
             source_schema_version=_optional_string(payload.get("schema_version")),
+            backend_id=_optional_string(_first_present(solver, ("backend_id", "backend"), default=None)),
         )
 
 
@@ -223,6 +226,17 @@ def diagnose_unsupported_route(
     """Return fail-closed diagnostics for unsupported request fields."""
 
     diagnostics: list[UnsupportedRouteDiagnostic] = []
+
+    if request.backend_id and request.backend_id != manifest.backend_id:
+        diagnostics.append(
+            _diagnostic(
+                UnsupportedReason.UNSUPPORTED_BACKEND,
+                "backend_id",
+                request.backend_id,
+                (manifest.backend_id,),
+                f"Unsupported backend_id {request.backend_id!r}; expected {manifest.backend_id!r}.",
+            )
+        )
 
     if request.dimension not in manifest.supported_dimensions:
         diagnostics.append(

--- a/tests/fixtures/quant_problem_specs/pinares_fixed_price_proxy.json
+++ b/tests/fixtures/quant_problem_specs/pinares_fixed_price_proxy.json
@@ -1,0 +1,96 @@
+{
+  "evidence": {
+    "caveats": [
+      "not private Pinares data"
+    ],
+    "evidence_ids": [
+      "public-synthetic"
+    ]
+  },
+  "mathematical_problem": {
+    "boundary_conditions": {
+      "S=0": "dirichlet",
+      "S=S_max": "linear_growth"
+    },
+    "dimension": 1,
+    "exercise_style": "european",
+    "formulations": [
+      {
+        "formulation_id": "expectation_fixed_price_proxy",
+        "kind": "conditional_expectation"
+      },
+      {
+        "formulation_id": "pde_fixed_price_proxy",
+        "kind": "generator_pde"
+      },
+      {
+        "formulation_id": "weak_form_fixed_price_proxy",
+        "kind": "weak_form"
+      }
+    ],
+    "has_hjb_control": false,
+    "has_jumps": false,
+    "has_obstacle": false,
+    "measure_id": "Q*",
+    "numeraire_id": "UF_money_market_account_proxy",
+    "pde_terms": [
+      "drift",
+      "diffusion",
+      "reaction"
+    ],
+    "state_variables": [
+      {
+        "description": "public synthetic property-value proxy",
+        "name": "S",
+        "role": "underlying",
+        "unit": "UF"
+      }
+    ],
+    "terminal_payoff": {
+      "expression": "0.97 * max(S-K,0)",
+      "payoff_id": "mortality_adjusted_call_payoff",
+      "timing": "terminal",
+      "units": "UF"
+    },
+    "units": {
+      "S": "UF",
+      "rate": "1/year",
+      "time": "year",
+      "value": "UF"
+    }
+  },
+  "problem_hash": "publicsyntheticpinares001",
+  "problem_id": "pinares.fixed_price_option_proxy.v1",
+  "schema_version": "quant-problem-spec/v0",
+  "solver_plan": {
+    "backend_id": "googa27/pinares-real-options",
+    "element_family": "lagrange_p2",
+    "formulation_kind": "generator_pde_or_weak_form",
+    "grid_type": "uniform",
+    "linear_solver": "scipy_direct",
+    "mesh_family": "line_uniform",
+    "method_id": "pinares_backend_compatibility_smoke",
+    "method_kind": "finite_difference_or_finite_element",
+    "requested_outputs": [
+      "value",
+      "delta",
+      "gamma"
+    ],
+    "stability_controls": [
+      "theta"
+    ]
+  },
+  "valuation_context": {
+    "measure": "Q*",
+    "numeraire": "UF_money_market_account_proxy",
+    "privacy_tier": "public_sanitized",
+    "time_domain": "[0, 1]",
+    "units": {
+      "S": "UF",
+      "rate": "1/year",
+      "time": "year",
+      "value": "UF"
+    },
+    "valuation_date": "2026-06-30"
+  }
+}

--- a/tests/fixtures/quant_problem_specs/pinares_fixed_price_proxy.json
+++ b/tests/fixtures/quant_problem_specs/pinares_fixed_price_proxy.json
@@ -63,7 +63,7 @@
   "problem_id": "pinares.fixed_price_option_proxy.v1",
   "schema_version": "quant-problem-spec/v0",
   "solver_plan": {
-    "backend_id": "googa27/pinares-real-options",
+    "backend_id": "finite_element_options.fem_backend.v0",
     "element_family": "lagrange_p2",
     "formulation_kind": "generator_pde_or_weak_form",
     "grid_type": "uniform",

--- a/tests/test_fem_backend_capabilities.py
+++ b/tests/test_fem_backend_capabilities.py
@@ -113,12 +113,15 @@ def test_pinares_fixed_price_problem_fixture_maps_to_supported_fem_route() -> No
     request = FEMRouteRequest.from_quant_problem_spec(payload)
 
     assert payload["problem_id"] == "pinares.fixed_price_option_proxy.v1"
+    assert payload["problem_hash"] == "publicsyntheticpinares001"
     assert request.source_schema_version == "quant-problem-spec/v0"
+    assert request.backend_id == "finite_element_options.fem_backend.v0"
     assert request.dimension == 1
     assert request.mesh_family == "line_uniform"
     assert request.element_family == "lagrange_p2"
     assert request.pde_terms == ("drift", "diffusion", "reaction")
     assert request.boundary_conditions == ("dirichlet",)
+    assert request.boundary_details == {"S=0": "dirichlet", "S=S_max": "linear_growth"}
     assert request.requested_outputs == ("value", "delta", "gamma")
     assert request.measure == "Q*"
     assert request.numeraire == "UF_money_market_account_proxy"
@@ -126,6 +129,20 @@ def test_pinares_fixed_price_problem_fixture_maps_to_supported_fem_route() -> No
     assert request.valuation_date == "2026-06-30"
     assert request.time_domain == "[0, 1]"
     assert diagnose_unsupported_route(request) == ()
+
+
+def test_wrong_backend_id_fails_closed_for_fem_route() -> None:
+    payload = json.loads((FIXTURE_DIR / "pinares_fixed_price_proxy.json").read_text())
+    payload["solver_plan"] = {**payload["solver_plan"], "backend_id": "finite_difference_options.fd_backend.v0"}
+    request = FEMRouteRequest.from_quant_problem_spec(payload)
+
+    diagnostics = diagnose_unsupported_route(request)
+    assert any(
+        diagnostic.reason == UnsupportedReason.UNSUPPORTED_BACKEND
+        and diagnostic.field == "backend_id"
+        and diagnostic.value == "finite_difference_options.fd_backend.v0"
+        for diagnostic in diagnostics
+    )
 
 
 def test_empty_boundary_conditions_fail_closed_instead_of_defaulting_to_dirichlet() -> None:

--- a/tests/test_fem_backend_capabilities.py
+++ b/tests/test_fem_backend_capabilities.py
@@ -105,6 +105,29 @@ def test_haircut_engine_vanilla_call_fixture_maps_to_supported_fem_route() -> No
     assert diagnose_unsupported_route(request) == ()
 
 
+def test_pinares_fixed_price_problem_fixture_maps_to_supported_fem_route() -> None:
+    """Pinares publishes the problem; FEM only chooses mesh/weak-form controls."""
+
+    payload = json.loads((FIXTURE_DIR / "pinares_fixed_price_proxy.json").read_text())
+
+    request = FEMRouteRequest.from_quant_problem_spec(payload)
+
+    assert payload["problem_id"] == "pinares.fixed_price_option_proxy.v1"
+    assert request.source_schema_version == "quant-problem-spec/v0"
+    assert request.dimension == 1
+    assert request.mesh_family == "line_uniform"
+    assert request.element_family == "lagrange_p2"
+    assert request.pde_terms == ("drift", "diffusion", "reaction")
+    assert request.boundary_conditions == ("dirichlet",)
+    assert request.requested_outputs == ("value", "delta", "gamma")
+    assert request.measure == "Q*"
+    assert request.numeraire == "UF_money_market_account_proxy"
+    assert request.units["S"] == "UF"
+    assert request.valuation_date == "2026-06-30"
+    assert request.time_domain == "[0, 1]"
+    assert diagnose_unsupported_route(request) == ()
+
+
 def test_empty_boundary_conditions_fail_closed_instead_of_defaulting_to_dirichlet() -> None:
     payload = _supported_payload()
     math_problem = payload["mathematical_problem"]


### PR DESCRIPTION
## Summary
- Adds a public-synthetic Pinares fixed-price QuantProblemSpec fixture for the finite-element backend.
- Verifies FEM capability screening consumes the same problem id/hash while owning only mesh/element/weak-form/linear-solver controls.
- Documents the problem/formulation/method boundary in the architecture spec.

## Closes
Closes #72

## Evidence
- `/tmp/fem-contract-venv/bin/pytest -o addopts='' -q` -> 52 passed, 2 skipped
- `/home/cristobal/.local/bin/pytest -o addopts='' tests/test_fem_backend_capabilities.py tests/architecture -q` -> 20 passed

## Project topology
- Project #5 epic field: `PROBLEM-FORMULATION-METHOD`
- Predecessors: finite_element_options#49; pinares-real-options#21.
