### PR TITLE
Repair finite-difference reference backend

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -340,7 +340,7 @@ Issue #78 extends the same adapter-screening architecture to Pinares without imp
 | FEM mesh/space/form/assembly | Stable core |
 | Time stepping and FEM state transfer | Stable core |
 | Sparse solver/factorization policies | Core plus optional solver adapters |
-| `fdsolver.py` or production FD routes | Migrate/remove production FD ownership; keep only the #51 time-bounded, uniform-grid 1D Black-Scholes benchmark oracle with fail-closed route validation, carry-aware boundaries, Dirichlet RHS elimination, residual/convergence metadata and factorization-reuse diagnostics. |
+| `fdsolver.py` or production FD routes | Migrate/remove production FD ownership; keep only the #51 time-bounded, uniform-grid 1D Black-Scholes benchmark oracle with fail-closed route validation, carry-aware/nonnegative-call boundaries, Dirichlet RHS elimination, residual/convergence metadata and factorization-reuse diagnostics. |
 | Black–Scholes/Heston/product classes | Thin validation/example adapters, not core ownership |
 | Calibration and statistical workflows | Optional profile or downstream consumer |
 | pandas/xarray/Arrow persistence | Optional experiment/interop profile |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,7 +61,7 @@ Cross-repository integration uses independently versioned wheels, semantic contr
 
 | Finding | Risk | Decision / owner |
 |---|---|---|
-| Historical `setup.py` declared `packages=['src']` | Built wheels did not represent the intended nested package API | #44 replaces it with PEP 621 metadata and `src/finite_element_options` package discovery |
+| Historical `setup.py` declared the repository `src` directory itself as a package | Built wheels did not represent the intended nested package API | #44 replaces it with PEP 621 metadata and `src/finite_element_options` package discovery |
 | Historical README/source imported `src.*` | Checkout success masked broken distribution installs | #44 removes `src` as a public package and adds clean-wheel tests |
 | Historical metadata lived outside `pyproject.toml` | Runtime dependencies, Python support, extras and entry points were undefined | #44 makes `pyproject.toml` the package source of truth |
 | Historical `requirements.txt` combined `scikit-fem[all]`, UI, FD, JAX, PyMC, dataframes and test tools | Large mandatory environment and fragile compatibility | #44 splits core dependencies from published extras and dev/test groups |
@@ -330,7 +330,7 @@ Issue #64 adds `finite_element_options.contracts.backend_capabilities` and `fini
 
 Issue #74 publishes the public arxiv-lab contract artifacts in `tests/fixtures/fem_bs_001/` alongside the executable report: `problem_spec.json` (fixture/problem spec), deterministic mesh/time-step configuration and boundary metadata, `result_export.json` (convergence rows and summary), and explicit equal-error comparison policy for parity consumers.
 
-Issue #78 extends the same adapter-screening architecture to Pinares without importing Pinares domain modules. `finite_element_options.validation.pinares_fixed_price_proxy` publishes `PINARES-FEM-FIXED-PRICE-PROXY-V0` and `PINARES-QPS-FIXED-PRICE-PROXY-V0` artifacts in `tests/fixtures/fem_pinares_fixed_price_proxy_v1/` plus the shared `tests/fixtures/quant_problem_specs/pinares_fixed_price_proxy.json`. The executable route solves the public-synthetic fixed-price option proxy as a normalized Black-Scholes weak form (`x=S/K`, UF value = survival probability × `K_uf` × normalized call value), records mesh/time/weak-form/boundary metadata, and checks value/Delta/Gamma plus no-arbitrage bounds. `PINARES-FEM-FAIL-CLOSED-V0` is the negative contract: full family contract, ROFR, legal/tax, obstacle/free-boundary, jump/liquidity and HJB/control requests are rejected by `FEMRouteRequest` diagnostics before mesh or assembly work.
+Issue #78 extends the same adapter-screening architecture to Pinares without importing Pinares domain modules. `finite_element_options.validation.pinares_fixed_price_proxy` publishes `PINARES-FEM-FIXED-PRICE-PROXY-V0` and `PINARES-QPS-FIXED-PRICE-PROXY-V0` artifacts in `tests/fixtures/fem_pinares_fixed_price_proxy_v1/` plus the shared `tests/fixtures/quant_problem_specs/pinares_fixed_price_proxy.json`. The executable route solves the public-synthetic fixed-price option proxy as a normalized Black-Scholes weak form ($x=S/K$, UF value = survival probability × $K_{uf}$ × normalized call value), records mesh/time/weak-form/boundary metadata, and checks value/Delta/Gamma plus no-arbitrage bounds. `PINARES-FEM-FAIL-CLOSED-V0` is the negative contract: full family contract, ROFR, legal/tax, obstacle/free-boundary, jump/liquidity and HJB/control requests are rejected by `FEMRouteRequest` diagnostics before mesh or assembly work.
 
 
 ## 17. Ownership cleanup
@@ -340,7 +340,7 @@ Issue #78 extends the same adapter-screening architecture to Pinares without imp
 | FEM mesh/space/form/assembly | Stable core |
 | Time stepping and FEM state transfer | Stable core |
 | Sparse solver/factorization policies | Core plus optional solver adapters |
