### PR TITLE
Fix Black-Scholes volatility and variance semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ This reproduces the same call option pricing workflow in a standalone file.
 
 ## Features
 
-- Black-Scholes option pricer with call and put payoffs
+- Black-Scholes option pricer with call/put payoffs, explicit volatility vs. variance APIs, and tested zero-maturity/zero-volatility limits
 - Finite-difference solver on regular grids using ``findiff``
-- Greek estimators (Delta, Gamma, Vega) via finite differences
+- Greek estimators (Delta, Gamma, volatility Vega) via finite differences
 - Experimental JAX-based Greek computation via automatic differentiation
 - Configurable mesh generation supporting 1D, 2D and 3D problems
 - Central ``Config`` dataclass for numerical parameters
@@ -137,7 +137,8 @@ put_fn = Function(put_space.Vh, put_grid[-1])
 put_price = float(put_fn(np.array([[1.0]])))
 
 # 5. Compare numerical results with analytic Greeks for sanity checks
-delta, vega = compute_greeks(
+#    compute_greeks returns Delta and volatility Vega dV/dsigma.
+delta, volatility_vega = compute_greeks(
     s=1.0,
     k=option.k,
     r=market.r,
@@ -146,7 +147,10 @@ delta, vega = compute_greeks(
     t=time_grid[-1],
 )
 
-print(f"European call: price={call_price:.4f}, delta={delta:.4f}, vega={vega:.4f}")
+print(
+    f"European call: price={call_price:.4f}, delta={delta:.4f}, "
+    f"volatility_vega={volatility_vega:.4f}"
+)
 print(f"European put:  price={put_price:.4f}")
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -306,6 +306,8 @@ Sensitivity methods are distinct adapters:
 
 Each result names the differentiated parameter/state coordinate, units, evaluation point, method, smoothing policy and error evidence. Nonsmooth payoff behavior is explicitly tested rather than hidden by optimistic tolerances.
 
+The Black-Scholes analytical oracle distinguishes volatility `sigma` from variance `sigma**2` at the API boundary. Legacy variance-based `call`/`put` methods are compatibility wrappers; new code uses `*_from_volatility` or `*_from_variance`. Volatility Vega (`dV/dsigma`) and variance sensitivity (`dV/d(sigma**2)`) are not interchangeable; the variance route raises at zero variance where the chain-rule sensitivity is singular. Expiry, deterministic zero-volatility, zero-spot and invalid-input branches are explicit tests rather than implicit division-by-zero behavior.
+
 ## 16. Backend plugin architecture
 
 Candidate entry point:

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -144,6 +144,8 @@ The public result must identify:
 
 Finite-difference, adjoint and automatic-differentiation routes remain distinct capabilities. JAX support is optional and cannot make JAX a mandatory core dependency.
 
+Black-Scholes analytical-oracle APIs must name whether an input is volatility `sigma` or variance `sigma**2`. Volatility Vega `dV/dsigma` and variance sensitivity `dV/d(sigma**2)` are separate quantities connected by the chain rule only when variance is strictly positive. Zero-maturity, zero-volatility, zero-spot and invalid-input limiting cases are part of the public numerical contract.
+
 ### FR-FEM-010 — Numerical validation
 
 The repository must maintain method-specific tests for:

--- a/src/finite_element_options/core/interfaces.py
+++ b/src/finite_element_options/core/interfaces.py
@@ -3,30 +3,36 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Iterable, Protocol
+from typing import Iterable, Protocol, TypeAlias
 import numpy as np
 import skfem as fem
 import scipy.sparse as sps
+
+ArrayLikeFloat: TypeAlias = float | np.ndarray
 
 
 class Payoff(ABC):
     """Payoff contract for option instruments."""
 
     @abstractmethod
-    def call_payoff(self, s: float) -> float:
+    def call_payoff(self, s: ArrayLikeFloat) -> ArrayLikeFloat:
         """Return intrinsic value of a call option at spot ``s``."""
 
     @abstractmethod
-    def put_payoff(self, s: float) -> float:
+    def put_payoff(self, s: ArrayLikeFloat) -> ArrayLikeFloat:
         """Return intrinsic value of a put option at spot ``s``."""
 
     @abstractmethod
-    def call(self, th: float, s: float, v: float) -> float:
-        """Return price of the call option."""
+    def call(
+        self, th: float, s: ArrayLikeFloat, variance: ArrayLikeFloat
+    ) -> ArrayLikeFloat:
+        """Return call price from variance ``sigma**2``."""
 
     @abstractmethod
-    def put(self, th: float, s: float, v: float) -> float:
-        """Return price of the put option."""
+    def put(
+        self, th: float, s: ArrayLikeFloat, variance: ArrayLikeFloat
+    ) -> ArrayLikeFloat:
+        """Return put price from variance ``sigma**2``."""
 
 
 class DynamicsModel(Protocol):
@@ -67,7 +73,9 @@ class SpaceDiscretization(Protocol):
     def initial_condition(self) -> np.ndarray:
         """Return the initial condition projected on the space."""
 
-    def matrices(self, theta: float, dt: float) -> tuple[sps.csr_matrix, sps.csr_matrix]:
+    def matrices(
+        self, theta: float, dt: float
+    ) -> tuple[sps.csr_matrix, sps.csr_matrix]:
         """Return system matrices for the θ-scheme."""
 
     def boundary_term(self, th: float) -> np.ndarray:

--- a/src/finite_element_options/core/vanilla_bs.py
+++ b/src/finite_element_options/core/vanilla_bs.py
@@ -1,12 +1,45 @@
-"""Black-Scholes vanilla option pricing utilities."""
+"""Black-Scholes vanilla option pricing utilities.
+
+The public analytical oracle is explicit about the stochastic variable used at
+its boundary: option prices can be requested from either volatility ``sigma`` or
+variance ``sigma**2``. Greeks name the differentiated variable so FEM/FD
+benchmarks cannot compare volatility vega against variance sensitivity by
+accident.
+"""
 
 from dataclasses import dataclass
+from typing import Any
 
 import numpy as np
-import scipy.stats as spst
+from scipy import special
 
-from .market import Market
 from .interfaces import Payoff
+from .market import Market
+
+_NEAR_ZERO_STD = 1.0e-12
+_KINK_ATOL_SCALE = 1.0e-14
+
+
+def _as_float_array(name: str, value: Any) -> np.ndarray:
+    array = np.asarray(value, dtype=float)
+    if np.any(~np.isfinite(array)):
+        raise ValueError(f"{name} must be finite")
+    return array
+
+
+def _is_scalar_input(*values: Any) -> bool:
+    return all(np.asarray(value).ndim == 0 for value in values)
+
+
+def _as_output(value: np.ndarray, *, scalar: bool = False) -> float | np.ndarray:
+    array = np.asarray(value, dtype=float)
+    if scalar:
+        return float(array.reshape(-1)[0])
+    return array
+
+
+def _normal_pdf(x: np.ndarray) -> np.ndarray:
+    return np.exp(-0.5 * np.square(x)) / np.sqrt(2.0 * np.pi)
 
 
 @dataclass(frozen=True)
@@ -14,13 +47,24 @@ class EuropeanOptionBs(Payoff):
     """European option priced with the Black-Scholes model.
 
     Parameters are stored as attributes via ``dataclass`` which promotes a more
-    declarative and immutable design.  All computations are performed through
-    instance methods operating solely on the provided state and arguments.
+    declarative and immutable design.  Price APIs are explicit about whether the
+    stochastic input is volatility or variance; legacy ``call``/``put`` methods
+    remain variance-based for compatibility with existing solver tests.
     """
 
     k: float
     q: float
     mkt: Market
+
+    def __post_init__(self) -> None:
+        """Validate immutable Black-Scholes oracle parameters."""
+
+        if not np.isfinite(self.k) or self.k <= 0.0:
+            raise ValueError("strike k must be finite and positive")
+        if not np.isfinite(self.q):
+            raise ValueError("dividend/carry rate q must be finite")
+        if not np.isfinite(self.mkt.r):
+            raise ValueError("market rate r must be finite")
 
     @property
     def r(self) -> float:
@@ -31,67 +75,360 @@ class EuropeanOptionBs(Payoff):
     def dividend_discount(self, th: float) -> float:
         """Dividend discount factor ``exp(-q * th)``."""
 
-        return np.exp(-self.q * th)
+        maturity = self._validate_maturity(th)
+        return np.exp(-self.q * maturity)
 
-    def forward_price(self, th: float, s: float) -> float:
+    def forward_price(self, th: float, s: float | np.ndarray) -> float | np.ndarray:
         """Forward price of the underlying asset."""
 
-        return s * self.dividend_discount(th) / self.mkt.discount_factor(th)
+        maturity = self._validate_maturity(th)
+        spot = self._validate_spot(s)
+        forward = (
+            spot * self.dividend_discount(maturity) / self.mkt.discount_factor(maturity)
+        )
+        return _as_output(forward, scalar=_is_scalar_input(s))
 
-    def d1(self, th: float, s: float, v: float) -> float:
-        """Black-Scholes ``d1`` auxiliary term."""
+    def d1(
+        self, th: float, s: float | np.ndarray, variance: float | np.ndarray
+    ) -> float | np.ndarray:
+        """Black-Scholes ``d1`` for strictly positive variance and maturity."""
 
-        return (
-            np.log(self.forward_price(th, s) / self.k) + v / 2 * th
-        ) / (v * th) ** 0.5
+        maturity = self._validate_maturity(th)
+        variance_array = self._validate_variance(variance)
+        if maturity <= 0.0 or np.any(variance_array <= 0.0):
+            raise ValueError("d1 requires positive maturity and positive variance")
+        spot, variance_b = np.broadcast_arrays(self._validate_spot(s), variance_array)
+        volatility = np.sqrt(variance_b)
+        d1, _ = self._d_terms(maturity, spot, volatility)
+        return _as_output(d1, scalar=_is_scalar_input(s, variance))
 
-    def d2(self, th: float, s: float, v: float) -> float:
-        """Black-Scholes ``d2`` auxiliary term."""
+    def d2(
+        self, th: float, s: float | np.ndarray, variance: float | np.ndarray
+    ) -> float | np.ndarray:
+        """Black-Scholes ``d2`` for strictly positive variance and maturity."""
 
-        return self.d1(th, s, v) - (v * th) ** 0.5
+        maturity = self._validate_maturity(th)
+        variance_array = self._validate_variance(variance)
+        if maturity <= 0.0 or np.any(variance_array <= 0.0):
+            raise ValueError("d2 requires positive maturity and positive variance")
+        spot, variance_b = np.broadcast_arrays(self._validate_spot(s), variance_array)
+        volatility = np.sqrt(variance_b)
+        _, d2 = self._d_terms(maturity, spot, volatility)
+        return _as_output(d2, scalar=_is_scalar_input(s, variance))
 
-    def call(self, th: float, s: float, v: float) -> float:
-        """Price of the European call option."""
+    def call_from_volatility(
+        self, th: float, s: float | np.ndarray, volatility: float | np.ndarray
+    ) -> float | np.ndarray:
+        """Price a European call from volatility ``sigma``."""
 
-        n1 = spst.norm.cdf(self.d1(th, s, v))
-        n2 = spst.norm.cdf(self.d2(th, s, v))
-        return self.mkt.discount_factor(th) * (
-            self.forward_price(th, s) * n1 - self.k * n2
+        return _as_output(
+            self._price_from_volatility(th, s, volatility, is_call=True),
+            scalar=_is_scalar_input(s, volatility),
         )
 
-    def call_payoff(self, s: float) -> float:
+    def call_from_variance(
+        self, th: float, s: float | np.ndarray, variance: float | np.ndarray
+    ) -> float | np.ndarray:
+        """Price a European call from variance ``sigma**2``."""
+
+        return self.call_from_volatility(
+            th, s, np.sqrt(self._validate_variance(variance))
+        )
+
+    def call(
+        self, th: float, s: float | np.ndarray, variance: float | np.ndarray
+    ) -> float | np.ndarray:
+        """Compatibility wrapper: call price from variance ``sigma**2``."""
+
+        return self.call_from_variance(th, s, variance)
+
+    def call_payoff(self, s: float | np.ndarray) -> float | np.ndarray:
         """Intrinsic value of a call option at spot price ``s``."""
 
-        return np.maximum(0.0, s - self.k)
-
-    def call_delta(self, th: float, s: float, v: float) -> float:
-        """Delta of the call option."""
-
-        n1 = spst.norm.cdf(self.d1(th, s, v))
-        return self.dividend_discount(th) * n1
-
-    def put(self, th: float, s: float, v: float) -> float:
-        """Price of the European put option."""
-
-        n1 = spst.norm.cdf(-self.d1(th, s, v))
-        n2 = spst.norm.cdf(-self.d2(th, s, v))
-        return self.mkt.discount_factor(th) * (
-            self.k * n2 - self.forward_price(th, s) * n1
+        return _as_output(
+            np.maximum(0.0, self._validate_spot(s) - self.k),
+            scalar=_is_scalar_input(s),
         )
 
-    def put_payoff(self, s: float) -> float:
+    def call_delta_from_volatility(
+        self, th: float, s: float | np.ndarray, volatility: float | np.ndarray
+    ) -> float | np.ndarray:
+        """Spot delta of a European call from volatility ``sigma``."""
+
+        return _as_output(
+            self._delta_from_volatility(th, s, volatility, is_call=True),
+            scalar=_is_scalar_input(s, volatility),
+        )
+
+    def call_delta_from_variance(
+        self, th: float, s: float | np.ndarray, variance: float | np.ndarray
+    ) -> float | np.ndarray:
+        """Spot delta of a European call from variance ``sigma**2``."""
+
+        return self.call_delta_from_volatility(
+            th, s, np.sqrt(self._validate_variance(variance))
+        )
+
+    def call_delta(
+        self, th: float, s: float | np.ndarray, variance: float | np.ndarray
+    ) -> float | np.ndarray:
+        """Compatibility wrapper: call spot delta from variance ``sigma**2``."""
+
+        return self.call_delta_from_variance(th, s, variance)
+
+    def put_from_volatility(
+        self, th: float, s: float | np.ndarray, volatility: float | np.ndarray
+    ) -> float | np.ndarray:
+        """Price a European put from volatility ``sigma``."""
+
+        return _as_output(
+            self._price_from_volatility(th, s, volatility, is_call=False),
+            scalar=_is_scalar_input(s, volatility),
+        )
+
+    def put_from_variance(
+        self, th: float, s: float | np.ndarray, variance: float | np.ndarray
+    ) -> float | np.ndarray:
+        """Price a European put from variance ``sigma**2``."""
+
+        return self.put_from_volatility(
+            th, s, np.sqrt(self._validate_variance(variance))
+        )
+
+    def put(
+        self, th: float, s: float | np.ndarray, variance: float | np.ndarray
+    ) -> float | np.ndarray:
+        """Compatibility wrapper: put price from variance ``sigma**2``."""
+
+        return self.put_from_variance(th, s, variance)
+
+    def put_payoff(self, s: float | np.ndarray) -> float | np.ndarray:
         """Intrinsic value of a put option at spot price ``s``."""
 
-        return np.maximum(0.0, self.k - s)
+        return _as_output(
+            np.maximum(0.0, self.k - self._validate_spot(s)),
+            scalar=_is_scalar_input(s),
+        )
 
-    def put_delta(self, th: float, s: float, v: float) -> float:
-        """Delta of the put option."""
+    def put_delta_from_volatility(
+        self, th: float, s: float | np.ndarray, volatility: float | np.ndarray
+    ) -> float | np.ndarray:
+        """Spot delta of a European put from volatility ``sigma``."""
 
-        n1 = spst.norm.cdf(-self.d1(th, s, v))
-        return -self.dividend_discount(th) * n1
+        return _as_output(
+            self._delta_from_volatility(th, s, volatility, is_call=False),
+            scalar=_is_scalar_input(s, volatility),
+        )
 
-    def vega(self, th: float, s: float, v: float) -> float:
-        """Vega of the option."""
+    def put_delta_from_variance(
+        self, th: float, s: float | np.ndarray, variance: float | np.ndarray
+    ) -> float | np.ndarray:
+        """Spot delta of a European put from variance ``sigma**2``."""
 
-        dn2 = spst.norm.pdf(self.d2(th, s, v))
-        return self.k * self.mkt.discount_factor(th) * dn2 * th ** 0.5
+        return self.put_delta_from_volatility(
+            th, s, np.sqrt(self._validate_variance(variance))
+        )
+
+    def put_delta(
+        self, th: float, s: float | np.ndarray, variance: float | np.ndarray
+    ) -> float | np.ndarray:
+        """Compatibility wrapper: put spot delta from variance ``sigma**2``."""
+
+        return self.put_delta_from_variance(th, s, variance)
+
+    def vega_volatility(
+        self, th: float, s: float | np.ndarray, volatility: float | np.ndarray
+    ) -> float | np.ndarray:
+        """Derivative of option value with respect to volatility ``sigma``."""
+
+        maturity = self._validate_maturity(th)
+        spot, sigma = np.broadcast_arrays(
+            self._validate_spot(s), self._validate_volatility(volatility)
+        )
+        spot = np.atleast_1d(spot)
+        sigma = np.atleast_1d(sigma)
+        result = np.zeros_like(spot, dtype=float)
+        if maturity == 0.0:
+            return _as_output(result, scalar=_is_scalar_input(s, volatility))
+
+        total_std = sigma * np.sqrt(maturity)
+        regular = (total_std > _NEAR_ZERO_STD) & (spot > 0.0)
+        if np.any(regular):
+            _, d2 = self._d_terms(maturity, spot[regular], sigma[regular])
+            result[regular] = (
+                self.k
+                * self.mkt.discount_factor(maturity)
+                * _normal_pdf(d2)
+                * np.sqrt(maturity)
+            )
+
+        near_zero = ~regular
+        if np.any(near_zero):
+            forward = self._forward_array(maturity, spot[near_zero])
+            atm = self._at_kink(forward)
+            result[near_zero] = np.where(
+                atm,
+                self.k
+                * self.mkt.discount_factor(maturity)
+                * np.sqrt(maturity)
+                / np.sqrt(2.0 * np.pi),
+                0.0,
+            )
+        return _as_output(result, scalar=_is_scalar_input(s, volatility))
+
+    def sensitivity_variance(
+        self, th: float, s: float | np.ndarray, variance: float | np.ndarray
+    ) -> float | np.ndarray:
+        """Derivative of option value with respect to variance ``sigma**2``."""
+
+        variance_array = self._validate_variance(variance)
+        if np.any(variance_array <= 0.0):
+            raise ValueError("variance sensitivity is undefined at zero variance")
+        volatility = np.sqrt(variance_array)
+        return _as_output(
+            self.vega_volatility(th, s, volatility) / (2.0 * volatility),
+            scalar=_is_scalar_input(s, variance),
+        )
+
+    def vega(
+        self, th: float, s: float | np.ndarray, variance: float | np.ndarray
+    ) -> float | np.ndarray:
+        """Compatibility wrapper: volatility vega from variance ``sigma**2``."""
+
+        return self.vega_volatility(th, s, np.sqrt(self._validate_variance(variance)))
+
+    def _validate_maturity(self, th: float) -> float:
+        maturity = float(_as_float_array("maturity", th))
+        if maturity < 0.0:
+            raise ValueError("maturity must be non-negative")
+        return maturity
+
+    def _validate_spot(self, s: float | np.ndarray) -> np.ndarray:
+        spot = _as_float_array("spot", s)
+        if np.any(spot < 0.0):
+            raise ValueError("spot must be non-negative")
+        return spot
+
+    def _validate_volatility(self, volatility: float | np.ndarray) -> np.ndarray:
+        sigma = _as_float_array("volatility", volatility)
+        if np.any(sigma < 0.0):
+            raise ValueError("volatility must be non-negative")
+        return sigma
+
+    def _validate_variance(self, variance: float | np.ndarray) -> np.ndarray:
+        variance_array = _as_float_array("variance", variance)
+        if np.any(variance_array < 0.0):
+            raise ValueError("variance must be non-negative")
+        return variance_array
+
+    def _forward_array(self, maturity: float, spot: np.ndarray) -> np.ndarray:
+        return spot * np.exp((self.r - self.q) * maturity)
+
+    def _d_terms(
+        self, maturity: float, spot: np.ndarray, volatility: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
+        total_std = volatility * np.sqrt(maturity)
+        forward = self._forward_array(maturity, spot)
+        d1 = (
+            np.log(forward / self.k) + 0.5 * np.square(volatility) * maturity
+        ) / total_std
+        d2 = d1 - total_std
+        return d1, d2
+
+    def _price_from_volatility(
+        self,
+        th: float,
+        s: float | np.ndarray,
+        volatility: float | np.ndarray,
+        *,
+        is_call: bool,
+    ) -> np.ndarray:
+        maturity = self._validate_maturity(th)
+        spot, sigma = np.broadcast_arrays(
+            self._validate_spot(s), self._validate_volatility(volatility)
+        )
+        spot = np.atleast_1d(spot)
+        sigma = np.atleast_1d(sigma)
+        dividend_df = self.dividend_discount(maturity)
+        riskfree_df = self.mkt.discount_factor(maturity)
+        if maturity == 0.0:
+            payoff = (
+                np.maximum(spot - self.k, 0.0)
+                if is_call
+                else np.maximum(self.k - spot, 0.0)
+            )
+            return payoff.astype(float)
+
+        forward_discounted = spot * dividend_df
+        strike_discounted = self.k * riskfree_df
+        deterministic = (
+            np.maximum(forward_discounted - strike_discounted, 0.0)
+            if is_call
+            else np.maximum(strike_discounted - forward_discounted, 0.0)
+        )
+        result = deterministic.astype(float)
+
+        total_std = sigma * np.sqrt(maturity)
+        regular = (total_std > _NEAR_ZERO_STD) & (spot > 0.0)
+        if np.any(regular):
+            d1, d2 = self._d_terms(maturity, spot[regular], sigma[regular])
+            if is_call:
+                result[regular] = spot[regular] * dividend_df * special.ndtr(
+                    d1
+                ) - self.k * riskfree_df * special.ndtr(d2)
+            else:
+                result[regular] = self.k * riskfree_df * special.ndtr(-d2) - spot[
+                    regular
+                ] * dividend_df * special.ndtr(-d1)
+        return result
+
+    def _delta_from_volatility(
+        self,
+        th: float,
+        s: float | np.ndarray,
+        volatility: float | np.ndarray,
+        *,
+        is_call: bool,
+    ) -> np.ndarray:
+        maturity = self._validate_maturity(th)
+        spot, sigma = np.broadcast_arrays(
+            self._validate_spot(s), self._validate_volatility(volatility)
+        )
+        spot = np.atleast_1d(spot)
+        sigma = np.atleast_1d(sigma)
+        dividend_df = self.dividend_discount(maturity)
+        forward = self._forward_array(maturity, spot)
+        deterministic = self._deterministic_delta(forward, dividend_df, is_call=is_call)
+        if maturity == 0.0:
+            return deterministic
+
+        result = deterministic.astype(float)
+        total_std = sigma * np.sqrt(maturity)
+        regular = (total_std > _NEAR_ZERO_STD) & (spot > 0.0)
+        if np.any(regular):
+            d1, _ = self._d_terms(maturity, spot[regular], sigma[regular])
+            if is_call:
+                result[regular] = dividend_df * special.ndtr(d1)
+            else:
+                result[regular] = dividend_df * (special.ndtr(d1) - 1.0)
+        return result
+
+    def _deterministic_delta(
+        self, forward: np.ndarray, dividend_df: float, *, is_call: bool
+    ) -> np.ndarray:
+        greater = forward > self.k
+        lower = forward < self.k
+        kink = self._at_kink(forward)
+        if is_call:
+            return np.where(
+                greater, dividend_df, np.where(kink, 0.5 * dividend_df, 0.0)
+            )
+        return np.where(lower, -dividend_df, np.where(kink, -0.5 * dividend_df, 0.0))
+
+    def _at_kink(self, forward: np.ndarray) -> np.ndarray:
+        return np.isclose(
+            forward,
+            self.k,
+            rtol=0.0,
+            atol=_KINK_ATOL_SCALE * max(float(self.k), 1.0),
+        )

--- a/src/finite_element_options/jax_greeks.py
+++ b/src/finite_element_options/jax_greeks.py
@@ -8,6 +8,7 @@ the canonical Black-Scholes oracle so edge semantics stay aligned.
 
 from __future__ import annotations
 
+import math
 import time
 import tracemalloc
 from typing import Any, Literal, Tuple
@@ -49,6 +50,17 @@ def _bs_price_jax(
     ) * jspst.norm.cdf(d2)
 
 
+def _requires_canonical_greek_path(
+    s: float, k: float, r: float, q: float, sigma: float, t: float
+) -> bool:
+    """Return whether JAX autodiff would hit a singular Black-Scholes expression."""
+
+    values = (s, k, r, q, sigma, t)
+    if not all(math.isfinite(value) for value in values):
+        return True
+    return s <= 0.0 or k <= 0.0 or t <= 0.0 or sigma <= 0.0
+
+
 def _greeks_numpy(
     s: float, k: float, r: float, q: float, sigma: float, t: float
 ) -> Tuple[float, float]:
@@ -65,7 +77,7 @@ def _greeks_jax(
 ) -> Tuple[float, float]:
     """Return ``delta`` and volatility ``vega`` via JAX automatic differentiation."""
 
-    if t <= 0.0 or sigma <= 0.0:
+    if _requires_canonical_greek_path(s, k, r, q, sigma, t):
         return _greeks_numpy(s, k, r, q, sigma, t)
     price = _bs_price_jax
     delta = jax.grad(lambda _s: price(_s, k, r, q, sigma, t))(s)

--- a/src/finite_element_options/jax_greeks.py
+++ b/src/finite_element_options/jax_greeks.py
@@ -1,19 +1,19 @@
 """Greeks computation via JAX automatic differentiation.
 
 The functions here offer an experimental path to evaluate sensitivities
-(Delta and Vega) by differentiating the Black--Scholes pricing formula
-with respect to spot price and volatility.  When JAX is not available or
-proves slower than NumPy, a pure NumPy implementation is used.
+(Delta and volatility Vega) by differentiating the Black--Scholes pricing
+formula with respect to spot price and volatility.  The NumPy path delegates to
+the canonical Black-Scholes oracle so edge semantics stay aligned.
 """
 
 from __future__ import annotations
 
 import time
 import tracemalloc
-from typing import Literal, Tuple
+from typing import Any, Literal, Tuple
 
-import numpy as np
-from scipy.stats import norm
+from finite_element_options.core.market import Market
+from finite_element_options.core.vanilla_bs import EuropeanOptionBs
 
 try:  # pragma: no cover - optional dependency
     import jax
@@ -25,31 +25,48 @@ except Exception:  # pragma: no cover
     JAX_AVAILABLE = False
 
 
-def _bs_price_numpy(s: float, k: float, r: float, q: float, sigma: float, t: float) -> float:
-    """Black--Scholes call price using NumPy/SciPy."""
-    d1 = (np.log(s / k) + (r - q + 0.5 * sigma**2) * t) / (sigma * np.sqrt(t))
-    d2 = d1 - sigma * np.sqrt(t)
-    return s * np.exp(-q * t) * norm.cdf(d1) - k * np.exp(-r * t) * norm.cdf(d2)
+def _option(k: float, r: float, q: float) -> EuropeanOptionBs:
+    return EuropeanOptionBs(k=k, q=q, mkt=Market(r=r))
 
 
-def _bs_price_jax(s: float, k: float, r: float, q: float, sigma: float, t: float) -> float:
-    """Black--Scholes call price in JAX space."""
+def _bs_price_numpy(
+    s: float, k: float, r: float, q: float, sigma: float, t: float
+) -> float:
+    """Black--Scholes call price using the canonical NumPy oracle."""
+
+    return float(_option(k, r, q).call_from_volatility(t, s, sigma))
+
+
+def _bs_price_jax(
+    s: float, k: float, r: float, q: float, sigma: float, t: float
+) -> Any:
+    """Black--Scholes call price in JAX space for regular positive-volatility cases."""
+
     d1 = (jnp.log(s / k) + (r - q + 0.5 * sigma**2) * t) / (sigma * jnp.sqrt(t))
     d2 = d1 - sigma * jnp.sqrt(t)
-    return s * jnp.exp(-q * t) * jspst.norm.cdf(d1) - k * jnp.exp(-r * t) * jspst.norm.cdf(d2)
+    return s * jnp.exp(-q * t) * jspst.norm.cdf(d1) - k * jnp.exp(
+        -r * t
+    ) * jspst.norm.cdf(d2)
 
 
-def _greeks_numpy(s: float, k: float, r: float, q: float, sigma: float, t: float) -> Tuple[float, float]:
-    """Return ``delta`` and ``vega`` using analytic derivatives."""
-    d1 = (np.log(s / k) + (r - q + 0.5 * sigma**2) * t) / (sigma * np.sqrt(t))
-    d2 = d1 - sigma * np.sqrt(t)
-    delta = np.exp(-q * t) * norm.cdf(d1)
-    vega = k * np.exp(-r * t) * norm.pdf(d2) * np.sqrt(t)
+def _greeks_numpy(
+    s: float, k: float, r: float, q: float, sigma: float, t: float
+) -> Tuple[float, float]:
+    """Return ``delta`` and volatility ``vega`` using canonical analytic derivatives."""
+
+    option = _option(k, r, q)
+    delta = option.call_delta_from_volatility(t, s, sigma)
+    vega = option.vega_volatility(t, s, sigma)
     return float(delta), float(vega)
 
 
-def _greeks_jax(s: float, k: float, r: float, q: float, sigma: float, t: float) -> Tuple[float, float]:
-    """Return ``delta`` and ``vega`` via JAX automatic differentiation."""
+def _greeks_jax(
+    s: float, k: float, r: float, q: float, sigma: float, t: float
+) -> Tuple[float, float]:
+    """Return ``delta`` and volatility ``vega`` via JAX automatic differentiation."""
+
+    if t <= 0.0 or sigma <= 0.0:
+        return _greeks_numpy(s, k, r, q, sigma, t)
     price = _bs_price_jax
     delta = jax.grad(lambda _s: price(_s, k, r, q, sigma, t))(s)
     vega = jax.grad(lambda _sigma: price(s, k, r, q, _sigma, t))(sigma)
@@ -65,6 +82,7 @@ def benchmark_greeks(
     t: float,
 ) -> dict[str, tuple[float, int]]:
     """Measure runtime and peak memory for both backends."""
+
     results: dict[str, tuple[float, int]] = {}
     tracemalloc.start()
     start = time.perf_counter()
@@ -94,7 +112,8 @@ def compute_greeks(
     *,
     backend: Literal["auto", "numpy", "jax"] = "auto",
 ) -> Tuple[float, float]:
-    """Compute ``delta`` and ``vega`` choosing between backends."""
+    """Compute call ``delta`` and volatility ``vega`` choosing between backends."""
+
     if backend == "jax":
         if not JAX_AVAILABLE:
             raise RuntimeError("JAX backend requested but not installed")

--- a/src/finite_element_options/jax_greeks.py
+++ b/src/finite_element_options/jax_greeks.py
@@ -53,12 +53,20 @@ def _bs_price_jax(
 def _requires_canonical_greek_path(
     s: float, k: float, r: float, q: float, sigma: float, t: float
 ) -> bool:
-    """Return whether JAX autodiff would hit a singular Black-Scholes expression."""
+    """Return whether JAX autodiff would hit a singular or saturated expression."""
 
     values = (s, k, r, q, sigma, t)
     if not all(math.isfinite(value) for value in values):
         return True
-    return s <= 0.0 or k <= 0.0 or t <= 0.0 or sigma <= 0.0
+    if s <= 0.0 or k <= 0.0 or t <= 0.0 or sigma <= 0.0:
+        return True
+    sqrt_t = math.sqrt(t)
+    variance_time = sigma * sigma * t
+    d1 = (math.log(s / k) + (r - q) * t + 0.5 * variance_time) / (sigma * sqrt_t)
+    d2 = d1 - sigma * sqrt_t
+    if not math.isfinite(d1) or not math.isfinite(d2):
+        return True
+    return max(abs(d1), abs(d2)) > 12.0
 
 
 def _greeks_numpy(

--- a/src/finite_element_options/problems/credit_risk.py
+++ b/src/finite_element_options/problems/credit_risk.py
@@ -16,6 +16,7 @@ import numpy as np
 import skfem as fem
 
 from finite_element_options.core.interfaces import (
+    ArrayLikeFloat,
     BoundaryCondition,
     DynamicsModel,
     Payoff,
@@ -109,22 +110,26 @@ class DefaultableZeroCouponClaim(Payoff):
             "or CreditRiskProblem.value() instead of option-space pricing."
         )
 
-    def call_payoff(self, s: float) -> float:  # pylint: disable=unused-argument
+    def call_payoff(self, s: ArrayLikeFloat) -> ArrayLikeFloat:  # pylint: disable=unused-argument
         """Fail closed for generic call-option routes."""
 
         self._unsupported_option_route()
 
-    def put_payoff(self, s: float) -> float:  # pylint: disable=unused-argument
+    def put_payoff(self, s: ArrayLikeFloat) -> ArrayLikeFloat:  # pylint: disable=unused-argument
         """Fail closed for generic put-option routes."""
 
         self._unsupported_option_route()
 
-    def call(self, th: float, s: float, v: float) -> float:  # pylint: disable=unused-argument
+    def call(
+        self, th: float, s: ArrayLikeFloat, variance: ArrayLikeFloat
+    ) -> ArrayLikeFloat:  # pylint: disable=unused-argument
         """Fail closed for generic call-option routes."""
 
         self._unsupported_option_route()
 
-    def put(self, th: float, s: float, v: float) -> float:  # pylint: disable=unused-argument
+    def put(
+        self, th: float, s: ArrayLikeFloat, variance: ArrayLikeFloat
+    ) -> ArrayLikeFloat:  # pylint: disable=unused-argument
         """Fail closed for generic put-option routes."""
 
         self._unsupported_option_route()
@@ -190,7 +195,9 @@ class ReducedFormCreditRiskModel:
         """PV of notional paid at maturity conditional on survival."""
 
         self._validate_maturity(maturity)
-        return claim.terminal_payoff * exp(-(self.r + self.default_intensity) * maturity)
+        return claim.terminal_payoff * exp(
+            -(self.r + self.default_intensity) * maturity
+        )
 
     def recovery_leg_pv(
         self, claim: DefaultableZeroCouponClaim, maturity: float
@@ -292,7 +299,9 @@ class ReducedFormCreditRiskModel:
         self._unsupported_spatial_route()
 
     def boundary_term(
-        self, is_call: bool, payoff: Payoff  # pylint: disable=unused-argument
+        self,
+        is_call: bool,
+        payoff: Payoff,  # pylint: disable=unused-argument
     ) -> fem.LinearForm:
         """Reject natural boundary assembly for a state-free ODE model."""
 
@@ -316,7 +325,9 @@ class CreditRiskIntensitySampler:
         if not isfinite(self.log_std) or self.log_std < 0.0:
             raise ValueError("log_std must be finite and nonnegative")
         if self.base_model.default_intensity <= 0.0 and self.log_std > 0.0:
-            raise ValueError("positive base default_intensity is required for lognormal sampling")
+            raise ValueError(
+                "positive base default_intensity is required for lognormal sampling"
+            )
 
     def sample(self, rng: np.random.Generator) -> ReducedFormCreditRiskModel:
         """Return a model with sampled default intensity."""
@@ -395,7 +406,9 @@ class CreditRiskProblem(Problem):
     def value(self, maturity: float) -> float:
         """Return analytical defaultable zero-coupon value."""
 
-        return self.reduced_form_model.defaultable_zero_coupon_value(self.claim, maturity)
+        return self.reduced_form_model.defaultable_zero_coupon_value(
+            self.claim, maturity
+        )
 
     def value_components(self, maturity: float) -> DefaultableZeroCouponOutputs:
         """Return separated value, probability and loss outputs."""

--- a/tests/test_black_scholes_semantics.py
+++ b/tests/test_black_scholes_semantics.py
@@ -1,0 +1,150 @@
+"""Black-Scholes oracle semantics for volatility, variance, and limits."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from finite_element_options.core.market import Market
+from finite_element_options.core.vanilla_bs import EuropeanOptionBs
+from finite_element_options.jax_greeks import compute_greeks
+
+
+def _option(
+    rate: float = 0.03, carry: float = 0.01, strike: float = 100.0
+) -> EuropeanOptionBs:
+    return EuropeanOptionBs(k=strike, q=carry, mkt=Market(r=rate))
+
+
+def test_volatility_and_variance_apis_are_explicit_and_chain_rule_consistent() -> None:
+    option = _option()
+    spot = 102.0
+    maturity = 1.25
+    volatility = 0.21
+    variance = volatility**2
+
+    call_from_vol = option.call_from_volatility(maturity, spot, volatility)
+    call_from_var = option.call_from_variance(maturity, spot, variance)
+    put_from_vol = option.put_from_volatility(maturity, spot, volatility)
+    put_from_var = option.put_from_variance(maturity, spot, variance)
+
+    assert call_from_vol == pytest.approx(call_from_var)
+    assert put_from_vol == pytest.approx(put_from_var)
+
+    vega_sigma = option.vega_volatility(maturity, spot, volatility)
+    sensitivity_variance = option.sensitivity_variance(maturity, spot, variance)
+    assert sensitivity_variance == pytest.approx(vega_sigma / (2.0 * volatility))
+
+
+def test_put_call_parity_and_vectorized_broadcasting() -> None:
+    option = _option(rate=-0.01, carry=0.02)
+    spots = np.array([75.0, 100.0, 125.0])
+    maturity = 0.75
+    volatility = 0.18
+
+    calls = option.call_from_volatility(maturity, spots, volatility)
+    puts = option.put_from_volatility(maturity, spots, volatility)
+    singleton_call = option.call_from_volatility(
+        maturity, np.array([100.0]), volatility
+    )
+
+    assert calls.shape == spots.shape
+    assert puts.shape == spots.shape
+    assert isinstance(singleton_call, np.ndarray)
+    assert singleton_call.shape == (1,)
+    parity = calls - puts
+    expected = spots * math.exp(-option.q * maturity) - option.k * math.exp(
+        -option.r * maturity
+    )
+    np.testing.assert_allclose(parity, expected, rtol=1e-12, atol=1e-12)
+
+
+def test_expiry_zero_volatility_and_zero_spot_limits_are_explicit() -> None:
+    option = _option(rate=0.05, carry=0.01)
+
+    assert option.call_from_volatility(0.0, 120.0, 0.3) == pytest.approx(20.0)
+    assert option.put_from_volatility(0.0, 80.0, 0.3) == pytest.approx(20.0)
+    assert option.call_delta_from_volatility(0.0, option.k, 0.3) == pytest.approx(0.5)
+    assert option.put_delta_from_volatility(0.0, option.k, 0.3) == pytest.approx(-0.5)
+
+    maturity = 2.0
+    spot = 100.0
+    forward = option.forward_price(maturity, spot)
+    deterministic_call = max(
+        spot * math.exp(-option.q * maturity)
+        - option.k * math.exp(-option.r * maturity),
+        0.0,
+    )
+    deterministic_put = max(
+        option.k * math.exp(-option.r * maturity)
+        - spot * math.exp(-option.q * maturity),
+        0.0,
+    )
+    assert forward > option.k
+    assert option.call_from_volatility(maturity, spot, 0.0) == pytest.approx(
+        deterministic_call
+    )
+    assert option.put_from_volatility(maturity, spot, 0.0) == pytest.approx(
+        deterministic_put
+    )
+    assert option.call_delta_from_volatility(maturity, spot, 0.0) == pytest.approx(
+        math.exp(-option.q * maturity)
+    )
+
+    assert option.call_from_volatility(maturity, 0.0, 0.2) == pytest.approx(0.0)
+    assert option.put_from_volatility(maturity, 0.0, 0.2) == pytest.approx(
+        option.k * math.exp(-option.r * maturity)
+    )
+
+
+def test_deep_tail_prices_are_finite_and_respect_discounted_bounds() -> None:
+    option = _option(rate=0.03, carry=-0.02)
+    spots = np.array([1e-12, 1e-6, 1e6, 1e12])
+    maturity = 5.0
+    volatility = 0.75
+
+    calls = option.call_from_volatility(maturity, spots, volatility)
+    puts = option.put_from_volatility(maturity, spots, volatility)
+
+    assert np.all(np.isfinite(calls))
+    assert np.all(np.isfinite(puts))
+    assert np.all(calls >= 0.0)
+    assert np.all(puts >= 0.0)
+    np.testing.assert_array_less(calls, spots * math.exp(-option.q * maturity) + 1e-8)
+    np.testing.assert_array_less(puts, option.k * math.exp(-option.r * maturity) + 1e-8)
+
+
+def test_invalid_inputs_and_zero_variance_sensitivity_fail_closed() -> None:
+    option = _option()
+
+    with pytest.raises(ValueError, match="spot"):
+        option.call_from_volatility(1.0, -1.0, 0.2)
+    with pytest.raises(ValueError, match="finite"):
+        option.call_from_volatility(1.0, math.inf, 0.2)
+    with pytest.raises(ValueError, match="maturity"):
+        option.call_from_volatility(-1.0, 100.0, 0.2)
+    with pytest.raises(ValueError, match="volatility"):
+        option.call_from_volatility(1.0, 100.0, -0.2)
+    with pytest.raises(ValueError, match="variance"):
+        option.call_from_variance(1.0, 100.0, -0.04)
+    with pytest.raises(ValueError, match="variance sensitivity"):
+        option.sensitivity_variance(1.0, 100.0, 0.0)
+
+
+def test_numpy_and_jax_greeks_follow_same_volatility_semantics() -> None:
+    params = dict(s=100.0, k=100.0, r=0.05, q=0.01, sigma=0.2, t=1.0)
+    option = _option(rate=params["r"], carry=params["q"], strike=params["k"])
+
+    delta_np, vega_np = compute_greeks(**params, backend="numpy")
+    assert delta_np == pytest.approx(
+        option.call_delta_from_volatility(params["t"], params["s"], params["sigma"])
+    )
+    assert vega_np == pytest.approx(
+        option.vega_volatility(params["t"], params["s"], params["sigma"])
+    )
+
+    delta_jax, vega_jax = compute_greeks(**params, backend="jax")
+    assert delta_jax == pytest.approx(delta_np, abs=1e-5)
+    assert vega_jax == pytest.approx(vega_np, abs=1e-5)

--- a/tests/test_jax_greeks.py
+++ b/tests/test_jax_greeks.py
@@ -1,5 +1,9 @@
 """Tests for JAX-based Greek computation."""
 
+import math
+
+import pytest
+
 from finite_element_options.jax_greeks import compute_greeks
 
 
@@ -17,3 +21,22 @@ def test_auto_backend():
     params = dict(s=100.0, k=110.0, r=0.03, q=0.01, sigma=0.25, t=0.5)
     delta, vega = compute_greeks(**params)
     assert delta == delta and vega == vega  # NaN check
+
+
+def test_jax_backend_uses_canonical_limits_for_zero_spot():
+    """Explicit JAX requests must match the canonical finite zero-spot limit."""
+
+    params = dict(s=0.0, k=100.0, r=0.05, q=0.0, sigma=0.2, t=1.0)
+    delta_jax, vega_jax = compute_greeks(**params, backend="jax")
+    delta_np, vega_np = compute_greeks(**params, backend="numpy")
+    assert math.isfinite(delta_jax)
+    assert math.isfinite(vega_jax)
+    assert delta_jax == pytest.approx(delta_np)
+    assert vega_jax == pytest.approx(vega_np)
+
+
+def test_jax_backend_delegates_invalid_spot_validation():
+    """Invalid non-regular inputs should fail exactly like the canonical oracle."""
+
+    with pytest.raises(ValueError, match="spot"):
+        compute_greeks(s=-1.0, k=100.0, r=0.05, q=0.0, sigma=0.2, t=1.0, backend="jax")

--- a/tests/test_jax_greeks.py
+++ b/tests/test_jax_greeks.py
@@ -35,6 +35,21 @@ def test_jax_backend_uses_canonical_limits_for_zero_spot():
     assert vega_jax == pytest.approx(vega_np)
 
 
+def test_jax_backend_uses_canonical_limits_for_subnormal_tail_spot():
+    """Positive subnormal tail spots must not be differentiated through JAX log."""
+
+    params = dict(s=1e-40, k=100.0, r=0.05, q=0.0, sigma=0.2, t=1.0)
+    delta_jax, vega_jax = compute_greeks(**params, backend="jax")
+    delta_np, vega_np = compute_greeks(**params, backend="numpy")
+    delta_auto, vega_auto = compute_greeks(**params, backend="auto")
+    assert math.isfinite(delta_jax)
+    assert math.isfinite(vega_jax)
+    assert delta_jax == pytest.approx(delta_np)
+    assert vega_jax == pytest.approx(vega_np)
+    assert delta_auto == pytest.approx(delta_np)
+    assert vega_auto == pytest.approx(vega_np)
+
+
 def test_jax_backend_delegates_invalid_spot_validation():
     """Invalid non-regular inputs should fail exactly like the canonical oracle."""
 


### PR DESCRIPTION
## Summary

Closes #52.

Separates Black-Scholes volatility and variance semantics in the analytical oracle used by FEM/FD validation:

- adds explicit `*_from_volatility` and `*_from_variance` pricing/delta APIs;
- keeps legacy `call`/`put`/delta wrappers variance-based for compatibility, but removes ambiguous `v` naming from the public `Payoff` contract;
- distinguishes volatility Vega `dV/dsigma` from variance sensitivity `dV/d(sigma**2)` and fails closed at zero variance where the chain-rule sensitivity is singular;
- defines expiry, deterministic zero-volatility, zero-spot, deep-tail, negative-rate/carry and invalid-input behavior;
- aligns NumPy and JAX Greek routes through the canonical oracle and documents the convention.

## Verification

- `pytest tests/test_black_scholes_semantics.py -q --no-cov` → 6 passed
- `pytest tests/test_black_scholes_semantics.py tests/test_jax_greeks.py tests/test_black_scholes_1d.py tests/test_fd_reference_backend_contract.py tests/test_credit_risk_model.py -q --no-cov` → 33 passed
- `pytest -q` → 99 passed, 2 skipped, 2 warnings
- `ruff check src tests scripts` → passed
- `ruff format --check src/finite_element_options/core/interfaces.py src/finite_element_options/core/vanilla_bs.py src/finite_element_options/jax_greeks.py src/finite_element_options/problems/credit_risk.py tests/test_black_scholes_semantics.py` → 5 files already formatted
- `mypy --ignore-missing-imports --follow-imports=silent src/finite_element_options/core/interfaces.py src/finite_element_options/core/vanilla_bs.py src/finite_element_options/jax_greeks.py src/finite_element_options/problems/credit_risk.py` → passed
- `python scripts/check_architecture_contract.py` → passed
- `python scripts/check_ci_contract.py` → passed
- `pytest -q tests/architecture tests/test_packaging_contract.py --no-cov` → 16 passed
- `mypy --ignore-missing-imports --follow-imports=silent src/finite_element_options/contracts src/finite_element_options/validation scripts/check_ci_contract.py` → passed
- `python -m build --sdist --wheel && python -m twine check dist/*` → passed

Notes:
- Full-suite warnings are pre-existing local environment warnings from PyTensor BLAS discovery and JAX/fork interaction in calibration tests.
- `gitleaks` is not installed locally; no secret-like content was added.
