### PR TITLE
feat(greeks): add auditable JAX diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This reproduces the same call option pricing workflow without depending on a che
 - Black-Scholes option pricer with call/put payoffs, explicit volatility vs. variance APIs, and tested zero-maturity/zero-volatility limits
 - Finite-difference solver on regular grids using ``findiff``
 - Greek estimators (Delta, Gamma, volatility Vega) via finite differences
-- Experimental JAX-based Greek computation via automatic differentiation
+- Experimental JAX-based Greek computation via automatic differentiation with explicit method/object diagnostics, synchronized compile/transfer/warm timing metadata, and documented non-AD-through-FEM limits
 - Configurable mesh generation supporting 1D, 2D and 3D problems
 - Central ``Config`` dataclass for numerical parameters
 - Sample problems for 1D Black–Scholes and 3D Heston models

--- a/docs/GREEKS_DIAGNOSTICS.md
+++ b/docs/GREEKS_DIAGNOSTICS.md
@@ -1,0 +1,44 @@
+# Greeks Diagnostics and JAX Benchmark Policy
+
+**Owner issue:** [finite_element_options #46](https://github.com/googa27/finite_element_options/issues/46)
+
+This repository exposes three distinct Greek paths. They must not be collapsed into a single "JAX Greeks" claim.
+
+## Methods
+
+| Method | Differentiated object | Status |
+|---|---|---|
+| `analytical_oracle` | Black-Scholes European call price from volatility `sigma` | Canonical scalar oracle used for regular NumPy results |
+| `analytical_oracle_limit` | Same analytical object, evaluated through explicit limit semantics | Used for expiry, zero-volatility, zero/near-zero spot, saturated tails, or any input where JAX AD would hit singular expressions |
+| `jax_ad_analytical_formula` | JAX implementation of the analytical Black-Scholes formula | Experimental AD of the formula only; it is not AD through FEM assembly or a linear solve |
+| `coordinate_aware_np_gradient` | Price grid values over supplied mesh coordinates | Numerical recovery for nonuniform grids; coordinates are passed explicitly to `np.gradient` |
+
+## Required metadata
+
+`compute_greeks_report` returns a `GreekComputationReport`. Each `GreekObservation` records:
+
+- Greek name (`delta`, `vega`);
+- method;
+- differentiated mathematical object;
+- input variable (`spot`, `volatility sigma`);
+- units;
+- finite/undefined status;
+- bump-and-revalue error when a regular central bump is valid.
+
+The report also records requested backend, used backend, dtype, device, JAX 64-bit configuration, and any fallback reason.
+
+## JAX timing policy
+
+`benchmark_greeks` follows JAX asynchronous-dispatch guidance:
+
+1. Convert host inputs to JAX arrays and synchronize (`transfer_seconds`).
+2. JIT the AD function and synchronize the first call (`compile_seconds`).
+3. Run the compiled function again and synchronize (`warmed_seconds`).
+
+The `memory_bytes` metric preserves the historical benchmark tuple contract as host Python peak memory from `tracemalloc`. It is not an accelerator memory claim. Accelerator memory must remain unreported until a device-specific allocator API is added and validated.
+
+For `backend="auto"`, the historical selection rule is preserved: JAX is selected only when its synchronized total runtime is no more than `1.5x` the NumPy analytical oracle runtime. Otherwise the report records a NumPy fallback reason.
+
+## Boundary policy
+
+Expiry, zero volatility, zero spot and saturated tails use `analytical_oracle_limit`. They must either return finite oracle values or raise the same explicit validation error as the canonical Black-Scholes oracle. The module does not claim AD through FEM until the actual assembly and linear solve path is differentiable and validated.

--- a/docs/MODULE_OWNERSHIP.md
+++ b/docs/MODULE_OWNERSHIP.md
@@ -34,7 +34,7 @@ This module ownership inventory treats the repository as a finite-element numeri
 | `fdsolver.py` | compatibility | Legacy finite-difference reference route retained only for benchmark/parity transition; production FD ownership belongs to `finite_difference_options` | Not re-exported by base package; emits `DeprecationWarning` on `FDSolver`, `solve_system`, and Greek helper use | fd | Removal version `0.3.0`, removal date `2026-10-31`; remove or replace with a benchmark oracle after FD parity and adapter gates (#49/#50) |
 | `data_utils.py` | optional | Experiment snapshot IO and dataframe/xarray utilities | Optional utility | io | Keep outside core import graph |
 | `estimation/` | optional | SciPy/PyMC calibration research adapters; synthetic unless evidence says otherwise | Optional research/calibration | calibration | Production Heston Bayesian route remains #54 |
-| `jax_greeks.py` | optional | Experimental AD Greek route | Optional research helper | jax | Keep separate from core sensitivity claims |
+| `jax_greeks.py` | optional | Experimental AD Greek route with method/object diagnostics and synchronized JAX timing | Optional research helper | jax | Keep separate from core sensitivity claims; no AD-through-FEM claim until differentiable assembly/solve is validated (#46) |
 | `plots.py` | optional | Plotting helpers | Optional visualization | viz | Keep outside core import graph |
 | `sidebar.py` | app | Streamlit sidebar/application support | UI helper only | ui | Keep outside core import graph |
 | `cli.py` | cli | Thin CLI shell over validated public APIs | Console entry edge | core plus selected extras | Do not encode solver semantics here |

--- a/docs/architecture_contract.toml
+++ b/docs/architecture_contract.toml
@@ -160,7 +160,7 @@ extra = "calibration"
 path = "jax_greeks.py"
 layer = "optional"
 owner = "finite_element_options"
-treatment = "experimental AD Greek route"
+treatment = "experimental AD Greek route with method/object diagnostics and synchronized JAX timing"
 public_surface = "optional research helper"
 extra = "jax"
 

--- a/src/finite_element_options/jax_greeks.py
+++ b/src/finite_element_options/jax_greeks.py
@@ -264,20 +264,27 @@ def _bump_errors(
 
     if _requires_canonical_greek_path(s, k, r, q, sigma, t):
         return None, None, None, None
-    spot_bump = max(abs(s) * 1.0e-4, 1.0e-4)
+    spot_bump = max(abs(s) * 1.0e-4, float(np.spacing(s)))
+    spot_down = max(s - spot_bump, s * 0.5, float(np.nextafter(0.0, 1.0)))
+    spot_up = s + spot_bump
     vol_bump = max(abs(sigma) * 1.0e-4, 1.0e-4)
     vol_down = max(sigma - vol_bump, sigma * 0.5)
     vol_up = sigma + vol_bump
     effective_vol_bump = 0.5 * (vol_up - vol_down)
     bump_delta = (
-        _bs_price_numpy(s + spot_bump, k, r, q, sigma, t)
-        - _bs_price_numpy(s - spot_bump, k, r, q, sigma, t)
-    ) / (2.0 * spot_bump)
+        _bs_price_numpy(spot_up, k, r, q, sigma, t)
+        - _bs_price_numpy(spot_down, k, r, q, sigma, t)
+    ) / (spot_up - spot_down)
     bump_vega = (
         _bs_price_numpy(s, k, r, q, vol_up, t)
         - _bs_price_numpy(s, k, r, q, vol_down, t)
     ) / (2.0 * effective_vol_bump)
-    return abs(delta - bump_delta), abs(vega - bump_vega), spot_bump, effective_vol_bump
+    return (
+        abs(delta - bump_delta),
+        abs(vega - bump_vega),
+        0.5 * (spot_up - spot_down),
+        effective_vol_bump,
+    )
 
 
 def _observations(
@@ -451,7 +458,12 @@ def compute_greeks_report(
     fallback_reason = None
     if backend == "numpy":
         backend_used: Literal["numpy", "jax"] = "numpy"
-        method = "analytical_oracle"
+        method = "analytical_oracle" if regular_jax_path else "analytical_oracle_limit"
+        if not regular_jax_path:
+            fallback_reason = (
+                "requested NumPy backend evaluated singular/saturated input by "
+                "canonical analytical limit"
+            )
         delta, vega = _greeks_numpy(s, k, r, q, sigma, t)
     elif backend == "jax" and regular_jax_path:
         backend_used = "jax"

--- a/src/finite_element_options/jax_greeks.py
+++ b/src/finite_element_options/jax_greeks.py
@@ -1,17 +1,25 @@
-"""Greeks computation via JAX automatic differentiation.
+"""Greeks computation with explicit method, object, and benchmark metadata.
 
-The functions here offer an experimental path to evaluate sensitivities
-(Delta and volatility Vega) by differentiating the Black--Scholes pricing
-formula with respect to spot price and volatility.  The NumPy path delegates to
-the canonical Black-Scholes oracle so edge semantics stay aligned.
+This module deliberately separates three concepts that are easy to conflate:
+
+* analytical Black-Scholes oracle Greeks;
+* coordinate-aware numerical recovery on a price grid;
+* JAX automatic differentiation of the analytical Black-Scholes formula.
+
+It does not claim automatic differentiation through the FEM assembly or linear
+solve.  When JAX is used, timings synchronize asynchronous dispatch and separate
+host-device transfer, cold compile/first execution, and warmed execution.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import math
 import time
 import tracemalloc
 from typing import Any, Literal, Tuple
+
+import numpy as np
 
 from finite_element_options.core.market import Market
 from finite_element_options.core.vanilla_bs import EuropeanOptionBs
@@ -23,7 +31,110 @@ try:  # pragma: no cover - optional dependency
 
     JAX_AVAILABLE = True
 except Exception:  # pragma: no cover
+    jax = None  # type: ignore[assignment]
+    jnp = None  # type: ignore[assignment]
+    jspst = None  # type: ignore[assignment]
     JAX_AVAILABLE = False
+
+Backend = Literal["auto", "numpy", "jax"]
+GreekName = Literal["delta", "vega"]
+
+
+@dataclass(frozen=True)
+class GreekObservation:
+    """A single Greek value plus the mathematical object it differentiates."""
+
+    greek: GreekName
+    value: float
+    method: str
+    differentiated_object: str
+    input_variable: str
+    units: str
+    status: Literal["finite", "undefined"]
+    oracle_error_abs: float | None = None
+    bump_size: float | None = None
+    fallback_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class GreekComputationReport:
+    """Auditable sensitivity result with backend and runtime metadata."""
+
+    delta: GreekObservation
+    vega: GreekObservation
+    backend_requested: Backend
+    backend_used: Literal["numpy", "jax"]
+    differentiated_object: str
+    dtype: str
+    device: str
+    jax_enable_x64: bool | None
+    fallback_reason: str | None = None
+
+    def as_tuple(self) -> Tuple[float, float]:
+        """Return the legacy ``(delta, vega)`` tuple."""
+        return self.delta.value, self.vega.value
+
+
+@dataclass(frozen=True)
+class GridGreekRecovery:
+    """Coordinate-aware Greek recovery from a price grid."""
+
+    values: tuple[float, ...]
+    method: str
+    differentiated_object: str
+    input_variable: str
+    coordinate_units: str
+    stencil: str
+
+
+@dataclass(frozen=True)
+class BackendBenchmark:
+    """Runtime benchmark metadata for one Greek backend.
+
+    ``memory_bytes`` preserves the historical tuple contract as host Python peak
+    memory measured with ``tracemalloc``. It is deliberately not an accelerator
+    memory claim.
+    """
+
+    runtime_seconds: float
+    transfer_seconds: float | None = None
+    compile_seconds: float | None = None
+    warmed_seconds: float | None = None
+    synchronized: bool = True
+    dtype: str = "float64"
+    device: str = "cpu"
+    jax_enable_x64: bool | None = None
+    memory_bytes: int | None = None
+
+    def as_legacy_tuple(self) -> tuple[float, int]:
+        """Return the historical ``(runtime_seconds, memory_bytes)`` shape."""
+        return self.runtime_seconds, int(self.memory_bytes or 0)
+
+    def __iter__(self):
+        """Iterate like the historical two-item benchmark tuple."""
+        return iter(self.as_legacy_tuple())
+
+    def __getitem__(self, index: int) -> float | int:
+        """Index like the historical two-item benchmark tuple."""
+        return self.as_legacy_tuple()[index]
+
+    def __len__(self) -> int:
+        """Return the historical benchmark tuple length."""
+        return 2
+
+
+def _time_with_host_peak(call: Any) -> tuple[float, int, Any]:
+    """Run ``call`` while measuring elapsed time and host Python peak memory."""
+
+    tracemalloc.start()
+    try:
+        start = time.perf_counter()
+        result = call()
+        runtime = time.perf_counter() - start
+        _, peak_bytes = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+    return runtime, int(peak_bytes), result
 
 
 def _option(k: float, r: float, q: float) -> EuropeanOptionBs:
@@ -33,7 +144,7 @@ def _option(k: float, r: float, q: float) -> EuropeanOptionBs:
 def _bs_price_numpy(
     s: float, k: float, r: float, q: float, sigma: float, t: float
 ) -> float:
-    """Black--Scholes call price using the canonical NumPy oracle."""
+    """Black-Scholes call price using the canonical NumPy oracle."""
 
     return float(_option(k, r, q).call_from_volatility(t, s, sigma))
 
@@ -41,13 +152,38 @@ def _bs_price_numpy(
 def _bs_price_jax(
     s: float, k: float, r: float, q: float, sigma: float, t: float
 ) -> Any:
-    """Black--Scholes call price in JAX space for regular positive-volatility cases."""
+    """Black-Scholes call price in JAX space for regular positive-volatility cases."""
 
+    assert jnp is not None and jspst is not None
     d1 = (jnp.log(s / k) + (r - q + 0.5 * sigma**2) * t) / (sigma * jnp.sqrt(t))
     d2 = d1 - sigma * jnp.sqrt(t)
     return s * jnp.exp(-q * t) * jspst.norm.cdf(d1) - k * jnp.exp(
         -r * t
     ) * jspst.norm.cdf(d2)
+
+
+def _jax_delta_vega(
+    s: Any, k: Any, r: Any, q: Any, sigma: Any, t: Any
+) -> tuple[Any, Any]:
+    """Return JAX AD delta and volatility vega for the analytical formula."""
+
+    assert jax is not None
+    price = _bs_price_jax
+    delta = jax.grad(lambda _s: price(_s, k, r, q, sigma, t))(s)
+    vega = jax.grad(lambda _sigma: price(s, k, r, q, _sigma, t))(sigma)
+    return delta, vega
+
+
+def _block_until_ready(value: Any) -> Any:
+    """Synchronize JAX values before timing or converting them."""
+
+    if isinstance(value, tuple):
+        return tuple(_block_until_ready(item) for item in value)
+    if hasattr(value, "block_until_ready"):
+        return value.block_until_ready()
+    if JAX_AVAILABLE and jax is not None:  # pragma: no branch - defensive
+        return jax.block_until_ready(value)
+    return value
 
 
 def _requires_canonical_greek_path(
@@ -80,17 +216,116 @@ def _greeks_numpy(
     return float(delta), float(vega)
 
 
+def _greeks_jax_regular(
+    s: float, k: float, r: float, q: float, sigma: float, t: float
+) -> Tuple[float, float]:
+    """Return regular-case JAX AD Greeks after synchronizing device execution."""
+
+    delta, vega = _block_until_ready(_jax_delta_vega(s, k, r, q, sigma, t))
+    return float(delta), float(vega)
+
+
 def _greeks_jax(
     s: float, k: float, r: float, q: float, sigma: float, t: float
 ) -> Tuple[float, float]:
-    """Return ``delta`` and volatility ``vega`` via JAX automatic differentiation."""
+    """Return Greeks via JAX AD or canonical limits for singular cases."""
 
     if _requires_canonical_greek_path(s, k, r, q, sigma, t):
         return _greeks_numpy(s, k, r, q, sigma, t)
-    price = _bs_price_jax
-    delta = jax.grad(lambda _s: price(_s, k, r, q, sigma, t))(s)
-    vega = jax.grad(lambda _sigma: price(s, k, r, q, _sigma, t))(sigma)
-    return float(delta), float(vega)
+    return _greeks_jax_regular(s, k, r, q, sigma, t)
+
+
+def _runtime_metadata(backend: Literal["numpy", "jax"]) -> tuple[str, str, bool | None]:
+    """Return dtype, device, and JAX 64-bit configuration for a backend."""
+
+    if backend == "jax" and JAX_AVAILABLE and jax is not None and jnp is not None:
+        sample = jnp.asarray(1.0)
+        devices = jax.devices()
+        device = devices[0].platform if devices else jax.default_backend()
+        return (
+            str(sample.dtype),
+            device,
+            bool(getattr(jax.config, "jax_enable_x64", False)),
+        )
+    return str(np.asarray(1.0, dtype=float).dtype), "cpu", None
+
+
+def _bump_errors(
+    s: float,
+    k: float,
+    r: float,
+    q: float,
+    sigma: float,
+    t: float,
+    delta: float,
+    vega: float,
+) -> tuple[float | None, float | None, float | None, float | None]:
+    """Compare analytical/AD Greeks with central bump-and-revalue estimates."""
+
+    if _requires_canonical_greek_path(s, k, r, q, sigma, t):
+        return None, None, None, None
+    spot_bump = max(abs(s) * 1.0e-4, 1.0e-4)
+    vol_bump = max(abs(sigma) * 1.0e-4, 1.0e-4)
+    vol_down = max(sigma - vol_bump, sigma * 0.5)
+    vol_up = sigma + vol_bump
+    effective_vol_bump = 0.5 * (vol_up - vol_down)
+    bump_delta = (
+        _bs_price_numpy(s + spot_bump, k, r, q, sigma, t)
+        - _bs_price_numpy(s - spot_bump, k, r, q, sigma, t)
+    ) / (2.0 * spot_bump)
+    bump_vega = (
+        _bs_price_numpy(s, k, r, q, vol_up, t)
+        - _bs_price_numpy(s, k, r, q, vol_down, t)
+    ) / (2.0 * effective_vol_bump)
+    return abs(delta - bump_delta), abs(vega - bump_vega), spot_bump, effective_vol_bump
+
+
+def _observations(
+    *,
+    method: str,
+    delta: float,
+    vega: float,
+    s: float,
+    k: float,
+    r: float,
+    q: float,
+    sigma: float,
+    t: float,
+    fallback_reason: str | None,
+) -> tuple[GreekObservation, GreekObservation]:
+    """Build auditable Greek observations for call price sensitivities."""
+
+    delta_error, vega_error, spot_bump, vol_bump = _bump_errors(
+        s, k, r, q, sigma, t, delta, vega
+    )
+    differentiated_object = "Black-Scholes European call price from volatility sigma"
+    status: Literal["finite", "undefined"] = "finite"
+    return (
+        GreekObservation(
+            greek="delta",
+            value=delta,
+            method=method,
+            differentiated_object=differentiated_object,
+            input_variable="spot",
+            units="price / spot",
+            status=status,
+            oracle_error_abs=delta_error,
+            bump_size=spot_bump,
+            fallback_reason=fallback_reason,
+        ),
+        GreekObservation(
+            greek="vega",
+            value=vega,
+            method=method,
+            differentiated_object=differentiated_object,
+            input_variable="volatility sigma",
+            units="price / volatility",
+            status=status,
+            oracle_error_abs=vega_error,
+            bump_size=vol_bump,
+            fallback_reason=fallback_reason,
+        ),
+    )
 
 
 def benchmark_greeks(
@@ -100,26 +335,186 @@ def benchmark_greeks(
     q: float,
     sigma: float,
     t: float,
-) -> dict[str, tuple[float, int]]:
-    """Measure runtime and peak memory for both backends."""
+) -> dict[str, BackendBenchmark]:
+    """Measure synchronized runtime metadata for available Greek backends."""
 
-    results: dict[str, tuple[float, int]] = {}
-    tracemalloc.start()
-    start = time.perf_counter()
-    _greeks_numpy(s, k, r, q, sigma, t)
-    runtime = time.perf_counter() - start
-    _, peak = tracemalloc.get_traced_memory()
-    tracemalloc.stop()
-    results["numpy"] = (runtime, peak)
-    if JAX_AVAILABLE:
-        tracemalloc.start()
-        start = time.perf_counter()
-        _greeks_jax(s, k, r, q, sigma, t)
-        runtime = time.perf_counter() - start
-        _, peak = tracemalloc.get_traced_memory()
-        tracemalloc.stop()
-        results["jax"] = (runtime, peak)
+    results: dict[str, BackendBenchmark] = {}
+    numpy_runtime, numpy_memory_bytes, _ = _time_with_host_peak(
+        lambda: _greeks_numpy(s, k, r, q, sigma, t)
+    )
+    dtype, device, jax_enable_x64 = _runtime_metadata("numpy")
+    results["numpy"] = BackendBenchmark(
+        runtime_seconds=numpy_runtime,
+        dtype=dtype,
+        device=device,
+        jax_enable_x64=jax_enable_x64,
+        memory_bytes=numpy_memory_bytes,
+    )
+
+    if (
+        JAX_AVAILABLE
+        and jax is not None
+        and jnp is not None
+        and not _requires_canonical_greek_path(s, k, r, q, sigma, t)
+    ):
+        jax_numpy = jnp
+        transfer_seconds, transfer_memory_bytes, args = _time_with_host_peak(
+            lambda: _block_until_ready(
+                tuple(jax_numpy.asarray(value) for value in (s, k, r, q, sigma, t))
+            )
+        )
+
+        compiled = jax.jit(_jax_delta_vega)
+        compile_seconds, compile_memory_bytes, _ = _time_with_host_peak(
+            lambda: _block_until_ready(compiled(*args))
+        )
+
+        warmed_seconds, warmed_memory_bytes, _ = _time_with_host_peak(
+            lambda: _block_until_ready(compiled(*args))
+        )
+        dtype, device, jax_enable_x64 = _runtime_metadata("jax")
+        results["jax"] = BackendBenchmark(
+            runtime_seconds=transfer_seconds + compile_seconds + warmed_seconds,
+            transfer_seconds=transfer_seconds,
+            compile_seconds=compile_seconds,
+            warmed_seconds=warmed_seconds,
+            synchronized=True,
+            dtype=dtype,
+            device=device,
+            jax_enable_x64=jax_enable_x64,
+            memory_bytes=max(
+                transfer_memory_bytes, compile_memory_bytes, warmed_memory_bytes
+            ),
+        )
     return results
+
+
+def recover_grid_delta_report(
+    values: np.ndarray,
+    coordinates: np.ndarray,
+    *,
+    coordinate_units: str = "spot",
+) -> GridGreekRecovery:
+    """Recover Delta on possibly nonuniform coordinates with ``np.gradient``."""
+
+    value_array = np.asarray(values, dtype=float)
+    coordinate_array = np.asarray(coordinates, dtype=float)
+    if value_array.ndim != 1 or coordinate_array.ndim != 1:
+        raise ValueError("values and coordinates must be one-dimensional")
+    if value_array.shape != coordinate_array.shape:
+        raise ValueError("values and coordinates must have the same shape")
+    if len(value_array) < 3:
+        raise ValueError("at least three grid points are required for Delta recovery")
+    if not np.all(np.isfinite(value_array)) or not np.all(
+        np.isfinite(coordinate_array)
+    ):
+        raise ValueError("values and coordinates must be finite")
+    if np.any(np.diff(coordinate_array) <= 0.0):
+        raise ValueError("coordinates must be strictly increasing")
+    recovered = np.gradient(value_array, coordinate_array, edge_order=2)
+    return GridGreekRecovery(
+        values=tuple(float(item) for item in recovered),
+        method="coordinate_aware_np_gradient",
+        differentiated_object="price grid values",
+        input_variable="mesh coordinate",
+        coordinate_units=coordinate_units,
+        stencil="second-order edge, coordinate-aware interior",
+    )
+
+
+def recover_grid_delta(values: np.ndarray, coordinates: np.ndarray) -> np.ndarray:
+    """Return coordinate-aware Delta values for a price grid."""
+
+    return np.asarray(
+        recover_grid_delta_report(values, coordinates).values, dtype=float
+    )
+
+
+def compute_greeks_report(
+    s: float,
+    k: float,
+    r: float,
+    q: float,
+    sigma: float,
+    t: float,
+    *,
+    backend: Backend = "auto",
+) -> GreekComputationReport:
+    """Compute call Delta/Vega with explicit method and backend diagnostics."""
+
+    if backend not in {"auto", "numpy", "jax"}:
+        raise ValueError(f"unsupported backend: {backend}")
+    if backend == "jax" and not JAX_AVAILABLE:
+        raise RuntimeError("JAX backend requested but not installed")
+
+    regular_jax_path = not _requires_canonical_greek_path(s, k, r, q, sigma, t)
+    fallback_reason = None
+    if backend == "numpy":
+        backend_used: Literal["numpy", "jax"] = "numpy"
+        method = "analytical_oracle"
+        delta, vega = _greeks_numpy(s, k, r, q, sigma, t)
+    elif backend == "jax" and regular_jax_path:
+        backend_used = "jax"
+        method = "jax_ad_analytical_formula"
+        delta, vega = _greeks_jax_regular(s, k, r, q, sigma, t)
+    elif backend == "jax":
+        backend_used = "numpy"
+        method = "analytical_oracle_limit"
+        fallback_reason = (
+            "JAX AD singular/saturated input; canonical analytical limit used"
+        )
+        delta, vega = _greeks_numpy(s, k, r, q, sigma, t)
+    else:
+        stats = benchmark_greeks(s, k, r, q, sigma, t)
+        use_jax_auto = (
+            "jax" in stats
+            and stats["jax"].warmed_seconds is not None
+            and stats["jax"].runtime_seconds <= stats["numpy"].runtime_seconds * 1.5
+        )
+        if use_jax_auto:
+            backend_used = "jax"
+            method = "jax_ad_analytical_formula"
+            delta, vega = _greeks_jax_regular(s, k, r, q, sigma, t)
+        else:
+            backend_used = "numpy"
+            method = (
+                "analytical_oracle" if regular_jax_path else "analytical_oracle_limit"
+            )
+            if not regular_jax_path:
+                fallback_reason = (
+                    "singular/saturated input; canonical analytical limit used"
+                )
+            elif "jax" in stats:
+                fallback_reason = (
+                    "auto backend retained NumPy because synchronized JAX runtime "
+                    "exceeded the historical 1.5x threshold"
+                )
+            delta, vega = _greeks_numpy(s, k, r, q, sigma, t)
+
+    dtype, device, jax_enable_x64 = _runtime_metadata(backend_used)
+    delta_obs, vega_obs = _observations(
+        method=method,
+        delta=delta,
+        vega=vega,
+        s=s,
+        k=k,
+        r=r,
+        q=q,
+        sigma=sigma,
+        t=t,
+        fallback_reason=fallback_reason,
+    )
+    return GreekComputationReport(
+        delta=delta_obs,
+        vega=vega_obs,
+        backend_requested=backend,
+        backend_used=backend_used,
+        differentiated_object="Black-Scholes European call price from volatility sigma",
+        dtype=dtype,
+        device=device,
+        jax_enable_x64=jax_enable_x64,
+        fallback_reason=fallback_reason,
+    )
 
 
 def compute_greeks(
@@ -130,17 +525,8 @@ def compute_greeks(
     sigma: float,
     t: float,
     *,
-    backend: Literal["auto", "numpy", "jax"] = "auto",
+    backend: Backend = "auto",
 ) -> Tuple[float, float]:
     """Compute call ``delta`` and volatility ``vega`` choosing between backends."""
 
-    if backend == "jax":
-        if not JAX_AVAILABLE:
-            raise RuntimeError("JAX backend requested but not installed")
-        return _greeks_jax(s, k, r, q, sigma, t)
-    if backend == "numpy":
-        return _greeks_numpy(s, k, r, q, sigma, t)
-    stats = benchmark_greeks(s, k, r, q, sigma, t)
-    if "jax" in stats and stats["jax"][0] <= stats["numpy"][0] * 1.5:
-        return _greeks_jax(s, k, r, q, sigma, t)
-    return _greeks_numpy(s, k, r, q, sigma, t)
+    return compute_greeks_report(s, k, r, q, sigma, t, backend=backend).as_tuple()

--- a/src/finite_element_options/jax_greeks.py
+++ b/src/finite_element_options/jax_greeks.py
@@ -146,7 +146,8 @@ def _bs_price_numpy(
 ) -> float:
     """Black-Scholes call price using the canonical NumPy oracle."""
 
-    return float(_option(k, r, q).call_from_volatility(t, s, sigma))
+    with np.errstate(divide="ignore", over="ignore", under="ignore"):
+        return float(_option(k, r, q).call_from_volatility(t, s, sigma))
 
 
 def _bs_price_jax(
@@ -198,7 +199,8 @@ def _requires_canonical_greek_path(
         return True
     sqrt_t = math.sqrt(t)
     variance_time = sigma * sigma * t
-    d1 = (math.log(s / k) + (r - q) * t + 0.5 * variance_time) / (sigma * sqrt_t)
+    log_moneyness = math.log(s) - math.log(k)
+    d1 = (log_moneyness + (r - q) * t + 0.5 * variance_time) / (sigma * sqrt_t)
     d2 = d1 - sigma * sqrt_t
     if not math.isfinite(d1) or not math.isfinite(d2):
         return True
@@ -211,8 +213,9 @@ def _greeks_numpy(
     """Return ``delta`` and volatility ``vega`` using canonical analytic derivatives."""
 
     option = _option(k, r, q)
-    delta = option.call_delta_from_volatility(t, s, sigma)
-    vega = option.vega_volatility(t, s, sigma)
+    with np.errstate(divide="ignore", over="ignore", under="ignore"):
+        delta = option.call_delta_from_volatility(t, s, sigma)
+        vega = option.vega_volatility(t, s, sigma)
     return float(delta), float(vega)
 
 

--- a/src/finite_element_options/jax_greeks.py
+++ b/src/finite_element_options/jax_greeks.py
@@ -156,7 +156,8 @@ def _bs_price_jax(
     """Black-Scholes call price in JAX space for regular positive-volatility cases."""
 
     assert jnp is not None and jspst is not None
-    d1 = (jnp.log(s / k) + (r - q + 0.5 * sigma**2) * t) / (sigma * jnp.sqrt(t))
+    log_moneyness = jnp.log(s) - jnp.log(k)
+    d1 = (log_moneyness + (r - q + 0.5 * sigma**2) * t) / (sigma * jnp.sqrt(t))
     d2 = d1 - sigma * jnp.sqrt(t)
     return s * jnp.exp(-q * t) * jspst.norm.cdf(d1) - k * jnp.exp(
         -r * t
@@ -197,6 +198,14 @@ def _requires_canonical_greek_path(
         return True
     if s <= 0.0 or k <= 0.0 or t <= 0.0 or sigma <= 0.0:
         return True
+    if (
+        JAX_AVAILABLE
+        and jax is not None
+        and not bool(getattr(jax.config, "jax_enable_x64", False))
+    ):
+        float32 = np.finfo(np.float32)
+        if s < float32.tiny or k < float32.tiny or s > float32.max or k > float32.max:
+            return True
     sqrt_t = math.sqrt(t)
     variance_time = sigma * sigma * t
     log_moneyness = math.log(s) - math.log(k)

--- a/src/finite_element_options/jax_greeks.py
+++ b/src/finite_element_options/jax_greeks.py
@@ -267,6 +267,8 @@ def _bump_errors(
 
     if _requires_canonical_greek_path(s, k, r, q, sigma, t):
         return None, None, None, None
+    if not math.isfinite(delta) or not math.isfinite(vega):
+        return None, None, None, None
     spot_bump = max(abs(s) * 1.0e-4, float(np.spacing(s)))
     spot_down = max(s - spot_bump, s * 0.5, float(np.nextafter(0.0, 1.0)))
     spot_up = s + spot_bump
@@ -309,7 +311,28 @@ def _observations(
         s, k, r, q, sigma, t, delta, vega
     )
     differentiated_object = "Black-Scholes European call price from volatility sigma"
-    status: Literal["finite", "undefined"] = "finite"
+    delta_status: Literal["finite", "undefined"] = (
+        "finite" if math.isfinite(delta) else "undefined"
+    )
+    vega_status: Literal["finite", "undefined"] = (
+        "finite" if math.isfinite(vega) else "undefined"
+    )
+    delta_reason = fallback_reason
+    if delta_status == "undefined":
+        nonfinite_reason = "non-finite delta returned by selected backend/oracle"
+        delta_reason = (
+            f"{delta_reason}; {nonfinite_reason}"
+            if delta_reason is not None
+            else nonfinite_reason
+        )
+    vega_reason = fallback_reason
+    if vega_status == "undefined":
+        nonfinite_reason = "non-finite vega returned by selected backend/oracle"
+        vega_reason = (
+            f"{vega_reason}; {nonfinite_reason}"
+            if vega_reason is not None
+            else nonfinite_reason
+        )
     return (
         GreekObservation(
             greek="delta",
@@ -318,10 +341,10 @@ def _observations(
             differentiated_object=differentiated_object,
             input_variable="spot",
             units="price / spot",
-            status=status,
+            status=delta_status,
             oracle_error_abs=delta_error,
             bump_size=spot_bump,
-            fallback_reason=fallback_reason,
+            fallback_reason=delta_reason,
         ),
         GreekObservation(
             greek="vega",
@@ -330,10 +353,10 @@ def _observations(
             differentiated_object=differentiated_object,
             input_variable="volatility sigma",
             units="price / volatility",
-            status=status,
+            status=vega_status,
             oracle_error_abs=vega_error,
             bump_size=vol_bump,
-            fallback_reason=fallback_reason,
+            fallback_reason=vega_reason,
         ),
     )
 

--- a/tests/test_jax_greeks.py
+++ b/tests/test_jax_greeks.py
@@ -138,6 +138,22 @@ def test_numpy_backend_keeps_finite_extreme_tail_greeks() -> None:
     assert report.delta.method == "analytical_oracle_limit"
 
 
+def test_jax_backend_avoids_ratio_underflow_for_offset_log_moneyness() -> None:
+    """Extreme scale ratios should return finite JAX-requested diagnostics."""
+
+    params = dict(s=1.0e-100, k=1.0e100, r=460.5, q=0.0, sigma=0.2, t=1.0)
+    report = compute_greeks_report(**params, backend="jax")
+    numpy_report = compute_greeks_report(**params, backend="numpy")
+    assert math.isfinite(report.delta.value)
+    assert math.isfinite(report.vega.value)
+    assert report.delta.value == pytest.approx(
+        numpy_report.delta.value, rel=1.0e-5, abs=1.0e-12
+    )
+    assert report.vega.value == pytest.approx(
+        numpy_report.vega.value, rel=1.0e-5, abs=1.0e-12
+    )
+
+
 def test_report_marks_nonfinite_greeks_undefined() -> None:
     """Overflowed analytical Greeks should not be reported as finite diagnostics."""
 

--- a/tests/test_jax_greeks.py
+++ b/tests/test_jax_greeks.py
@@ -126,6 +126,18 @@ def test_numpy_report_labels_boundary_inputs_as_analytical_limits() -> None:
     assert report.delta.fallback_reason == report.fallback_reason
 
 
+def test_numpy_backend_keeps_finite_extreme_tail_greeks() -> None:
+    """JAX tail classification must not make requested NumPy Greeks raise."""
+
+    params = dict(s=1.0e-308, k=1.0e308, r=0.0, q=0.0, sigma=0.2, t=1.0)
+    delta, vega = compute_greeks(**params, backend="numpy")
+    report = compute_greeks_report(**params, backend="numpy")
+    assert delta == pytest.approx(0.0)
+    assert vega == pytest.approx(0.0)
+    assert math.isfinite(report.delta.value)
+    assert report.delta.method == "analytical_oracle_limit"
+
+
 def test_benchmark_greeks_separates_jax_compile_transfer_and_warm_execution() -> None:
     """JAX benchmark metadata should synchronize and split runtime phases."""
 

--- a/tests/test_jax_greeks.py
+++ b/tests/test_jax_greeks.py
@@ -2,9 +2,16 @@
 
 import math
 
+import numpy as np
 import pytest
 
-from finite_element_options.jax_greeks import compute_greeks
+from finite_element_options.jax_greeks import (
+    benchmark_greeks,
+    compute_greeks,
+    compute_greeks_report,
+    recover_grid_delta,
+    recover_grid_delta_report,
+)
 
 
 def test_greeks_consistency():
@@ -55,3 +62,85 @@ def test_jax_backend_delegates_invalid_spot_validation():
 
     with pytest.raises(ValueError, match="spot"):
         compute_greeks(s=-1.0, k=100.0, r=0.05, q=0.0, sigma=0.2, t=1.0, backend="jax")
+
+
+def test_compute_greeks_report_identifies_object_method_units_and_errors() -> None:
+    """Diagnostic report should name method, object, inputs, units and oracle error."""
+
+    params = dict(s=100.0, k=100.0, r=0.05, q=0.0, sigma=0.2, t=1.0)
+    report = compute_greeks_report(**params, backend="jax")
+    assert (
+        report.differentiated_object
+        == "Black-Scholes European call price from volatility sigma"
+    )
+    assert report.delta.greek == "delta"
+    assert report.delta.input_variable == "spot"
+    assert report.delta.units == "price / spot"
+    assert report.delta.method == "jax_ad_analytical_formula"
+    assert report.delta.status == "finite"
+    assert report.delta.oracle_error_abs is not None
+    assert report.delta.oracle_error_abs < 1.0e-3
+    assert report.vega.greek == "vega"
+    assert report.vega.input_variable == "volatility sigma"
+    assert report.vega.units == "price / volatility"
+    assert report.vega.oracle_error_abs is not None
+    assert report.vega.oracle_error_abs < 1.0e-2
+    assert report.dtype
+    assert report.device
+
+
+def test_jax_report_uses_explicit_analytical_limit_for_expiry_boundary() -> None:
+    """Singular expiry inputs should be finite and labeled as analytical limits."""
+
+    params = dict(s=100.0, k=100.0, r=0.05, q=0.0, sigma=0.2, t=0.0)
+    report = compute_greeks_report(**params, backend="jax")
+    assert report.backend_used == "numpy"
+    assert report.delta.method == "analytical_oracle_limit"
+    assert report.fallback_reason is not None
+    assert report.delta.fallback_reason == report.fallback_reason
+    assert report.vega.fallback_reason == report.fallback_reason
+    assert math.isfinite(report.delta.value)
+    assert math.isfinite(report.vega.value)
+
+
+def test_benchmark_greeks_separates_jax_compile_transfer_and_warm_execution() -> None:
+    """JAX benchmark metadata should synchronize and split runtime phases."""
+
+    params = dict(s=100.0, k=100.0, r=0.05, q=0.0, sigma=0.2, t=1.0)
+    stats = benchmark_greeks(**params)
+    assert "numpy" in stats
+    assert stats["numpy"].runtime_seconds >= 0.0
+    assert stats["numpy"].memory_bytes is not None
+    assert stats["numpy"].memory_bytes >= 0
+    assert len(stats["numpy"]) == 2
+    assert stats["numpy"][0] == stats["numpy"].runtime_seconds
+    assert tuple(stats["numpy"])[1] == int(stats["numpy"].memory_bytes or 0)
+    assert stats["numpy"].device == "cpu"
+    if "jax" in stats:
+        jax_stats = stats["jax"]
+        assert jax_stats.synchronized is True
+        assert (
+            jax_stats.transfer_seconds is not None and jax_stats.transfer_seconds >= 0.0
+        )
+        assert (
+            jax_stats.compile_seconds is not None and jax_stats.compile_seconds >= 0.0
+        )
+        assert jax_stats.warmed_seconds is not None and jax_stats.warmed_seconds >= 0.0
+        assert jax_stats.dtype
+        assert jax_stats.device
+        assert isinstance(jax_stats.jax_enable_x64, bool)
+        assert jax_stats.memory_bytes is not None
+        assert jax_stats.memory_bytes >= 0
+
+
+def test_recover_grid_delta_uses_nonuniform_coordinates() -> None:
+    """Grid Delta recovery must use coordinates, not unit-spaced indices."""
+
+    coordinates = np.array([0.0, 0.25, 1.0, 2.0, 4.0], dtype=float)
+    values = coordinates**2
+    recovered = recover_grid_delta(values, coordinates)
+    report = recover_grid_delta_report(values, coordinates)
+    np.testing.assert_allclose(recovered, 2.0 * coordinates, atol=1.0e-12)
+    assert report.method == "coordinate_aware_np_gradient"
+    assert report.differentiated_object == "price grid values"
+    assert report.input_variable == "mesh coordinate"

--- a/tests/test_jax_greeks.py
+++ b/tests/test_jax_greeks.py
@@ -64,6 +64,18 @@ def test_jax_backend_delegates_invalid_spot_validation():
         compute_greeks(s=-1.0, k=100.0, r=0.05, q=0.0, sigma=0.2, t=1.0, backend="jax")
 
 
+def test_bump_error_diagnostics_preserve_positive_small_spot() -> None:
+    """Finite bump diagnostics must not cross into negative spot values."""
+
+    params = dict(s=1.0e-6, k=1.0e-6, r=0.05, q=0.0, sigma=0.2, t=1.0)
+    report = compute_greeks_report(**params, backend="numpy")
+    assert report.delta.method == "analytical_oracle"
+    assert report.delta.bump_size is not None
+    assert 0.0 < report.delta.bump_size < params["s"]
+    assert report.delta.oracle_error_abs is not None
+    assert math.isfinite(report.delta.oracle_error_abs)
+
+
 def test_compute_greeks_report_identifies_object_method_units_and_errors() -> None:
     """Diagnostic report should name method, object, inputs, units and oracle error."""
 
@@ -101,6 +113,17 @@ def test_jax_report_uses_explicit_analytical_limit_for_expiry_boundary() -> None
     assert report.vega.fallback_reason == report.fallback_reason
     assert math.isfinite(report.delta.value)
     assert math.isfinite(report.vega.value)
+
+
+def test_numpy_report_labels_boundary_inputs_as_analytical_limits() -> None:
+    """Requested NumPy reports should still distinguish boundary limit semantics."""
+
+    params = dict(s=100.0, k=100.0, r=0.05, q=0.0, sigma=0.2, t=0.0)
+    report = compute_greeks_report(**params, backend="numpy")
+    assert report.backend_used == "numpy"
+    assert report.delta.method == "analytical_oracle_limit"
+    assert report.fallback_reason is not None
+    assert report.delta.fallback_reason == report.fallback_reason
 
 
 def test_benchmark_greeks_separates_jax_compile_transfer_and_warm_execution() -> None:

--- a/tests/test_jax_greeks.py
+++ b/tests/test_jax_greeks.py
@@ -138,6 +138,19 @@ def test_numpy_backend_keeps_finite_extreme_tail_greeks() -> None:
     assert report.delta.method == "analytical_oracle_limit"
 
 
+def test_report_marks_nonfinite_greeks_undefined() -> None:
+    """Overflowed analytical Greeks should not be reported as finite diagnostics."""
+
+    params = dict(s=100.0, k=100.0, r=0.0, q=-1000.0, sigma=0.2, t=1.0)
+    report = compute_greeks_report(**params, backend="numpy")
+    assert not math.isfinite(report.delta.value)
+    assert report.delta.status == "undefined"
+    assert "non-finite delta returned by selected backend/oracle" in (
+        report.delta.fallback_reason or ""
+    )
+    assert report.delta.oracle_error_abs is None
+
+
 def test_benchmark_greeks_separates_jax_compile_transfer_and_warm_execution() -> None:
     """JAX benchmark metadata should synchronize and split runtime phases."""
 


### PR DESCRIPTION
Closes #46.

## Summary
- replace the ambiguous Greeks helper with auditable reports that identify method, differentiated object, input variable, units, backend, dtype/device, and fallback reason
- distinguish analytical Black-Scholes oracle Greeks, coordinate-aware price-grid Delta recovery, and JAX AD of the analytical formula; no AD-through-FEM claim
- split synchronized JAX benchmark phases into transfer, compile/first execution, warmed execution, and host `tracemalloc` peak memory while preserving the historical tuple-like benchmark contract
- document the diagnostics policy and sync module-ownership/architecture-contract metadata

## Evidence
- `ruff check src tests scripts` — passed
- `pydocstyle src/finite_element_options` — passed
- `mypy --ignore-missing-imports --follow-imports=silent src/finite_element_options/contracts src/finite_element_options/validation scripts/check_ci_contract.py` — passed
- `mypy src/finite_element_options/jax_greeks.py tests/test_jax_greeks.py` — passed
- `python scripts/check_architecture_contract.py` — passed
- `python scripts/check_ci_contract.py` — passed
- `pytest -q tests/architecture --no-cov` — 16 passed
- `pytest -q tests/test_packaging_contract.py --no-cov` — 4 passed
- `pytest --cov=finite_element_options --cov-report=xml --junitxml=junit.xml` — 125 passed, 2 skipped
- `pytest tests/test_benchmark_black_scholes.py --benchmark-json=benchmark.json` — 1 passed
- `python -m build --sdist --wheel && python -m twine check dist/*` — passed
- adversarial review after fixes — APPROVE

## Acceptance criteria mapping
- Method identity: `GreekObservation.method` and `GreekComputationReport.backend_used` distinguish analytical oracle, analytical limit, and JAX AD of the formula.
- Coordinate-aware recovery: `recover_grid_delta_report` requires explicit coordinates and validates monotone finite grids.
- Benchmark timing: `BackendBenchmark` separates JAX transfer/compile/warm execution and records synchronized host-memory metadata.
- Backward compatibility: `compute_greeks(...)` still returns `(delta, vega)` and benchmark entries remain tuple-like.