-| `fdsolver.py` or production FD routes | Migrate/remove; optional time-bounded benchmark oracle only |
+| `fdsolver.py` or production FD routes | Migrate/remove production FD ownership; keep only the #51 time-bounded, uniform-grid 1D Black-Scholes benchmark oracle with fail-closed route validation, carry-aware boundaries, Dirichlet RHS elimination, residual/convergence metadata and factorization-reuse diagnostics. |
 | Black–Scholes/Heston/product classes | Thin validation/example adapters, not core ownership |
 | Calibration and statistical workflows | Optional profile or downstream consumer |
 | pandas/xarray/Arrow persistence | Optional experiment/interop profile |

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -174,7 +174,7 @@ Owner: #49.
 
 Issue #64 provides the first executable Project #5 compatibility slice before the full entry-point plugin: a public-synthetic QuantProblemSpec adapter manifest, fail-closed route diagnostics and the `fem-bs-001` Black-Scholes parity fixture. This slice is deliberately narrow and validates only the one-dimensional uniform-line/Lagrange-P2/theta/SciPy-direct route against the Haircut analytical oracle with named endpoint boundary enforcement and value/Delta/Gamma error evidence; unsupported dimensions, adaptive meshes, unvalidated elements, American exercise, jump terms and HJB/control terms fail before mesh or weak-form allocation.
 
-Issue #74 extends this to a public arxiv-lab compatible FEM oracle artifact set for the same European call benchmark. It adds deterministic public problem/contract files, explicit weak-form sign metadata, typed boundary metadata (`S=0`, `S=S_max`), mesh/time-step and results exports, and an equal-error comparison policy so parity consumers can compare results against matching error budgets using public files/contracts.
+Issue #74 extends this to a public arxiv-lab compatible FEM oracle artifact set for the same European call benchmark. It adds deterministic public problem/contract files, explicit weak-form sign metadata, typed boundary metadata ($S=0$, $S=S_{\max}$), mesh/time-step and results exports, and an equal-error comparison policy so parity consumers can compare results against matching error budgets using public files/contracts.
 
 Issue #78 adds the Pinares-specific public-synthetic fixed-price proxy weak-form fixture. It consumes/exports a `quant-problem-spec/v0` record with UF units, `Q*` proxy measure, maturity date/time domain, survival-scaled terminal payoff, one-dimensional drift/diffusion/reaction terms, endpoint Dirichlet/linear-growth boundary metadata, Lagrange-P2 line mesh controls, theta stepping and SciPy-direct solve evidence. The route is validated only for the fixed-price option proxy; full family-contract, ROFR, obstacle/free-boundary, jump/liquidity, HJB/control and legal/tax-output requests fail closed with diagnostics before mesh allocation.
 
@@ -183,6 +183,8 @@ Issue #78 adds the Pinares-specific public-synthetic fixed-price proxy weak-form
 The stable package owns FEM numerical mechanics. The embedded FD implementation, full application/product workflows, duplicate examples and heavy UI/calibration responsibilities must be classified as core, optional, example, compatibility, migrate or delete.
 
 Production FD behavior migrates to `finite_difference_options`; only time-bounded benchmark or compatibility code may remain. Owner: #50.
+
+Issue #51 repairs the remaining benchmark-oracle role for `fdsolver.py`: it is now documented as a narrow one-dimensional Black-Scholes reference over validated uniform spot/time-to-maturity grids, not a production FD backend. The route fails closed for invalid/nonuniform grids and time grids, uses carry-aware endpoint Dirichlet boundaries, eliminates nonzero Dirichlet columns from interior equations, propagates payoff domain errors instead of broad scalar fallback, reuses a constant factorization, and returns labeled xarray coordinates plus route/time/residual/convergence metadata.
 
 ### FR-FEM-013 — Optional research and application profiles
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -184,7 +184,7 @@ The stable package owns FEM numerical mechanics. The embedded FD implementation,
 
 Production FD behavior migrates to `finite_difference_options`; only time-bounded benchmark or compatibility code may remain. Owner: #50.
 
-Issue #51 repairs the remaining benchmark-oracle role for `fdsolver.py`: it is now documented as a narrow one-dimensional Black-Scholes reference over validated uniform spot/time-to-maturity grids, not a production FD backend. The route fails closed for invalid/nonuniform grids and time grids, uses carry-aware endpoint Dirichlet boundaries, eliminates nonzero Dirichlet columns from interior equations, propagates payoff domain errors instead of broad scalar fallback, reuses a constant factorization, and returns labeled xarray coordinates plus route/time/residual/convergence metadata.
+Issue #51 repairs the remaining benchmark-oracle role for `fdsolver.py`: it is now documented as a narrow one-dimensional Black-Scholes reference over validated uniform spot/time-to-maturity grids, not a production FD backend. The route fails closed for invalid/nonuniform grids and time grids, uses carry-aware endpoint Dirichlet boundaries with a nonnegative call far-field clamp, eliminates nonzero Dirichlet columns from interior equations, propagates payoff domain errors instead of broad scalar fallback, reuses a constant factorization, and returns labeled xarray coordinates plus route/time/residual/convergence metadata.
 
 ### FR-FEM-013 — Optional research and application profiles
 

--- a/src/finite_element_options/fdsolver.py
+++ b/src/finite_element_options/fdsolver.py
@@ -1,12 +1,10 @@
-"""Finite difference solver for option pricing PDEs.
+"""Auditable 1D finite-difference reference for Black-Scholes options.
 
