### PR TITLE
fix: align FEM oracle solver identifiers

### DIFF
--- a/src/validation/black_scholes_parity.py
+++ b/src/validation/black_scholes_parity.py
@@ -492,7 +492,7 @@ def run_public_black_scholes_parity_fixture(
         min_refinement_level=min(refinement_levels),
         max_refinement_level=max(refinement_levels),
         refinement_levels=tuple(refinement_levels),
-        solver_backing="scikit-fem_direct",
+        solver_backing="scikit-fem+sparse-direct",
     )
     time_metadata = TimeMetadata(
         integrator="theta_crank_nicolson",

--- a/tests/fixtures/fem_bs_001/result_export.json
+++ b/tests/fixtures/fem_bs_001/result_export.json
@@ -13,8 +13,8 @@
     "primary_metric": "price/Delta/Gamma absolute error",
     "tolerance": 0.002
   },
-  "config_hash": "6c4fe89c536392c068767dfd0e40207b9257dae208a7ebe122ec3ce6fcbbce58",
-  "config_id": "6c4fe89c536392c068767dfd0e40207b9257dae208a7ebe122ec3ce6fcbbce58",
+  "config_hash": "94e07ddcf8eb9bae10710f9fa1df61c2fd269af3a43ae643d9c66add7ee26930",
+  "config_id": "94e07ddcf8eb9bae10710f9fa1df61c2fd269af3a43ae643d9c66add7ee26930",
   "format_version": "fem-bs-oracle-result-v1",
   "mesh_metadata": {
     "domain_max": 4.0,
@@ -28,7 +28,7 @@
       5,
       6
     ],
-    "solver_backing": "scikit-fem_direct",
+    "solver_backing": "scikit-fem+sparse-direct",
     "spatial_domain": "[0, 4.0] normalized spot"
   },
   "privacy_class": "public_synthetic",

--- a/tests/test_fem_backend_capabilities.py
+++ b/tests/test_fem_backend_capabilities.py
@@ -351,6 +351,7 @@ def test_fem_bs_001_public_problem_spec_is_stable_and_consumable() -> None:
 def test_fem_bs_001_result_export_is_public_mesh_time_and_result_payload() -> None:
     report = run_public_black_scholes_parity_fixture()
     payload = json.loads(FEM_BS_001_RESULT_EXPORT_PATH.read_text())
+    spec_payload = json.loads(FEM_BS_001_PROBLEM_SPEC_PATH.read_text())
 
     assert payload["format_version"] == "fem-bs-oracle-result-v1"
     assert payload["benchmark_id"] == report.benchmark_id
@@ -365,6 +366,7 @@ def test_fem_bs_001_result_export_is_public_mesh_time_and_result_payload() -> No
         "gamma_absolute": report.gamma_tolerance_absolute,
     }
     assert payload["mesh_metadata"]["mesh_family"] == report.mesh_metadata.mesh_family
+    assert payload["mesh_metadata"]["solver_backing"] == spec_payload["mesh_metadata"]["solver_backing"]
     assert payload["mesh_metadata"]["refinement_levels"] == list(
         report.mesh_metadata.refinement_levels
     )


### PR DESCRIPTION
## Summary
- follow up on post-merge review feedback from #75
- align the FEM public problem spec and result export solver identifier
- add regression coverage that both public artifacts publish the same solver backing

## Verification
- `python3.12 -m pytest --override-ini addopts= -q tests/test_fem_backend_capabilities.py tests/architecture` -> 25 passed
- `uvx ruff check src/validation/black_scholes_parity.py tests/test_fem_backend_capabilities.py` -> All checks passed
- `git diff --check`


Closes #77
