### PR TITLE
Add validated atomic metadata artifacts

### DIFF
--- a/src/finite_element_options/data_utils.py
+++ b/src/finite_element_options/data_utils.py
@@ -64,17 +64,20 @@ def _sha256(path: Path) -> str:
 def _artifact_lock(path: Path) -> Iterator[None]:
     lock_path = path.with_suffix(path.suffix + ".lock")
     fd: int | None = None
+    acquired = False
     try:
         fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        acquired = True
         os.write(fd, str(os.getpid()).encode("utf-8"))
         yield
     finally:
         if fd is not None:
             os.close(fd)
-        try:
-            lock_path.unlink()
-        except FileNotFoundError:
-            pass
+        if acquired:
+            try:
+                lock_path.unlink()
+            except FileNotFoundError:
+                pass
 
 
 def _write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:

--- a/src/finite_element_options/data_utils.py
+++ b/src/finite_element_options/data_utils.py
@@ -95,6 +95,20 @@ def _write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
             pass
 
 
+def _missing_io_extra_message() -> str:
+    """Return a useful optional-dependency error message for Parquet helpers."""
+
+    return (
+        "Parquet artifact helpers require the 'io' extra: "
+        "install finite-element-options[io] to enable pyarrow-backed reads/writes."
+    )
+
+
+def _restore_publish_backup(backup_path: Path, final_path: Path) -> None:
+    if backup_path.exists():
+        os.replace(backup_path, final_path)
+
+
 def _artifact_manifest(
     *,
     path: Path,
@@ -129,10 +143,20 @@ def _atomic_publish(
     final_path.parent.mkdir(parents=True, exist_ok=True)
     manifest_path = _manifest_path(final_path)
     tmp_data = final_path.with_name(f".{final_path.name}.{uuid.uuid4().hex}.tmp")
+    tmp_manifest = manifest_path.with_name(
+        f".{manifest_path.name}.{uuid.uuid4().hex}.tmp"
+    )
+    backup_data = final_path.with_name(f".{final_path.name}.{uuid.uuid4().hex}.bak")
+    backup_manifest = manifest_path.with_name(
+        f".{manifest_path.name}.{uuid.uuid4().hex}.bak"
+    )
 
     with _artifact_lock(final_path):
         if not overwrite and (final_path.exists() or manifest_path.exists()):
             raise FileExistsError(f"artifact already exists: {final_path}")
+        data_backed_up = False
+        manifest_backed_up = False
+        data_published = False
         try:
             writer(tmp_data)
             manifest = _artifact_manifest(
@@ -142,15 +166,39 @@ def _atomic_publish(
                 extra=extra,
             )
             manifest["data_path"] = final_path.name
+            manifest["data_sha256"] = _sha256(tmp_data)
+            tmp_manifest.write_text(
+                json.dumps(manifest, indent=2, sort_keys=True, default=_json_default)
+                + "\n",
+                encoding="utf-8",
+            )
+            if final_path.exists():
+                os.replace(final_path, backup_data)
+                data_backed_up = True
+            if manifest_path.exists():
+                os.replace(manifest_path, backup_manifest)
+                manifest_backed_up = True
             os.replace(tmp_data, final_path)
-            manifest["data_sha256"] = _sha256(final_path)
-            _write_json_atomic(manifest_path, manifest)
+            data_published = True
+            os.replace(tmp_manifest, manifest_path)
+            backup_data.unlink(missing_ok=True)
+            backup_manifest.unlink(missing_ok=True)
             return manifest
+        except Exception:
+            if data_published:
+                final_path.unlink(missing_ok=True)
+            if not manifest_backed_up:
+                manifest_path.unlink(missing_ok=True)
+            _restore_publish_backup(backup_data, final_path)
+            _restore_publish_backup(backup_manifest, manifest_path)
+            raise
         finally:
-            try:
-                tmp_data.unlink()
-            except FileNotFoundError:
-                pass
+            tmp_data.unlink(missing_ok=True)
+            tmp_manifest.unlink(missing_ok=True)
+            if not data_backed_up:
+                backup_data.unlink(missing_ok=True)
+            if not manifest_backed_up:
+                backup_manifest.unlink(missing_ok=True)
 
 
 def _load_manifest(path: str | Path, expected_artifact_type: str) -> dict[str, Any]:
@@ -182,8 +230,13 @@ def _write_parquet_with_metadata(
 ) -> None:
     """Write a Parquet table with finite-element-options metadata in the schema."""
 
-    import pyarrow as pa  # type: ignore[import-untyped]
-    import pyarrow.parquet as pq  # type: ignore[import-untyped]
+    try:
+        import pyarrow as pa  # type: ignore[import-untyped]
+        import pyarrow.parquet as pq  # type: ignore[import-untyped]
+    except (
+        ModuleNotFoundError
+    ) as exc:  # pragma: no cover - covered via import monkeypatch.
+        raise ImportError(_missing_io_extra_message()) from exc
 
     table = pa.Table.from_pandas(df, preserve_index=False)
     existing = table.schema.metadata or {}
@@ -199,7 +252,12 @@ def _write_parquet_with_metadata(
 def _read_parquet_metadata(path: str | Path) -> dict[str, Any]:
     """Read finite-element-options metadata embedded in a Parquet schema."""
 
-    import pyarrow.parquet as pq  # type: ignore[import-untyped]
+    try:
+        import pyarrow.parquet as pq  # type: ignore[import-untyped]
+    except (
+        ModuleNotFoundError
+    ) as exc:  # pragma: no cover - covered via import monkeypatch.
+        raise ImportError(_missing_io_extra_message()) from exc
 
     metadata = pq.read_schema(path).metadata or {}
     raw = metadata.get(b"finite_element_options.metadata")

--- a/src/finite_element_options/data_utils.py
+++ b/src/finite_element_options/data_utils.py
@@ -1,85 +1,533 @@
 """Helpers for market data and solution snapshots.
 
-This module centralises utilities for constructing pandas DataFrames and
-xarray DataArrays used throughout the project.  It also provides simple
-serialisation helpers enabling reproducible experiments.
+The helpers in this module validate tabular inputs and solution arrays before
+writing, publish artifacts via same-directory temporary files, and pair every
+artifact with a hash-linked manifest sidecar. The sidecar is the completion
+marker used by readers: a data file without a matching manifest is treated as an
+incomplete artifact.
 """
 
 from __future__ import annotations
 
+import hashlib
+import json
+import os
+import uuid
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from contextlib import contextmanager
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Iterable
+from typing import Any, TypeVar
 
 import numpy as np
 import pandas as pd
 import xarray as xr
+
+MARKET_DATA_SCHEMA_VERSION = "finite-element-options.market-data.v1"
+SOLUTION_SNAPSHOT_SCHEMA_VERSION = "finite-element-options.solution-snapshot.v1"
+ARTIFACT_MANIFEST_SCHEMA_VERSION = "finite-element-options.artifact-manifest.v1"
+
+T = TypeVar("T")
+
+# ---------------------------------------------------------------------------
+# Manifest and atomic write helpers
+
+
+def _json_default(value: Any) -> Any:
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, Path):
+        return str(value)
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
+def _json_roundtripable(mapping: Mapping[str, Any]) -> dict[str, Any]:
+    return json.loads(json.dumps(dict(mapping), default=_json_default, sort_keys=True))
+
+
+def _manifest_path(path: str | Path) -> Path:
+    artifact = Path(path)
+    return artifact.with_suffix(artifact.suffix + ".manifest.json")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@contextmanager
+def _artifact_lock(path: Path) -> Iterator[None]:
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    fd: int | None = None
+    try:
+        fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        os.write(fd, str(os.getpid()).encode("utf-8"))
+        yield
+    finally:
+        if fd is not None:
+            os.close(fd)
+        try:
+            lock_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    tmp = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        tmp.write_text(
+            json.dumps(payload, indent=2, sort_keys=True, default=_json_default) + "\n",
+            encoding="utf-8",
+        )
+        os.replace(tmp, path)
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _artifact_manifest(
+    *,
+    path: Path,
+    artifact_type: str,
+    metadata: Mapping[str, Any],
+    extra: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload = {
+        "schema_version": ARTIFACT_MANIFEST_SCHEMA_VERSION,
+        "artifact_type": artifact_type,
+        "data_path": path.name,
+        "data_sha256": _sha256(path),
+        "created_at": datetime.now(UTC).isoformat(),
+        "run_id": metadata.get("run_id", "unknown-run"),
+        "metadata": _json_roundtripable(metadata),
+    }
+    if extra:
+        payload.update(_json_roundtripable(extra))
+    return payload
+
+
+def _atomic_publish(
+    path: str | Path,
+    *,
+    artifact_type: str,
+    metadata: Mapping[str, Any],
+    writer: Callable[[Path], None],
+    overwrite: bool = False,
+    extra: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    final_path = Path(path)
+    final_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path = _manifest_path(final_path)
+    tmp_data = final_path.with_name(f".{final_path.name}.{uuid.uuid4().hex}.tmp")
+
+    with _artifact_lock(final_path):
+        if not overwrite and (final_path.exists() or manifest_path.exists()):
+            raise FileExistsError(f"artifact already exists: {final_path}")
+        try:
+            writer(tmp_data)
+            manifest = _artifact_manifest(
+                path=tmp_data,
+                artifact_type=artifact_type,
+                metadata=metadata,
+                extra=extra,
+            )
+            manifest["data_path"] = final_path.name
+            os.replace(tmp_data, final_path)
+            manifest["data_sha256"] = _sha256(final_path)
+            _write_json_atomic(manifest_path, manifest)
+            return manifest
+        finally:
+            try:
+                tmp_data.unlink()
+            except FileNotFoundError:
+                pass
+
+
+def _load_manifest(path: str | Path, expected_artifact_type: str) -> dict[str, Any]:
+    final_path = Path(path)
+    manifest_path = _manifest_path(final_path)
+    if not manifest_path.is_file():
+        raise FileNotFoundError(f"manifest sidecar missing for artifact: {final_path}")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if manifest.get("schema_version") != ARTIFACT_MANIFEST_SCHEMA_VERSION:
+        raise ValueError("manifest schema_version is incompatible")
+    if manifest.get("artifact_type") != expected_artifact_type:
+        raise ValueError(
+            f"manifest artifact_type {manifest.get('artifact_type')!r} does not match "
+            f"{expected_artifact_type!r}"
+        )
+    if manifest.get("data_path") != final_path.name:
+        raise ValueError("manifest data_path does not match artifact filename")
+    actual_hash = _sha256(final_path)
+    if manifest.get("data_sha256") != actual_hash:
+        raise ValueError("artifact hash does not match manifest")
+    metadata = manifest.get("metadata")
+    if not isinstance(metadata, dict):
+        raise ValueError("manifest metadata must be an object")
+    return manifest
+
+
+def _write_parquet_with_metadata(
+    df: pd.DataFrame, path: Path, metadata: Mapping[str, Any]
+) -> None:
+    """Write a Parquet table with finite-element-options metadata in the schema."""
+
+    import pyarrow as pa  # type: ignore[import-untyped]
+    import pyarrow.parquet as pq  # type: ignore[import-untyped]
+
+    table = pa.Table.from_pandas(df, preserve_index=False)
+    existing = table.schema.metadata or {}
+    schema_metadata = {
+        **existing,
+        b"finite_element_options.metadata": json.dumps(
+            _json_roundtripable(metadata), sort_keys=True, default=_json_default
+        ).encode("utf-8"),
+    }
+    pq.write_table(table.replace_schema_metadata(schema_metadata), path)
+
+
+def _read_parquet_metadata(path: str | Path) -> dict[str, Any]:
+    """Read finite-element-options metadata embedded in a Parquet schema."""
+
+    import pyarrow.parquet as pq  # type: ignore[import-untyped]
+
+    metadata = pq.read_schema(path).metadata or {}
+    raw = metadata.get(b"finite_element_options.metadata")
+    if raw is None:
+        raise ValueError("Parquet artifact missing finite_element_options metadata")
+    payload = json.loads(raw.decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("Parquet metadata payload must be an object")
+    return payload
 
 
 # ---------------------------------------------------------------------------
 # Market data helpers
 
 
+def _base_market_metadata(metadata: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    supplied = dict(metadata or {})
+    base = {
+        "schema_version": MARKET_DATA_SCHEMA_VERSION,
+        "run_id": supplied.get("run_id", f"run-{uuid.uuid4().hex}"),
+        "units": supplied.get("units", "unspecified"),
+        "currency": supplied.get("currency", "unspecified"),
+        "quote_type": supplied.get("quote_type", "option_price"),
+        "source": supplied.get("source", "unspecified"),
+        "coordinates": ["strike", "maturity"],
+    }
+    base.update(supplied)
+    base["schema_version"] = MARKET_DATA_SCHEMA_VERSION
+    base["coordinates"] = ["strike", "maturity"]
+    return _json_roundtripable(base)
+
+
+def _validate_market_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    required = ["strike", "maturity", "price"]
+    missing = [column for column in required if column not in df.columns]
+    if missing:
+        raise ValueError(f"market data missing required columns: {missing}")
+    clean = df.loc[:, required].astype(float)
+    lengths = {len(clean[column]) for column in required}
+    if len(lengths) != 1:
+        raise ValueError("strike, maturity and price must have the same length")
+    values = clean.to_numpy(dtype=float)
+    if not np.isfinite(values).all():
+        raise ValueError("market data values must be finite")
+    if (clean["strike"] <= 0).any():
+        raise ValueError("strike values must be positive")
+    if (clean["maturity"] < 0).any():
+        raise ValueError("maturity values must be non-negative")
+    if clean.duplicated(subset=["strike", "maturity"]).any():
+        raise ValueError("market data contains duplicate strike/maturity keys")
+    return clean
+
+
 def make_market_dataframe(
     strikes: Iterable[float],
     maturities: Iterable[float],
     prices: Iterable[float],
+    *,
+    metadata: Mapping[str, Any] | None = None,
 ) -> pd.DataFrame:
-    """Return a canonical market DataFrame.
+    """Return a validated canonical market DataFrame.
 
     Parameters
     ----------
     strikes, maturities, prices:
         One-dimensional sequences describing the option surface.
+    metadata:
+        Optional run/source/units metadata stored in ``DataFrame.attrs`` and in
+        artifact manifests when the table is written.
     """
 
-    return pd.DataFrame({"strike": strikes, "maturity": maturities, "price": prices})
+    strike_arr = np.asarray(list(strikes), dtype=float)
+    maturity_arr = np.asarray(list(maturities), dtype=float)
+    price_arr = np.asarray(list(prices), dtype=float)
+    if not (len(strike_arr) == len(maturity_arr) == len(price_arr)):
+        raise ValueError("strike, maturity and price must have the same length")
+    df = pd.DataFrame(
+        {"strike": strike_arr, "maturity": maturity_arr, "price": price_arr}
+    )
+    clean = _validate_market_dataframe(df)
+    clean.attrs.update(_base_market_metadata(metadata))
+    return clean
 
 
-def df_to_csv(df: pd.DataFrame, path: str | Path) -> None:
-    """Serialise ``df`` to ``path`` in CSV format."""
+def _market_metadata(df: pd.DataFrame) -> dict[str, Any]:
+    metadata = _base_market_metadata(df.attrs)
+    return metadata
 
-    df.to_csv(path, index=False)
+
+def df_to_csv(
+    df: pd.DataFrame,
+    path: str | Path,
+    *,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Serialise ``df`` and a hash-linked manifest to CSV."""
+
+    clean = _validate_market_dataframe(df)
+    metadata = _market_metadata(df)
+
+    def writer(tmp_path: Path) -> None:
+        clean.to_csv(tmp_path, index=False)
+
+    return _atomic_publish(
+        path,
+        artifact_type="market-data.csv",
+        metadata=metadata,
+        writer=writer,
+        overwrite=overwrite,
+        extra={
+            "columns": list(clean.columns),
+            "dtypes": clean.dtypes.astype(str).to_dict(),
+        },
+    )
 
 
-def df_to_parquet(df: pd.DataFrame, path: str | Path) -> None:
-    """Serialise ``df`` to ``path`` in Parquet format."""
+def df_to_parquet(
+    df: pd.DataFrame,
+    path: str | Path,
+    *,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Serialise ``df`` and a hash-linked manifest to Parquet."""
 
-    df.to_parquet(path, index=False)
+    clean = _validate_market_dataframe(df)
+    metadata = _market_metadata(df)
+
+    def writer(tmp_path: Path) -> None:
+        _write_parquet_with_metadata(clean, tmp_path, metadata)
+
+    return _atomic_publish(
+        path,
+        artifact_type="market-data.parquet",
+        metadata=metadata,
+        writer=writer,
+        overwrite=overwrite,
+        extra={
+            "columns": list(clean.columns),
+            "dtypes": clean.dtypes.astype(str).to_dict(),
+        },
+    )
 
 
 def df_from_csv(path: str | Path) -> pd.DataFrame:
-    """Load market data from ``path`` stored in CSV format."""
+    """Load manifest-validated market data stored in CSV format."""
 
-    return pd.read_csv(path)
+    manifest = _load_manifest(path, "market-data.csv")
+    df = _validate_market_dataframe(pd.read_csv(path))
+    df.attrs.update(manifest["metadata"])
+    return df
 
 
 def df_from_parquet(path: str | Path) -> pd.DataFrame:
-    """Load market data from ``path`` stored in Parquet format."""
+    """Load manifest-validated market data stored in Parquet format."""
 
-    return pd.read_parquet(path)
+    manifest = _load_manifest(path, "market-data.parquet")
+    parquet_metadata = _read_parquet_metadata(path)
+    if parquet_metadata.get("schema_version") != MARKET_DATA_SCHEMA_VERSION:
+        raise ValueError("Parquet schema metadata is incompatible")
+    if parquet_metadata.get("run_id") != manifest["metadata"].get("run_id"):
+        raise ValueError("Parquet schema metadata does not match manifest")
+    df = _validate_market_dataframe(pd.read_parquet(path))
+    df.attrs.update(manifest["metadata"])
+    return df
 
 
 # ---------------------------------------------------------------------------
 # Solution snapshot helpers
 
 
+def _base_solution_metadata(
+    *,
+    coordinates: list[str],
+    shape: tuple[int, ...],
+    dtype: str,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    supplied = dict(metadata or {})
+    base = {
+        "schema_version": SOLUTION_SNAPSHOT_SCHEMA_VERSION,
+        "run_id": supplied.get("run_id", f"run-{uuid.uuid4().hex}"),
+        "units": supplied.get("units", "unspecified"),
+        "model": supplied.get("model", "unspecified"),
+        "config_hash": supplied.get("config_hash", "unspecified"),
+        "backend": supplied.get("backend", "unspecified"),
+        "convergence_state": supplied.get("convergence_state", "unknown"),
+        "coordinates": coordinates,
+        "shape": list(shape),
+        "dtype": dtype,
+    }
+    base.update(supplied)
+    base["schema_version"] = SOLUTION_SNAPSHOT_SCHEMA_VERSION
+    base["coordinates"] = coordinates
+    base["shape"] = list(shape)
+    base["dtype"] = dtype
+    return _json_roundtripable(base)
+
+
+def _decode_attr(value: Any) -> Any:
+    if isinstance(value, str) and value and value[0] in "[{":
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return value
+    return value
+
+
+def _encode_attrs_for_netcdf(attrs: Mapping[str, Any]) -> dict[str, Any]:
+    encoded: dict[str, Any] = {}
+    for key, value in attrs.items():
+        if isinstance(value, str | int | float | np.integer | np.floating):
+            encoded[key] = value
+        else:
+            encoded[key] = json.dumps(value, default=_json_default, sort_keys=True)
+    return encoded
+
+
 def snapshot(
     array: np.ndarray,
     time_grid: Iterable[float],
     space_grid: Iterable[float],
+    *,
+    time_name: str = "time",
+    space_name: str = "space",
+    metadata: Mapping[str, Any] | None = None,
 ) -> xr.DataArray:
-    """Convert ``array`` into an :class:`xarray.DataArray` snapshot.
+    """Convert ``array`` into a validated :class:`xarray.DataArray` snapshot.
 
     Parameters
     ----------
     array:
-        Two-dimensional ``time`` × ``space`` array of option values.
+        Two-dimensional time × space array of option values.
     time_grid, space_grid:
         Coordinate vectors for the respective axes.
+    time_name, space_name:
+        Coordinate/dimension names, e.g. ``tau`` and ``spot``.
+    metadata:
+        Optional run/model/backend/convergence metadata stored in attributes and
+        artifact manifests when the snapshot is written.
     """
 
-    return xr.DataArray(
-        array,
-        coords={"time": np.asarray(list(time_grid)), "space": np.asarray(list(space_grid))},
-        dims=("time", "space"),
+    values = np.asarray(array)
+    time = np.asarray(list(time_grid), dtype=float)
+    space = np.asarray(list(space_grid), dtype=float)
+    if values.ndim != 2:
+        raise ValueError("solution snapshot array must be two-dimensional")
+    if values.shape != (len(time), len(space)):
+        raise ValueError(
+            "solution snapshot shape must match time and space coordinate lengths"
+        )
+    if (
+        not np.isfinite(values).all()
+        or not np.isfinite(time).all()
+        or not np.isfinite(space).all()
+    ):
+        raise ValueError("solution snapshot values and coordinates must be finite")
+    if len(set([time_name, space_name])) != 2:
+        raise ValueError("solution snapshot coordinate names must be distinct")
+    attrs = _base_solution_metadata(
+        coordinates=[time_name, space_name],
+        shape=values.shape,
+        dtype=str(values.dtype),
+        metadata=metadata,
     )
+    return xr.DataArray(
+        values,
+        coords={time_name: time, space_name: space},
+        dims=(time_name, space_name),
+        name="solution",
+        attrs=attrs,
+    )
+
+
+def _validate_snapshot(data: xr.DataArray) -> xr.DataArray:
+    if data.ndim != 2:
+        raise ValueError("solution snapshot must be two-dimensional")
+    if len(data.dims) != 2 or len(set(data.dims)) != 2:
+        raise ValueError("solution snapshot must have two distinct coordinates")
+    if not np.isfinite(np.asarray(data.values, dtype=float)).all():
+        raise ValueError("solution snapshot values must be finite")
+    for dim in data.dims:
+        if dim not in data.coords:
+            raise ValueError(f"solution snapshot missing coordinate: {dim}")
+        if not np.isfinite(np.asarray(data.coords[dim].values, dtype=float)).all():
+            raise ValueError(f"solution snapshot coordinate {dim!r} must be finite")
+    attrs = {key: _decode_attr(value) for key, value in data.attrs.items()}
+    if attrs.get("schema_version") != SOLUTION_SNAPSHOT_SCHEMA_VERSION:
+        raise ValueError("solution snapshot schema_version is missing or incompatible")
+    if attrs.get("coordinates") != list(data.dims):
+        raise ValueError("solution snapshot coordinate metadata does not match dims")
+    if attrs.get("shape") != list(data.shape):
+        raise ValueError("solution snapshot shape metadata does not match data")
+    data.attrs.clear()
+    data.attrs.update(attrs)
+    return data
+
+
+def snapshot_to_netcdf(
+    data: xr.DataArray,
+    path: str | Path,
+    *,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Serialise a solution snapshot and hash-linked manifest to NetCDF."""
+
+    clean = _validate_snapshot(data.copy(deep=True))
+    metadata = _json_roundtripable(clean.attrs)
+
+    def writer(tmp_path: Path) -> None:
+        encoded = clean.copy(deep=True)
+        encoded.attrs = _encode_attrs_for_netcdf(encoded.attrs)
+        encoded.to_netcdf(tmp_path, engine="scipy")
+
+    return _atomic_publish(
+        path,
+        artifact_type="solution-snapshot.netcdf",
+        metadata=metadata,
+        writer=writer,
+        overwrite=overwrite,
+        extra={
+            "coordinates": list(clean.dims),
+            "shape": list(clean.shape),
+            "dtype": str(clean.dtype),
+        },
+    )
+
+
+def snapshot_from_netcdf(path: str | Path) -> xr.DataArray:
+    """Load a manifest-validated solution snapshot from NetCDF."""
+
+    manifest = _load_manifest(path, "solution-snapshot.netcdf")
+    loaded = xr.open_dataarray(path, engine="scipy").load()
+    loaded.attrs.update(manifest["metadata"])
+    return _validate_snapshot(loaded)

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -1,31 +1,189 @@
 """Tests for data utility helpers."""
 
-from finite_element_options.data_utils import (
-    make_market_dataframe,
-    df_to_csv,
-    df_from_csv,
-    df_to_parquet,
-    df_from_parquet,
-    snapshot,
-)
+from __future__ import annotations
+
+import hashlib
+import json
 
 import numpy as np
+import pyarrow.parquet as pq
+import pytest
+
+from finite_element_options.data_utils import (
+    df_from_csv,
+    df_from_parquet,
+    df_to_csv,
+    df_to_parquet,
+    make_market_dataframe,
+    snapshot,
+    snapshot_from_netcdf,
+    snapshot_to_netcdf,
+)
 
 
-def test_dataframe_roundtrip(tmp_path):
-    df = make_market_dataframe([1, 2], [0.5, 0.6], [0.1, 0.2])
+def _metadata() -> dict[str, str]:
+    return {
+        "run_id": "run-001",
+        "units": "CLP",
+        "currency": "CLP",
+        "quote_type": "option_price",
+        "source": "public-synthetic",
+        "model": "black_scholes",
+        "config_hash": "cfg-abc",
+        "backend": "scikit-fem",
+        "convergence_state": "converged",
+    }
+
+
+def _manifest(path):
+    return json.loads(path.with_suffix(path.suffix + ".manifest.json").read_text())
+
+
+def test_market_dataframe_validation_and_metadata() -> None:
+    df = make_market_dataframe([90, 100], [0.5, 1.0], [1.1, 2.2], metadata=_metadata())
+
+    assert list(df.columns) == ["strike", "maturity", "price"]
+    assert df.attrs["schema_version"] == "finite-element-options.market-data.v1"
+    assert df.attrs["run_id"] == "run-001"
+    assert df.attrs["coordinates"] == ["strike", "maturity"]
+
+    with pytest.raises(ValueError, match="same length"):
+        make_market_dataframe([90], [0.5, 1.0], [1.1], metadata=_metadata())
+    with pytest.raises(ValueError, match="finite"):
+        make_market_dataframe([90], [0.5], [np.nan], metadata=_metadata())
+    with pytest.raises(ValueError, match="duplicate"):
+        make_market_dataframe([90, 90], [0.5, 0.5], [1.1, 1.2], metadata=_metadata())
+
+
+def test_dataframe_roundtrip_writes_hash_linked_manifest(tmp_path) -> None:
+    df = make_market_dataframe([90, 100], [0.5, 1.0], [1.1, 2.2], metadata=_metadata())
     csv_path = tmp_path / "market.csv"
     pq_path = tmp_path / "market.parquet"
-    df_to_csv(df, csv_path)
-    df_to_parquet(df, pq_path)
-    assert df.equals(df_from_csv(csv_path))
-    assert df.equals(df_from_parquet(pq_path))
+
+    csv_manifest = df_to_csv(df, csv_path)
+    parquet_manifest = df_to_parquet(df, pq_path)
+
+    assert (
+        csv_manifest["data_sha256"] == hashlib.sha256(csv_path.read_bytes()).hexdigest()
+    )
+    assert (
+        parquet_manifest["data_sha256"]
+        == hashlib.sha256(pq_path.read_bytes()).hexdigest()
+    )
+    assert _manifest(csv_path)["run_id"] == "run-001"
+    assert _manifest(pq_path)["metadata"]["quote_type"] == "option_price"
+    embedded = pq.read_schema(pq_path).metadata[b"finite_element_options.metadata"]
+    embedded_metadata = json.loads(embedded.decode("utf-8"))
+    assert (
+        embedded_metadata["schema_version"] == "finite-element-options.market-data.v1"
+    )
+    assert embedded_metadata["run_id"] == "run-001"
+    assert embedded_metadata["units"] == "CLP"
+
+    csv_df = df_from_csv(csv_path)
+    parquet_df = df_from_parquet(pq_path)
+    assert df.equals(csv_df)
+    assert df.equals(parquet_df)
+    assert csv_df.attrs["run_id"] == "run-001"
+    assert parquet_df.attrs["backend"] == "scikit-fem"
 
 
-def test_snapshot_creation():
-    arr = np.arange(6).reshape(2, 3)
-    time = [0, 1]
-    space = [10, 20, 30]
-    da = snapshot(arr, time, space)
-    assert da.dims == ("time", "space")
-    assert np.all(da[0].values == arr[0])
+def test_dataframe_load_rejects_missing_or_tampered_manifest(tmp_path) -> None:
+    df = make_market_dataframe([90], [0.5], [1.1], metadata=_metadata())
+    bare_path = tmp_path / "bare.csv"
+    df.to_csv(bare_path, index=False)
+
+    with pytest.raises(FileNotFoundError, match="manifest"):
+        df_from_csv(bare_path)
+
+    good_path = tmp_path / "market.csv"
+    df_to_csv(df, good_path)
+    good_path.write_text(good_path.read_text() + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="hash"):
+        df_from_csv(good_path)
+
+
+def test_atomic_write_failure_leaves_no_partial_dataframe_files(
+    tmp_path, monkeypatch
+) -> None:
+    df = make_market_dataframe([90], [0.5], [1.1], metadata=_metadata())
+    path = tmp_path / "market.csv"
+
+    def boom(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise RuntimeError("late writer failure")
+
+    monkeypatch.setattr(type(df), "to_csv", boom)
+
+    with pytest.raises(RuntimeError, match="late writer failure"):
+        df_to_csv(df, path)
+
+    assert not path.exists()
+    assert not path.with_suffix(path.suffix + ".manifest.json").exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_concurrent_style_writers_cannot_overwrite_existing_artifact(tmp_path) -> None:
+    first = make_market_dataframe([90], [0.5], [1.1], metadata=_metadata())
+    second = make_market_dataframe(
+        [100], [1.0], [2.2], metadata={**_metadata(), "run_id": "run-002"}
+    )
+    path = tmp_path / "market.parquet"
+
+    df_to_parquet(first, path)
+    with pytest.raises(FileExistsError, match="already exists"):
+        df_to_parquet(second, path)
+
+    loaded = df_from_parquet(path)
+    assert loaded.attrs["run_id"] == "run-001"
+    assert loaded.iloc[0]["strike"] == 90
+
+
+def test_snapshot_validation_and_metadata() -> None:
+    arr = np.arange(6, dtype=float).reshape(2, 3)
+
+    da = snapshot(
+        arr,
+        [0, 1],
+        [90, 100, 110],
+        time_name="tau",
+        space_name="spot",
+        metadata=_metadata(),
+    )
+
+    assert da.dims == ("tau", "spot")
+    assert np.all(da.sel(tau=0).values == arr[0])
+    assert da.attrs["schema_version"] == "finite-element-options.solution-snapshot.v1"
+    assert da.attrs["coordinates"] == ["tau", "spot"]
+    assert da.attrs["run_id"] == "run-001"
+    assert da.attrs["convergence_state"] == "converged"
+
+    with pytest.raises(ValueError, match="shape"):
+        snapshot(arr, [0], [90, 100, 110], metadata=_metadata())
+    with pytest.raises(ValueError, match="finite"):
+        snapshot(np.array([[np.nan]]), [0], [90], metadata=_metadata())
+
+
+def test_snapshot_netcdf_roundtrip_and_hash_validation(tmp_path) -> None:
+    da = snapshot(
+        np.arange(6, dtype=float).reshape(2, 3),
+        [0, 1],
+        [90, 100, 110],
+        time_name="tau",
+        space_name="spot",
+        metadata=_metadata(),
+    )
+    path = tmp_path / "solution.nc"
+
+    manifest = snapshot_to_netcdf(da, path)
+
+    assert manifest["data_sha256"] == hashlib.sha256(path.read_bytes()).hexdigest()
+    loaded = snapshot_from_netcdf(path)
+    assert loaded.dims == ("tau", "spot")
+    assert loaded.attrs["run_id"] == "run-001"
+    assert loaded.attrs["backend"] == "scikit-fem"
+    assert np.allclose(loaded.values, da.values)
+
+    path.write_bytes(path.read_bytes() + b"tamper")
+    with pytest.raises(ValueError, match="hash"):
+        snapshot_from_netcdf(path)

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -123,6 +123,24 @@ def test_atomic_write_failure_leaves_no_partial_dataframe_files(
     assert list(tmp_path.iterdir()) == []
 
 
+def test_failed_lock_contender_does_not_remove_active_writer_lock(tmp_path) -> None:
+    df = make_market_dataframe([90], [0.5], [1.1], metadata=_metadata())
+    path = tmp_path / "market.csv"
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    lock_path.write_text("active-writer", encoding="utf-8")
+
+    with pytest.raises(FileExistsError):
+        df_to_csv(df, path)
+
+    assert lock_path.read_text(encoding="utf-8") == "active-writer"
+    assert not path.exists()
+    assert not path.with_suffix(path.suffix + ".manifest.json").exists()
+
+    lock_path.unlink()
+    df_to_csv(df, path)
+    assert path.exists()
+
+
 def test_concurrent_style_writers_cannot_overwrite_existing_artifact(tmp_path) -> None:
     first = make_market_dataframe([90], [0.5], [1.1], metadata=_metadata())
     second = make_market_dataframe(

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import builtins
 import hashlib
 import json
+import os
 
 import numpy as np
 import pyarrow.parquet as pq
@@ -139,6 +141,57 @@ def test_failed_lock_contender_does_not_remove_active_writer_lock(tmp_path) -> N
     lock_path.unlink()
     df_to_csv(df, path)
     assert path.exists()
+
+
+def test_manifest_publish_failure_rolls_back_existing_artifact(
+    tmp_path, monkeypatch
+) -> None:
+    original = make_market_dataframe([90], [0.5], [1.1], metadata=_metadata())
+    replacement = make_market_dataframe(
+        [100], [1.0], [2.2], metadata={**_metadata(), "run_id": "run-002"}
+    )
+    path = tmp_path / "market.csv"
+    df_to_csv(original, path)
+    original_manifest = _manifest(path)
+    real_replace = os.replace
+    manifest_path = path.with_suffix(path.suffix + ".manifest.json")
+
+    def fail_final_manifest_replace(src, dst):  # noqa: ANN001
+        if os.fspath(dst) == os.fspath(manifest_path) and os.fspath(src).endswith(
+            ".tmp"
+        ):
+            raise OSError("simulated manifest publish failure")
+        real_replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", fail_final_manifest_replace)
+
+    with pytest.raises(OSError, match="simulated manifest publish failure"):
+        df_to_csv(replacement, path, overwrite=True)
+
+    assert _manifest(path) == original_manifest
+    loaded = df_from_csv(path)
+    assert loaded.attrs["run_id"] == "run-001"
+    assert loaded.iloc[0]["strike"] == 90
+    assert not any(
+        child.name.endswith((".tmp", ".bak", ".lock")) for child in tmp_path.iterdir()
+    )
+
+
+def test_parquet_helpers_name_required_io_extra_when_pyarrow_missing(
+    tmp_path, monkeypatch
+) -> None:
+    df = make_market_dataframe([90], [0.5], [1.1], metadata=_metadata())
+    real_import = builtins.__import__
+
+    def blocked_import(name, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        if name.startswith("pyarrow"):
+            raise ModuleNotFoundError(name)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
+
+    with pytest.raises(ImportError, match=r"finite-element-options\[io\]"):
+        df_to_parquet(df, tmp_path / "market.parquet")
 
 
 def test_concurrent_style_writers_cannot_overwrite_existing_artifact(tmp_path) -> None:


### PR DESCRIPTION
## Summary

Closes #56.

- upgrades `data_utils` from bare table/snapshot helpers to versioned, validated artifacts
- adds atomic same-directory publish with `.lock`, temp files, `os.replace`, and hash-linked manifest sidecars
- embeds market metadata in Parquet schema metadata and solution metadata in NetCDF/xarray attrs
- validates finite/equal-length market tables, duplicate strike/maturity keys, solution shape/coordinates, manifest hash/type/path, and incompatible loads
- covers CSV sidecars, Parquet metadata, NetCDF snapshots, tamper detection, writer failure cleanup, and no-overwrite concurrent-writer protection

## Verification

- `uv run --extra dev ruff format src/finite_element_options/data_utils.py tests/test_data_utils.py`
- `uv run --extra dev ruff check src/finite_element_options/data_utils.py tests/test_data_utils.py`
- `uv run --extra dev python -m mypy --ignore-missing-imports src/finite_element_options/data_utils.py tests/test_data_utils.py`
- `uv run --extra dev python -m pytest -o addopts='' tests/test_data_utils.py tests/test_pinares_fem_proxy.py -q` → 12 passed
- `uv run --extra dev python scripts/check_architecture_contract.py` → passed
- `uv run --extra dev python scripts/check_ci_contract.py` → passed
- `uv run --extra dev python -m pytest tests -q` → 111 passed, 2 skipped
- `uv run --extra dev python -m build` → sdist/wheel built
- `uv run --extra dev python -m twine check dist/*` → passed