-This module wraps the :mod:`findiff` package to provide a regular-grid
-finite difference discretisation for the one-dimensional Black–Scholes
-PDE.  The solver exposes an API similar to the finite element
-``SpaceSolver`` so that either backend can be selected.
-
-It also supplies simple Greek estimators based on the derivative
-operators from :mod:`findiff`.
+This module intentionally stays narrow.  The reference backend is valid only for
+a one-dimensional Black-Scholes PDE on a finite, strictly increasing, uniform
+spot grid and a uniform forward time-to-maturity grid ``tau``.  Unsupported
+routes fail before discretisation so FEM comparisons do not inherit hidden
+finite-difference defects.
 """
 
 from __future__ import annotations
@@ -17,26 +15,32 @@ from typing import Callable, Iterable
 
 import numpy as np
 import scipy.sparse as sps
-from scipy.sparse.linalg import spsolve
-from findiff import FinDiff
+import scipy.sparse.linalg as spla
 from xarray import DataArray
 
 from .data_utils import snapshot
 
 
+_GRID_ATOL = 1.0e-12
+_GRID_RTOL = 1.0e-10
+
+
 @dataclass
 class FDSolver:
-    """Finite difference spatial discretisation for Black–Scholes PDE.
+    """Finite-difference spatial discretisation for the Black-Scholes PDE.
 
     Parameters
     ----------
     s_grid:
-        One-dimensional grid of underlying asset prices.
+        One-dimensional, finite, non-negative, strictly increasing and uniform
+        spot grid.  Nonuniform grids are rejected rather than discretised with
+        incorrect uniform stencils.
     dynamics:
-        Model parameters supplying ``r``, ``q`` and ``sig`` attributes.
+        Black-Scholes parameters supplying finite ``r``, ``q`` and positive
+        ``sig`` attributes.
     payoff:
-        Payoff object implementing ``call_payoff``/``put_payoff`` and
-        ``call``/``put`` evaluation methods.
+        Payoff object implementing ``call_payoff``/``put_payoff`` and carrying
+        a strike ``k``.
     is_call:
         ``True`` for a call option, ``False`` for a put.
     """
@@ -47,84 +51,146 @@ class FDSolver:
     is_call: bool = True
 
     def __post_init__(self) -> None:
-        """Prepare differential operators after dataclass initialisation."""
+        """Validate inputs and assemble the reference tridiagonal operator."""
+        self.s_grid = _validate_uniform_spot_grid(self.s_grid)
         self.ds = float(self.s_grid[1] - self.s_grid[0])
         self.N = len(self.s_grid)
+        self._validate_black_scholes_parameters()
+        self._validate_payoff_contract()
         # expose minimal interface expected by TimeStepper
         self.Vh = SimpleNamespace(N=self.N, doflocs=np.array([self.s_grid]))
-        self.I = sps.identity(self.N)
+        self.I = sps.identity(self.N, format="csr")
         self._assemble_operator()
 
     # ------------------------------------------------------------------
     # Assembly helpers
+    def _validate_black_scholes_parameters(self) -> None:
+        for name in ("r", "q", "sig"):
+            value = getattr(self.dynamics, name, None)
+            if value is None or not np.isfinite(float(value)):
+                raise ValueError(f"Black-Scholes dynamics must define finite {name}")
+        if float(self.dynamics.sig) <= 0.0:
+            raise ValueError("Black-Scholes volatility sig must be positive")
+
+    def _validate_payoff_contract(self) -> None:
+        if not hasattr(self.payoff, "k"):
+            raise ValueError("Black-Scholes FD reference payoff must expose strike k")
+        if not np.isfinite(float(self.payoff.k)) or float(self.payoff.k) <= 0.0:
+            raise ValueError("Black-Scholes FD reference strike k must be finite and positive")
+        method = "call_payoff" if self.is_call else "put_payoff"
+        if not callable(getattr(self.payoff, method, None)):
+            raise ValueError(f"Black-Scholes FD reference payoff must define {method}")
+
     def _assemble_operator(self) -> None:
-        """Assemble the spatial differential operator matrix ``L``."""
-        sig = self.dynamics.sig
-        r = self.dynamics.r
-        q = self.dynamics.q
-        s = self.s_grid
+        """Assemble the spatial operator ``L`` using central differences.
 
-        d1 = FinDiff(0, self.ds, 1, acc=2).matrix((self.N,))
-        d2 = FinDiff(0, self.ds, 2, acc=2).matrix((self.N,))
+        ``L`` represents
 
-        S = sps.diags(s)
-        S2 = sps.diags(s ** 2)
+        ``0.5 σ² S² V_SS + (r-q) S V_S - r V``
 
-        self.L = (
-            0.5 * sig**2 * S2 @ d2
-            + (r - q) * S @ d1
-            - r * self.I
-        ).tocsr()
+        on interior grid nodes.  Boundary rows are left as zero rows because
+        endpoint values are supplied through explicit Dirichlet elimination.
+        """
+        sigma = float(self.dynamics.sig)
+        rate = float(self.dynamics.r)
+        carry = float(self.dynamics.q)
+        ds = self.ds
+        lower = np.zeros(self.N, dtype=float)
+        diag = np.zeros(self.N, dtype=float)
+        upper = np.zeros(self.N, dtype=float)
+
+        for i in range(1, self.N - 1):
+            spot = self.s_grid[i]
+            diffusion = 0.5 * sigma * sigma * spot * spot
+            drift = (rate - carry) * spot
+            lower[i] = diffusion / ds**2 - drift / (2.0 * ds)
+            diag[i] = -2.0 * diffusion / ds**2 - rate
+            upper[i] = diffusion / ds**2 + drift / (2.0 * ds)
+
+        self.L = sps.diags(
+            diagonals=[lower[1:], diag, upper[:-1]],
+            offsets=[-1, 0, 1],
+            shape=(self.N, self.N),
+            format="csr",
+        )
 
     # ------------------------------------------------------------------
     def initial_condition(self) -> np.ndarray:
-        """Project the terminal payoff onto ``s_grid``.
+        """Evaluate the terminal payoff on ``s_grid``.
 
-        The implementation tries a vectorized payoff evaluation first, then falls
-        back to scalar evaluation for custom payoff objects that do not support
-        batched array inputs.
+        NumPy-aware payoff functions may return the full grid at once.  A scalar
+        fallback is allowed only for explicit scalar-only type errors or the
+        standard NumPy "ambiguous truth value" error.  Domain/value errors raised
+        by vectorized payoff code propagate instead of being hidden.
         """
 
-        if self.is_call:
-            payoff_fn = getattr(self.payoff, "call_payoff")
-        else:
-            payoff_fn = getattr(self.payoff, "put_payoff")
+        payoff_fn = getattr(self.payoff, "call_payoff" if self.is_call else "put_payoff")
         return _evaluate_payoff_grid(payoff_fn, self.s_grid)
 
     def matrices(self, theta: float, dt: float) -> tuple[sps.csr_matrix, sps.csr_matrix]:
-        """Return system matrices for the θ-scheme."""
-        A = self.I - theta * dt * self.L
-        B = self.I + (1 - theta) * dt * self.L
-        return A.tocsr(), B.tocsr()
+        """Return system matrices for the theta-scheme."""
+        theta = float(theta)
+        dt = float(dt)
+        if not np.isfinite(theta) or theta < 0.0 or theta > 1.0:
+            raise ValueError("theta must lie in [0, 1]")
+        if not np.isfinite(dt) or dt <= 0.0:
+            raise ValueError("dt must be finite and positive")
+        a_matrix = self.I - theta * dt * self.L
+        b_matrix = self.I + (1.0 - theta) * dt * self.L
+        return a_matrix.tocsr(), b_matrix.tocsr()
 
     def boundary_term(self, th: float) -> np.ndarray:  # pragma: no cover - no natural BC
-        """Return natural boundary vector (unused for Black–Scholes)."""
+        """Return natural boundary vector (unused for Black-Scholes)."""
         return np.zeros(self.N)
 
     def dirichlet(self, th: float) -> np.ndarray:
-        """Return Dirichlet boundary values at time ``th``."""
+        """Return endpoint Dirichlet values at time-to-maturity ``th``.
+
+        ``th`` is the forward transformed time ``tau = T - t``.  The high-call
+        boundary uses the affine Black-Scholes far-field
+        ``S_max exp(-q tau) - K exp(-r tau)``; the low-put boundary uses
+        ``K exp(-r tau)``.
+        """
+        tau = float(th)
+        if not np.isfinite(tau) or tau < 0.0:
+            raise ValueError("Dirichlet time-to-maturity th must be finite and non-negative")
+        strike = float(self.payoff.k)
+        rate = float(self.dynamics.r)
+        carry = float(self.dynamics.q)
+        values = np.zeros(self.N, dtype=float)
         if self.is_call:
-            left = 0.0
-            right = self.s_grid[-1] - self.payoff.k * np.exp(-self.dynamics.r * th)
-        else:  # put option
-            left = self.payoff.k * np.exp(-self.dynamics.r * th)
-            right = 0.0
-        u = np.zeros(self.N)
-        u[0] = left
-        u[-1] = right
-        return u
+            values[0] = 0.0
+            values[-1] = self.s_grid[-1] * np.exp(-carry * tau) - strike * np.exp(-rate * tau)
+        else:
+            values[0] = strike * np.exp(-rate * tau)
+            values[-1] = 0.0
+        return values
 
     def apply_dirichlet(self, A, b, _, u_dirichlet):
-        """Apply Dirichlet boundary conditions to ``A`` and ``b``."""
-        A = A.tolil()
-        b = b.copy()
-        A[0, :] = 0.0
-        A[0, 0] = 1.0
-        A[-1, :] = 0.0
-        A[-1, -1] = 1.0
-        b[0] = u_dirichlet[0]
-        b[-1] = u_dirichlet[-1]
-        return A.tocsr(), b
+        """Apply endpoint Dirichlet conditions by algebraic elimination.
+
+        Boundary columns are removed from interior equations and their known
+        values are subtracted from the right-hand side.  Boundary rows are then
+        replaced by identity equations.  This form makes the correction explicit
+        for tests and keeps the matrix invariant across time steps.
+        """
+        matrix = A.tolil(copy=True)
+        rhs = np.asarray(b, dtype=float).copy()
+        u = np.asarray(u_dirichlet, dtype=float)
+        if u.shape != (self.N,):
+            raise ValueError("u_dirichlet must have the same length as s_grid")
+
+        for index in (0, self.N - 1):
+            column = np.asarray(matrix[:, index].toarray()).ravel()
+            rhs -= column * u[index]
+
+        for index in (0, self.N - 1):
+            matrix[:, index] = 0.0
+            matrix[index, :] = 0.0
+            matrix[index, index] = 1.0
+            rhs[index] = u[index]
+
+        return matrix.tocsr(), rhs
 
 
 # ----------------------------------------------------------------------
@@ -132,35 +198,47 @@ class FDSolver:
 
 def delta(v: np.ndarray, ds: float) -> np.ndarray:
     """Compute Delta from a one-dimensional price grid ``v``."""
-    return FinDiff(0, ds, 1, acc=2)(v)
+    values = _validate_1d_values(v, "delta")
+    return np.gradient(values, _validate_spacing(ds), edge_order=2)
 
 
 def gamma(v: np.ndarray, ds: float) -> np.ndarray:
     """Compute Gamma from a one-dimensional price grid ``v``."""
-    return FinDiff(0, ds, 2, acc=2)(v)
+    values = _validate_1d_values(v, "gamma")
+    spacing = _validate_spacing(ds)
+    return np.gradient(np.gradient(values, spacing, edge_order=2), spacing, edge_order=2)
 
 
 def vega(v: np.ndarray, dv: float) -> np.ndarray:
-    """Compute Vega from a two-dimensional grid ``v`` (axis 1 is volatility)."""
-    return FinDiff(1, dv, 1, acc=2)(v)
+    """Compute Vega only when an explicit volatility axis is present."""
+    values = np.asarray(v, dtype=float)
+    if values.ndim != 2:
+        raise ValueError("vega requires a two-dimensional grid with an explicit volatility axis")
+    return np.gradient(values, _validate_spacing(dv), axis=1, edge_order=2)
 
 
 def _evaluate_payoff_grid(
     payoff_fn: Callable[[object], object], s_grid: np.ndarray
 ) -> np.ndarray:
-    """Evaluate payoff methods on a grid with scalar fallback.
-
-    Payoff objects own the intrinsic-value semantics.  The vectorized path is
-    attempted first for NumPy-aware implementations; scalar fallback preserves
-    custom Python payoffs that reject array truth values with ``TypeError`` or
-    ``ValueError``.
-    """
+    """Evaluate payoff methods on a grid with a narrow scalar fallback."""
 
     try:
         values = payoff_fn(s_grid)
-    except (TypeError, ValueError):
+    except TypeError:
         values = [payoff_fn(float(s)) for s in s_grid]
-    return np.asarray(values, dtype=float)
+    except ValueError as exc:
+        message = str(exc).lower()
+        if "truth value" not in message or "ambiguous" not in message:
+            raise
+        values = [payoff_fn(float(s)) for s in s_grid]
+    result = np.asarray(values, dtype=float)
+    if result.shape != s_grid.shape:
+        raise ValueError(
+            f"payoff evaluation returned shape {result.shape}, expected {s_grid.shape}"
+        )
+    if not np.all(np.isfinite(result)):
+        raise ValueError("payoff evaluation must return finite values")
+    return result
 
 
 # ----------------------------------------------------------------------
@@ -174,25 +252,102 @@ def solve_system(
     is_call: bool = True,
     theta: float = 0.5,
 ) -> DataArray:
-    """Solve the Black–Scholes PDE on a regular grid.
+    """Solve the Black-Scholes PDE on validated uniform grids.
 
-    Returns an :class:`xarray.DataArray` whose dimensions are ``time`` and
-    ``space``.  The function mirrors the high-level interface of the finite
-    element solver while providing labelled coordinates for post-processing.
+    ``t`` is a forward transformed time-to-maturity grid ``tau`` with ``t[0]=0``
+    at terminal payoff and ``t[-1]`` at valuation horizon.  The returned
+    :class:`xarray.DataArray` has dimensions ``time`` and ``space`` plus attrs
+    documenting the reference route, grid/time semantics and linear residuals.
     """
 
     solver = FDSolver(s_grid, dynamics, payoff, is_call=is_call)
-    t = np.asarray(list(t))
-    dt = t[1] - t[0]
-    A, B = solver.matrices(theta, dt)
+    tau_grid = _validate_uniform_time_grid(t)
+    dt = float(tau_grid[1] - tau_grid[0])
+    a_matrix, b_matrix = solver.matrices(theta, dt)
 
-    v = np.empty((len(t), solver.N))
-    v[0] = solver.initial_condition()
+    values = np.empty((len(tau_grid), solver.N), dtype=float)
+    values[0] = solver.initial_condition()
+    max_residual = 0.0
+    factorized_solver = None
 
-    for i, th in enumerate(t[:-1]):
-        b = B @ v[i]
-        u_d = solver.dirichlet(th + dt)
-        A_enf, b_enf = solver.apply_dirichlet(A, b, [], u_d)
-        v[i + 1] = spsolve(A_enf, b_enf)
+    for i, tau_prev in enumerate(tau_grid[:-1]):
+        tau_next = float(tau_grid[i + 1])
+        rhs = b_matrix @ values[i]
+        u_d = solver.dirichlet(tau_next)
+        enforced_matrix, enforced_rhs = solver.apply_dirichlet(a_matrix, rhs, [], u_d)
+        if factorized_solver is None:
+            factorized_solver = spla.factorized(enforced_matrix.tocsc())
+        next_values = factorized_solver(enforced_rhs)
+        residual = enforced_matrix @ next_values - enforced_rhs
+        max_residual = max(max_residual, float(np.max(np.abs(residual))))
+        values[i + 1] = next_values
 
-    return snapshot(v, t, solver.s_grid)
+    result = snapshot(values, tau_grid, solver.s_grid)
+    result.attrs.update(
+        {
+            "fd_backend": "black_scholes_uniform_1d",
+            "time_orientation": "tau_time_to_maturity_forward",
+            "coordinate_units": {"time": "year", "space": "spot"},
+            "theta": float(theta),
+            "dt": dt,
+            "space_step": solver.ds,
+            "spot_grid_uniform": True,
+            "time_grid_uniform": True,
+            "time_step_count": len(tau_grid) - 1,
+            "factorization_reuse_count": len(tau_grid) - 1,
+            "max_linear_residual_abs": max_residual,
+            "convergence_status": "solved",
+            "boundary_condition": "endpoint_dirichlet_elimination",
+            "left_boundary_tau0": float(solver.dirichlet(0.0)[0]),
+            "right_boundary_final_tau": float(solver.dirichlet(tau_grid[-1])[-1]),
+        }
+    )
+    return result
+
+
+def _validate_uniform_spot_grid(s_grid: Iterable[float]) -> np.ndarray:
+    grid = np.asarray(list(s_grid), dtype=float)
+    if grid.ndim != 1 or len(grid) < 3:
+        raise ValueError("s_grid must be one-dimensional with at least three nodes")
+    if not np.all(np.isfinite(grid)):
+        raise ValueError("s_grid entries must be finite")
+    if grid[0] < 0.0:
+        raise ValueError("s_grid lower boundary must be non-negative")
+    diffs = np.diff(grid)
+    if np.any(diffs <= 0.0):
+        raise ValueError("s_grid must be strictly increasing")
+    if not np.allclose(diffs, diffs[0], rtol=_GRID_RTOL, atol=_GRID_ATOL):
+        raise ValueError("s_grid must be uniform for the Black-Scholes FD reference backend")
+    return grid
+
+
+def _validate_uniform_time_grid(t: Iterable[float]) -> np.ndarray:
+    grid = np.asarray(list(t), dtype=float)
+    if grid.ndim != 1 or len(grid) < 2:
+        raise ValueError("time grid must be one-dimensional with at least two nodes")
+    if not np.all(np.isfinite(grid)):
+        raise ValueError("time grid entries must be finite")
+    if not np.isclose(grid[0], 0.0, rtol=0.0, atol=_GRID_ATOL):
+        raise ValueError("time grid must start at zero time-to-maturity")
+    diffs = np.diff(grid)
+    if np.any(diffs <= 0.0):
+        raise ValueError("time grid must be strictly increasing")
+    if not np.allclose(diffs, diffs[0], rtol=_GRID_RTOL, atol=_GRID_ATOL):
+        raise ValueError("time grid must be uniform for cached reference factorization")
+    return grid
+
+
+def _validate_spacing(spacing: float) -> float:
+    value = float(spacing)
+    if not np.isfinite(value) or value <= 0.0:
+        raise ValueError("finite-difference spacing must be finite and positive")
+    return value
+
+
+def _validate_1d_values(values: np.ndarray, name: str) -> np.ndarray:
+    array = np.asarray(values, dtype=float)
+    if array.ndim != 1 or len(array) < 3:
+        raise ValueError(f"{name} requires a one-dimensional grid with at least three values")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} input values must be finite")
+    return array

--- a/src/finite_element_options/fdsolver.py
+++ b/src/finite_element_options/fdsolver.py
@@ -148,7 +148,8 @@ class FDSolver:
 
         ``th`` is the forward transformed time ``tau = T - t``.  The high-call
         boundary uses the affine Black-Scholes far-field
-        ``S_max exp(-q tau) - K exp(-r tau)``; the low-put boundary uses
+        ``S_max exp(-q tau) - K exp(-r tau)`` clamped at zero for finite
+        boundary/no-arbitrage safety; the low-put boundary uses
         ``K exp(-r tau)``.
         """
         tau = float(th)
@@ -160,7 +161,10 @@ class FDSolver:
         values = np.zeros(self.N, dtype=float)
         if self.is_call:
             values[0] = 0.0
-            values[-1] = self.s_grid[-1] * np.exp(-carry * tau) - strike * np.exp(-rate * tau)
+            values[-1] = max(
+                self.s_grid[-1] * np.exp(-carry * tau) - strike * np.exp(-rate * tau),
+                0.0,
+            )
         else:
             values[0] = strike * np.exp(-rate * tau)
             values[-1] = 0.0

--- a/tests/test_fd_black_scholes.py
+++ b/tests/test_fd_black_scholes.py
@@ -79,10 +79,10 @@ class _ScalarOnlyPayoffWithStrike:
 
 def test_fd_solver_initial_condition_honors_custom_payoff_semantics():
     dh = DynamicsParametersBlackScholes(r=0.03, q=0.0, sig=0.2)
-    s_grid = np.array([0.0, 1.0, 1.5, 2.0], dtype=float)
+    s_grid = np.array([0.0, 0.5, 1.0, 1.5], dtype=float)
     solver = FDSolver(s_grid, dh, _CappedPayoffWithStrike(), is_call=True)
 
-    np.testing.assert_allclose(solver.initial_condition(), [0.0, 0.0, 0.25, 0.25])
+    np.testing.assert_allclose(solver.initial_condition(), [0.0, 0.0, 0.0, 0.25])
 
 
 def test_fd_solver_initial_condition_falls_back_for_scalar_only_payoffs():

--- a/tests/test_fd_reference_backend_contract.py
+++ b/tests/test_fd_reference_backend_contract.py
@@ -1,0 +1,179 @@
+"""Regression tests for the Black-Scholes finite-difference reference backend.
+
+Issue #51 narrows this backend to a small, independently auditable 1D
+Black-Scholes oracle.  These tests guard the route gates, boundary algebra, time
+semantics, payoff evaluation, and result diagnostics required before FEM parity
+uses it as evidence.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import scipy.sparse as sps
+
+from finite_element_options.core.dynamics_black_scholes import DynamicsParametersBlackScholes
+from finite_element_options.core.market import Market
+from finite_element_options.core.vanilla_bs import EuropeanOptionBs
+from finite_element_options.fdsolver import FDSolver, solve_system, vega
+
+
+def _model(rate: float = 0.03, carry: float = 0.01, sigma: float = 0.2):
+    dynamics = DynamicsParametersBlackScholes(r=rate, q=carry, sig=sigma)
+    option = EuropeanOptionBs(k=1.0, q=dynamics.q, mkt=Market(r=dynamics.r))
+    return dynamics, option
+
+
+@pytest.mark.parametrize(
+    "grid, message",
+    [
+        (np.array([0.0, 1.0]), "at least three"),
+        (np.array([-0.1, 0.0, 0.1, 0.2]), "non-negative"),
+        (np.array([0.0, 1.0, 0.5, 2.0]), "strictly increasing"),
+        (np.array([0.0, 0.5, np.nan, 1.5]), "finite"),
+        (np.array([0.0, 0.5, 1.4, 2.0]), "uniform"),
+    ],
+)
+def test_fd_reference_rejects_invalid_or_nonuniform_spot_grids(grid, message) -> None:
+    dynamics, option = _model()
+
+    with pytest.raises(ValueError, match=message):
+        FDSolver(grid, dynamics, option, is_call=True)
+
+
+@pytest.mark.parametrize(
+    "time_grid, message",
+    [
+        ([0.0], "at least two"),
+        ([0.0, 0.25, np.nan], "finite"),
+        ([0.0, 0.5, 0.4], "strictly increasing"),
+        ([0.0, 0.25, 0.75, 1.0], "uniform"),
+    ],
+)
+def test_solve_system_rejects_invalid_or_nonuniform_time_grids(time_grid, message) -> None:
+    dynamics, option = _model()
+    s_grid = np.linspace(0.0, 2.0, 41)
+
+    with pytest.raises(ValueError, match=message):
+        solve_system(s_grid, time_grid, dynamics, option, is_call=True)
+
+
+def test_fd_reference_call_boundary_includes_dividend_carry() -> None:
+    dynamics, option = _model(rate=0.05, carry=0.02)
+    s_grid = np.linspace(0.0, 3.0, 61)
+    solver = FDSolver(s_grid, dynamics, option, is_call=True)
+    tau = 0.75
+
+    boundary = solver.dirichlet(tau)
+
+    assert boundary[0] == 0.0
+    assert boundary[-1] == pytest.approx(
+        s_grid[-1] * np.exp(-dynamics.q * tau) - option.k * np.exp(-dynamics.r * tau)
+    )
+
+
+def test_dirichlet_elimination_adjusts_interior_rhs_and_zeroes_boundary_columns() -> None:
+    dynamics, option = _model(rate=0.05, carry=0.02)
+    solver = FDSolver(np.linspace(0.0, 2.0, 5), dynamics, option, is_call=True)
+    matrix = sps.csr_matrix(
+        np.array(
+            [
+                [10.0, 2.0, 0.0, 0.0, 0.0],
+                [3.0, 11.0, 4.0, 0.0, 5.0],
+                [0.0, 6.0, 12.0, 7.0, 0.0],
+                [8.0, 0.0, 9.0, 13.0, 10.0],
+                [0.0, 0.0, 0.0, 14.0, 15.0],
+            ]
+        )
+    )
+    rhs = np.array([1.0, 20.0, 30.0, 40.0, 50.0])
+    boundary = np.array([2.0, 0.0, 0.0, 0.0, 3.0])
+
+    enforced, adjusted = solver.apply_dirichlet(matrix, rhs, [], boundary)
+    dense = enforced.toarray()
+
+    assert adjusted[1] == pytest.approx(20.0 - 3.0 * 2.0 - 5.0 * 3.0)
+    assert adjusted[3] == pytest.approx(40.0 - 8.0 * 2.0 - 10.0 * 3.0)
+    assert dense[1, 0] == dense[1, -1] == 0.0
+    assert dense[3, 0] == dense[3, -1] == 0.0
+    assert dense[0, 0] == dense[-1, -1] == 1.0
+    assert adjusted[0] == 2.0
+    assert adjusted[-1] == 3.0
+
+
+class _BrokenVectorizedPayoff:
+    k = 1.0
+
+    def call_payoff(self, s):
+        if isinstance(s, np.ndarray):
+            raise ValueError("negative spot domain bug should propagate")
+        return max(s - self.k, 0.0)
+
+    def put_payoff(self, s):
+        return max(self.k - s, 0.0)
+
+
+class _ScalarOnlyPayoff:
+    k = 1.0
+
+    def call_payoff(self, s):
+        if isinstance(s, np.ndarray):
+            raise TypeError("scalar only")
+        return max(s - self.k, 0.0)
+
+    def put_payoff(self, s):
+        if isinstance(s, np.ndarray):
+            raise TypeError("scalar only")
+        return max(self.k - s, 0.0)
+
+
+def test_payoff_domain_value_errors_are_not_swallowed_as_scalar_fallback() -> None:
+    dynamics, _ = _model()
+    solver = FDSolver(np.linspace(0.0, 2.0, 5), dynamics, _BrokenVectorizedPayoff(), is_call=True)
+
+    with pytest.raises(ValueError, match="domain bug"):
+        solver.initial_condition()
+
+
+def test_scalar_only_payoff_type_error_still_uses_explicit_scalar_fallback() -> None:
+    dynamics, _ = _model()
+    solver = FDSolver(np.linspace(0.0, 2.0, 5), dynamics, _ScalarOnlyPayoff(), is_call=True)
+
+    np.testing.assert_allclose(solver.initial_condition(), [0.0, 0.0, 0.0, 0.5, 1.0])
+
+
+def test_solve_system_reports_time_orientation_residual_and_factorization_reuse() -> None:
+    dynamics, option = _model(rate=0.03, carry=0.01)
+    s_grid = np.linspace(0.0, 2.0, 81)
+    tau_grid = np.linspace(0.0, 1.0, 41)
+
+    result = solve_system(s_grid, tau_grid, dynamics, option, is_call=True)
+
+    assert result.attrs["fd_backend"] == "black_scholes_uniform_1d"
+    assert result.attrs["time_orientation"] == "tau_time_to_maturity_forward"
+    assert result.attrs["time_step_count"] == len(tau_grid) - 1
+    assert result.attrs["factorization_reuse_count"] == len(tau_grid) - 1
+    assert result.attrs["convergence_status"] == "solved"
+    assert result.attrs["coordinate_units"] == {"time": "year", "space": "spot"}
+    assert result.attrs["max_linear_residual_abs"] < 1.0e-9
+
+
+def test_fd_reference_black_scholes_convergence_improves_with_refinement() -> None:
+    dynamics, option = _model(rate=0.03, carry=0.0)
+    tau = 0.5
+    strike = option.k
+    errors = []
+    for n_space, n_time in [(81, 41), (161, 81)]:
+        s_grid = np.linspace(0.0, 3.0, n_space)
+        tau_grid = np.linspace(0.0, tau, n_time)
+        result = solve_system(s_grid, tau_grid, dynamics, option, is_call=True)
+        numerical = result.sel(time=tau, space=strike, method="nearest").item()
+        exact = option.call(tau, strike, dynamics.sig**2)
+        errors.append(abs(numerical - exact))
+
+    assert errors[1] < 0.75 * errors[0]
+
+
+def test_vega_requires_an_explicit_volatility_axis() -> None:
+    with pytest.raises(ValueError, match="volatility axis"):
+        vega(np.ones(5), 0.1)

--- a/tests/test_fd_reference_backend_contract.py
+++ b/tests/test_fd_reference_backend_contract.py
@@ -72,6 +72,17 @@ def test_fd_reference_call_boundary_includes_dividend_carry() -> None:
     )
 
 
+def test_fd_reference_call_boundary_never_returns_negative_far_field() -> None:
+    dynamics, option = _model(rate=0.03, carry=1.00)
+    s_grid = np.linspace(0.0, 2.0, 41)
+    solver = FDSolver(s_grid, dynamics, option, is_call=True)
+
+    boundary = solver.dirichlet(1.0)
+
+    assert boundary[0] == 0.0
+    assert boundary[-1] == 0.0
+
+
 def test_dirichlet_elimination_adjusts_interior_rhs_and_zeroes_boundary_columns() -> None:
     dynamics, option = _model(rate=0.05, carry=0.02)
     solver = FDSolver(np.linspace(0.0, 2.0, 5), dynamics, option, is_call=True)


### PR DESCRIPTION
## Summary

Closes #51.

Repairs `fdsolver.py` as a deliberately narrow Black-Scholes finite-difference reference oracle rather than an accidental production FD backend:

- validates finite, non-negative, strictly increasing uniform spot grids and uniform forward time-to-maturity grids;
- replaces the broad `except Exception` payoff fallback with a narrow scalar-only fallback while propagating payoff/domain errors;
- uses explicit central-difference tridiagonal Black-Scholes operator assembly;
- applies carry-aware call/put endpoint Dirichlet boundaries and algebraic Dirichlet column/RHS elimination;
- reuses the constant sparse factorization and returns xarray route/time/grid/residual/convergence metadata;
- requires a real volatility axis for `vega`;
- documents the retained FD oracle role in PRD/architecture.

## Verification

- `.venv/bin/python -m pytest -q` -> 92 passed, 2 skipped, 1 warning
- `.venv/bin/python -m ruff check src/finite_element_options/fdsolver.py tests/test_fd_reference_backend_contract.py tests/test_fd_black_scholes.py` -> All checks passed
- `.venv/bin/python -m compileall -q src tests` -> pass
- `python3 /home/cristobal/.hermes/skills/productivity/markdown-rendering-standards/scripts/check_markdown_math_diagrams.py --strict docs/PRD.md docs/ARCHITECTURE.md` -> files=2 errors=0 warnings=0
- `git diff --check` -> pass

## Notes

A stale checkout-root `finite_element_options.egg-info` generated by local build tooling made `importlib.metadata` see empty metadata during one full-test run. I removed generated metadata/build/coverage artifacts and verified the installed `.venv` distribution advertises 49 `Requires-Dist` records including `pandas` under the `fd` extra before rerunning the full suite successfully.
