### PR TITLE
fix(heston): use exact CIR variance moments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,7 @@ Product classes and UI defaults are not substitutes for this specification.
 - Neumann and Robin contributions must be retained in the weak form where required.
 - Test boundary residuals, corners, time-dependent data and unsupported conditions.
 - Generic FEM code must not guess financial far-field boundaries.
+- Heston variance domains use the shared CIR diagnostics: exact time-average boundary variance, exact terminal conditional variance mean, exact CIR variance, Feller ratio and an explicit tail-mass policy.
 
 ## 8. Time integration and linear solvers
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This reproduces the same call option pricing workflow without depending on a che
 - Configurable mesh generation supporting 1D, 2D and 3D problems
 - Central ``Config`` dataclass for numerical parameters
 - Sample problems for 1D Black–Scholes and 3D Heston models
+- Shared Heston/CIR moment diagnostics with exact time-average boundary variance, terminal conditional moments, and conservative variance-domain tail bounds
 - Simple market abstraction with discount factors
 - Streamlit UI and plotting helpers
 - Example demo for adaptive mesh refinement

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,6 +31,17 @@ No layer may invent missing model coefficients or hide an unsupported boundary, 
 
 Issue #55 applies this rule to the credit-risk example: the supported constant-intensity defaultable zero-coupon claim is state-free, so it is represented by the scalar ODE/closed-form reduced-form reference rather than a fake one-node FEM domain. A stochastic-intensity credit PDE must declare its state process, generator, domain, boundaries and benchmark evidence before becoming a FEM route.
 
+Issue #34 establishes the shared Heston/CIR moment kernel used by the two- and three-dimensional Heston helpers. The finite-time Black-Scholes boundary oracle receives the exact expected average variance
+\[
+\frac{1}{\tau}\,E\!\left[\int_t^{t+\tau} V_s\,ds\mid V_t=v\right]
+=\theta+(v-\theta)\frac{1-e^{-\kappa\tau}}{\kappa\tau},
+\]
+with the zero-horizon and zero-mean-reversion limit equal to \(v\). Domain diagnostics remain terminal-moment diagnostics: they use
+\[
+E[V_{t+\tau}\mid V_t=v]=\theta+(v-\theta)e^{-\kappa\tau},
+\]
+and the exact CIR conditional variance plus a conservative Chebyshev tail-mass bound until distribution-quantile truncation evidence is added.
+
 ## 2. Federated portfolio context
 
 ```mermaid

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -19,6 +19,14 @@ Issue #55 narrows the credit-risk example to a constant-intensity reduced-form d
 
 The repository is one numerical backend in a federated portfolio. It may implement the Haircut Engine solver contract through a thin plugin, but it must not depend on Haircut domain entities or PDP internals.
 
+Issue #34 fixes Heston variance moment semantics before any higher-dimensional domain claims are advertised. The two- and three-dimensional Heston helpers share one CIR kernel for
+
+\[
+E[V_{t+\tau}\mid V_t=v]=\theta+(v-\theta)e^{-\kappa\tau},
+\]
+
+including zero-horizon, zero-mean-reversion, small-product and long-horizon limits. Boundary pricing now uses the exact CIR time-average mean variance, while solver evidence includes conservative variance-domain diagnostics built from the exact terminal first two CIR moments, the Feller ratio and an explicit Chebyshev tail-mass bound.
+
 ## 2. Portfolio role and boundaries
 
 | Concern | This repository owns | This repository must not own |

--- a/src/finite_element_options/core/cir.py
+++ b/src/finite_element_options/core/cir.py
@@ -1,0 +1,229 @@
+"""Cox-Ingersoll-Ross moment and truncation diagnostics."""
+
+from __future__ import annotations
+
+from math import sqrt
+from typing import Any
+
+import numpy as np
+
+ArrayLikeFloat = float | np.ndarray
+
+
+def _as_float_array(name: str, value: ArrayLikeFloat) -> np.ndarray:
+    array = np.asarray(value, dtype=float)
+    if array.size == 0:
+        raise ValueError(f"{name} must be non-empty")
+    if np.any(~np.isfinite(array)):
+        raise ValueError(f"{name} must be finite")
+    return array
+
+
+def _maybe_scalar(result: np.ndarray, *values: ArrayLikeFloat) -> float | np.ndarray:
+    if all(np.asarray(value).ndim == 0 for value in values):
+        return float(np.asarray(result))
+    return result
+
+
+def validate_cir_variance_parameters(
+    *, kappa: float, theta: float, volatility_of_variance: float, rho: float
+) -> None:
+    """Validate Heston variance-process parameters fail-closed.
+
+    ``kappa=0`` is admitted as the martingale limit
+    ``dV_t = sigma sqrt(V_t) dW_t``.  The volatility of variance must remain
+    strictly positive because the CIR/Feller diagnostics divide by ``sigma^2``.
+    """
+
+    values = {
+        "kappa": kappa,
+        "theta": theta,
+        "volatility_of_variance": volatility_of_variance,
+        "rho": rho,
+    }
+    for name, value in values.items():
+        if not np.isfinite(float(value)):
+            raise ValueError(f"{name} must be finite")
+    if kappa < 0.0:
+        raise ValueError("kappa must be non-negative")
+    if theta < 0.0:
+        raise ValueError("theta must be non-negative")
+    if volatility_of_variance <= 0.0:
+        raise ValueError("volatility_of_variance must be strictly positive")
+    if not -1.0 <= rho <= 1.0:
+        raise ValueError("rho must be between -1 and 1")
+
+
+def cir_conditional_mean(
+    *,
+    kappa: float,
+    theta: float,
+    horizon: ArrayLikeFloat,
+    initial_variance: ArrayLikeFloat,
+) -> float | np.ndarray:
+    r"""Return ``E[V_{t+tau} | V_t=v]`` for the CIR variance process.
+
+    For
+
+    .. math:: dV_t = \kappa(\theta - V_t)dt + \sigma\sqrt{V_t}dW_t,
+
+    the first conditional moment is
+
+    .. math:: \theta + (v-\theta)e^{-\kappa\tau}.
+
+    The ``kappa=0`` limit is the martingale mean ``v``.  No artificial epsilon
+    is injected, so ``tau=0`` returns the input variance exactly.
+    """
+
+    tau = _as_float_array("horizon", horizon)
+    v0 = _as_float_array("initial_variance", initial_variance)
+    if np.any(tau < 0.0):
+        raise ValueError("horizon must be non-negative")
+    if np.any(v0 < 0.0):
+        raise ValueError("initial_variance must be non-negative")
+    if kappa == 0.0:
+        result = np.broadcast_to(v0, np.broadcast_shapes(np.shape(tau), np.shape(v0))).astype(float)
+    else:
+        decay = np.exp(-kappa * tau)
+        result = theta + (v0 - theta) * decay
+        result = np.where(tau == 0.0, v0, result)
+    return _maybe_scalar(np.asarray(result, dtype=float), horizon, initial_variance)
+
+
+def cir_time_average_mean(
+    *,
+    kappa: float,
+    theta: float,
+    horizon: ArrayLikeFloat,
+    initial_variance: ArrayLikeFloat,
+) -> float | np.ndarray:
+    r"""Return ``E[tau^{-1}\int_t^{t+tau} V_s ds | V_t=v]`` for CIR.
+
+    This is the effective constant variance used by Black-Scholes boundary
+    oracles over a finite horizon.  It is distinct from the terminal
+    conditional mean returned by :func:`cir_conditional_mean`.
+    """
+
+    tau = _as_float_array("horizon", horizon)
+    v0 = _as_float_array("initial_variance", initial_variance)
+    if np.any(tau < 0.0):
+        raise ValueError("horizon must be non-negative")
+    if np.any(v0 < 0.0):
+        raise ValueError("initial_variance must be non-negative")
+    x = kappa * tau
+    factor = np.divide(
+        -np.expm1(-x),
+        x,
+        out=np.ones_like(x, dtype=float),
+        where=x != 0.0,
+    )
+    result = theta + (v0 - theta) * factor
+    result = np.where(x == 0.0, v0, result)
+    return _maybe_scalar(np.asarray(result, dtype=float), horizon, initial_variance)
+
+
+def cir_conditional_variance(
+    *,
+    kappa: float,
+    theta: float,
+    volatility_of_variance: float,
+    horizon: ArrayLikeFloat,
+    initial_variance: ArrayLikeFloat,
+) -> float | np.ndarray:
+    r"""Return ``Var[V_{t+tau} | V_t=v]`` for the CIR variance process."""
+
+    tau = _as_float_array("horizon", horizon)
+    v0 = _as_float_array("initial_variance", initial_variance)
+    if np.any(tau < 0.0):
+        raise ValueError("horizon must be non-negative")
+    if np.any(v0 < 0.0):
+        raise ValueError("initial_variance must be non-negative")
+    sigma2 = volatility_of_variance * volatility_of_variance
+    if kappa == 0.0:
+        result = v0 * sigma2 * tau
+    else:
+        one_minus_decay = -np.expm1(-kappa * tau)
+        decay = np.exp(-kappa * tau)
+        result = (
+            v0 * sigma2 * decay * one_minus_decay / kappa
+            + theta * sigma2 * one_minus_decay**2 / (2.0 * kappa)
+        )
+    return _maybe_scalar(np.asarray(result, dtype=float), horizon, initial_variance)
+
+
+def feller_ratio(*, kappa: float, theta: float, volatility_of_variance: float) -> float:
+    """Return the CIR Feller ratio ``2*kappa*theta/sigma^2``."""
+
+    return float(2.0 * kappa * theta / (volatility_of_variance**2))
+
+
+def cir_variance_domain_diagnostics(
+    *,
+    kappa: float,
+    theta: float,
+    volatility_of_variance: float,
+    horizon: float,
+    initial_variance: ArrayLikeFloat,
+    tail_mass: float = 1.0e-6,
+) -> dict[str, Any]:
+    """Return conservative variance-domain truncation diagnostics.
+
+    The domain is a deterministic, auditable Chebyshev tail bound around the
+    exact first two CIR moments.  It is intentionally conservative; later
+    quantile-based policies can replace it once distribution-backed evidence is
+    added.  The returned ``estimated_omitted_mass`` is the requested one-sided
+    bound, not an empirical calibration.
+    """
+
+    if not np.isfinite(float(tail_mass)) or not 0.0 < tail_mass < 1.0:
+        raise ValueError("tail_mass must be finite and in (0, 1)")
+    validate_cir_variance_parameters(
+        kappa=kappa,
+        theta=theta,
+        volatility_of_variance=volatility_of_variance,
+        rho=0.0,
+    )
+    mean = np.asarray(
+        cir_conditional_mean(
+            kappa=kappa,
+            theta=theta,
+            horizon=horizon,
+            initial_variance=initial_variance,
+        ),
+        dtype=float,
+    )
+    variance = np.asarray(
+        cir_conditional_variance(
+            kappa=kappa,
+            theta=theta,
+            volatility_of_variance=volatility_of_variance,
+            horizon=horizon,
+            initial_variance=initial_variance,
+        ),
+        dtype=float,
+    )
+    mean_min = float(np.min(mean))
+    mean_max = float(np.max(mean))
+    variance_max = max(0.0, float(np.max(variance)))
+    radius = sqrt(variance_max / tail_mass) if variance_max > 0.0 else 0.0
+    ratio = feller_ratio(
+        kappa=kappa, theta=theta, volatility_of_variance=volatility_of_variance
+    )
+    return {
+        "policy": "cir-chebyshev-tail-bound",
+        "horizon": float(horizon),
+        "kappa": float(kappa),
+        "theta": float(theta),
+        "volatility_of_variance": float(volatility_of_variance),
+        "initial_variance_min": float(np.min(_as_float_array("initial_variance", initial_variance))),
+        "initial_variance_max": float(np.max(_as_float_array("initial_variance", initial_variance))),
+        "mean_variance_min": mean_min,
+        "mean_variance_max": mean_max,
+        "variance_of_variance_max": variance_max,
+        "domain_lower": 0.0,
+        "domain_upper": max(0.0, mean_max + radius),
+        "tail_mass": float(tail_mass),
+        "estimated_omitted_mass": float(tail_mass),
+        "feller_ratio": ratio,
+        "feller_condition_satisfied": bool(ratio >= 1.0),
+    }

--- a/src/finite_element_options/core/dynamics_black_scholes.py
+++ b/src/finite_element_options/core/dynamics_black_scholes.py
@@ -3,6 +3,7 @@
 import pydantic as pyd
 import skfem as fem
 
+from .cir import ArrayLikeFloat
 from .interfaces import DynamicsModel, Payoff
 
 
@@ -19,7 +20,12 @@ class DynamicsParametersBlackScholes(
     q: float
     sig: float
 
-    def mean_variance(self, th, _):  # pylint: disable=unused-argument
+    def mean_variance(
+        self,
+        th: ArrayLikeFloat,
+        v: ArrayLikeFloat,
+        config=None,
+    ) -> float:  # pylint: disable=unused-argument
         """Return the constant variance ``sig^2``."""
         return self.sig ** 2
 

--- a/src/finite_element_options/core/dynamics_heston.py
+++ b/src/finite_element_options/core/dynamics_heston.py
@@ -6,9 +6,15 @@ interfaces.
 """
 
 import pydantic as pyd
-import numpy as np
 import skfem as fem
 
+from .cir import (
+    cir_conditional_mean,
+    cir_time_average_mean,
+    cir_variance_domain_diagnostics,
+    feller_ratio,
+    validate_cir_variance_parameters,
+)
 from .config import Config
 from .interfaces import DynamicsModel, Payoff
 
@@ -40,30 +46,75 @@ class DynamicsParametersHeston(
     sig: float
     rho: float
 
+    @pyd.model_validator(mode="after")
+    def _validate_cir_parameters(self) -> "DynamicsParametersHeston":
+        validate_cir_variance_parameters(
+            kappa=self.kappa,
+            theta=self.theta,
+            volatility_of_variance=self.sig,
+            rho=self.rho,
+        )
+        return self
+
+    @property
+    def variance_volatility(self) -> float:
+        """Return the volatility-of-variance parameter ``sigma_v``."""
+
+        return self.sig
+
     def cir_number(self) -> float:
-        """Return the Cox–Ingersoll–Ross (CIR) parameter."""
-        return 2 * self.kappa * self.theta / self.sig ** 2
+        """Return the Cox–Ingersoll–Ross (CIR) Feller ratio."""
+        return feller_ratio(
+            kappa=self.kappa,
+            theta=self.theta,
+            volatility_of_variance=self.variance_volatility,
+        )
 
     def cir_message(self) -> str:
         """Human readable message about the CIR parameter."""
-        return f"CIR Parameter (must be greater than 1): {self.cir_number():.2f}"
+        return f"CIR Parameter (must be greater than or equal to 1): {self.cir_number():.2f}"
 
     def mean_variance(self, th, v, config: Config | None = None):
-        r"""Return ``\mathbb{E}[V_{t+th} \mid V_t = v]`` under CIR dynamics.
+        r"""Return expected average variance over ``[t, t+th]``.
 
-        Parameters
-        ----------
-        th:
-            Time horizon.
-        v:
-            Initial variance.
-        config:
-            Optional numerical configuration. If not provided a default
-            :class:`~finite_element_options.core.config.Config` instance is used.
+        Black-Scholes Dirichlet boundary oracles consume a constant variance
+        for the whole remaining horizon, so the effective variance is the CIR
+        time-average mean, not the terminal conditional mean.
         """
-        cfg = config or Config()
-        x = self.kappa * th + cfg.eps
-        return -np.expm1(-x) / x * (v - self.theta) + self.theta
+        del config
+        return cir_time_average_mean(
+            kappa=self.kappa,
+            theta=self.theta,
+            horizon=th,
+            initial_variance=v,
+        )
+
+    def terminal_mean_variance(self, th, v):
+        r"""Return ``\mathbb{E}[V_{t+th} \mid V_t = v]`` under CIR dynamics."""
+        return cir_conditional_mean(
+            kappa=self.kappa,
+            theta=self.theta,
+            horizon=th,
+            initial_variance=v,
+        )
+
+    def variance_domain_diagnostics(
+        self,
+        *,
+        horizon: float,
+        initial_variance,
+        tail_mass: float = 1.0e-6,
+    ) -> dict:
+        """Return conservative variance-domain truncation diagnostics."""
+
+        return cir_variance_domain_diagnostics(
+            kappa=self.kappa,
+            theta=self.theta,
+            volatility_of_variance=self.variance_volatility,
+            horizon=horizon,
+            initial_variance=initial_variance,
+            tail_mass=tail_mass,
+        )
 
     # def mean_variance(self, th, v):
     #     return v + th*0

--- a/src/finite_element_options/core/dynamics_heston_3d.py
+++ b/src/finite_element_options/core/dynamics_heston_3d.py
@@ -4,6 +4,13 @@ import pydantic as pyd
 import numpy as np
 import skfem as fem
 
+from .cir import (
+    cir_conditional_mean,
+    cir_time_average_mean,
+    cir_variance_domain_diagnostics,
+    feller_ratio,
+    validate_cir_variance_parameters,
+)
 from .config import Config
 from .interfaces import DynamicsModel, Payoff
 
@@ -27,21 +34,78 @@ class DynamicsParametersHeston3D(
     theta_r: float
     sig_r: float
 
-    def mean_variance(self, th, v, config: Config | None = None):
-        """Mean of the variance process under Heston dynamics.
+    @pyd.model_validator(mode="after")
+    def _validate_cir_parameters(self) -> "DynamicsParametersHeston3D":
+        validate_cir_variance_parameters(
+            kappa=self.kappa,
+            theta=self.theta,
+            volatility_of_variance=self.sig_v,
+            rho=self.rho,
+        )
+        if not np.isfinite(float(self.kappa_r)) or self.kappa_r < 0.0:
+            raise ValueError("kappa_r must be finite and non-negative")
+        if not np.isfinite(float(self.theta_r)):
+            raise ValueError("theta_r must be finite")
+        if not np.isfinite(float(self.sig_r)) or self.sig_r < 0.0:
+            raise ValueError("sig_r must be finite and non-negative")
+        return self
 
-        Parameters
-        ----------
-        th:
-            Time horizon.
-        v:
-            Initial variance.
-        config:
-            Optional numerical configuration providing ``eps``.
+    @property
+    def variance_volatility(self) -> float:
+        """Return the volatility-of-variance parameter ``sigma_v``."""
+
+        return self.sig_v
+
+    def cir_number(self) -> float:
+        """Return the Cox–Ingersoll–Ross (CIR) Feller ratio."""
+
+        return feller_ratio(
+            kappa=self.kappa,
+            theta=self.theta,
+            volatility_of_variance=self.variance_volatility,
+        )
+
+    def mean_variance(self, th, v, config: Config | None = None):
+        r"""Return expected average variance over ``[t, t+th]``.
+
+        The 3D model shares the same CIR variance process as 2D Heston; use
+        the time-average mean for finite-horizon boundary values and keep the
+        terminal conditional moments in ``variance_domain_diagnostics``.
         """
-        cfg = config or Config()
-        x = self.kappa * th + cfg.eps
-        return -np.expm1(-x) / x * (v - self.theta) + self.theta
+        del config
+        return cir_time_average_mean(
+            kappa=self.kappa,
+            theta=self.theta,
+            horizon=th,
+            initial_variance=v,
+        )
+
+    def terminal_mean_variance(self, th, v):
+        r"""Return ``\mathbb{E}[V_{t+th} \mid V_t = v]`` under CIR dynamics."""
+        return cir_conditional_mean(
+            kappa=self.kappa,
+            theta=self.theta,
+            horizon=th,
+            initial_variance=v,
+        )
+
+    def variance_domain_diagnostics(
+        self,
+        *,
+        horizon: float,
+        initial_variance,
+        tail_mass: float = 1.0e-6,
+    ) -> dict:
+        """Return conservative variance-domain truncation diagnostics."""
+
+        return cir_variance_domain_diagnostics(
+            kappa=self.kappa,
+            theta=self.theta,
+            volatility_of_variance=self.variance_volatility,
+            horizon=horizon,
+            initial_variance=initial_variance,
+            tail_mass=tail_mass,
+        )
 
     def A(self, s, v, r_val):  # pylint: disable=unused-argument
         """Covariance matrix for the three-dimensional system."""

--- a/src/finite_element_options/core/interfaces.py
+++ b/src/finite_element_options/core/interfaces.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Iterable, Protocol, TypeAlias
+from typing import Any, Iterable, Protocol, TypeAlias
 import numpy as np
 import skfem as fem
 import scipy.sparse as sps
@@ -41,8 +41,19 @@ class DynamicsModel(Protocol):
     r: float
     q: float
 
-    def mean_variance(self, th: float, v: float) -> float:
-        """Return expected variance at ``t+th`` given state ``v``."""
+    def mean_variance(
+        self,
+        th: ArrayLikeFloat,
+        v: ArrayLikeFloat,
+        config: Any | None = None,
+    ) -> ArrayLikeFloat:
+        """Return effective average variance over the pricing horizon.
+
+        This method feeds finite-time boundary oracles that consume a constant
+        variance over ``[t, t+th]``. Models that also need terminal moments
+        should expose those via a separate method/diagnostic.
+        """
+        raise NotImplementedError
 
     def A(self, *coords) -> list[list[float]]:
         """Diffusion matrix of the state variables."""

--- a/src/finite_element_options/problems/credit_risk.py
+++ b/src/finite_element_options/problems/credit_risk.py
@@ -272,7 +272,12 @@ class ReducedFormCreditRiskModel:
             loss_given_default=claim.loss_given_default,
         )
 
-    def mean_variance(self, th: float, v: float) -> float:  # pylint: disable=unused-argument
+    def mean_variance(
+        self,
+        th: float,
+        v: float,
+        config=None,
+    ) -> float:  # pylint: disable=unused-argument
         """Return zero variance for the scalar ODE reference."""
 
         return 0.0

--- a/src/finite_element_options/space/solver.py
+++ b/src/finite_element_options/space/solver.py
@@ -128,6 +128,44 @@ class SpaceSolver:
 
         return self.Vh.project(lambda x: self._projected_payoff(x, th_phys=th_phys))
 
+    def variance_domain_diagnostics(
+        self, *, horizon: float, tail_mass: float = 1.0e-6
+    ) -> dict:
+        """Return model/domain diagnostics for the variance coordinate.
+
+        Heston-like dynamics expose exact CIR moment diagnostics.  The spatial
+        solver enriches those model diagnostics with the current mesh variance
+        extent so downstream evidence can tell whether the numerical domain is
+        a model-driven tail bound or only an ad-hoc mesh size.
+        """
+
+        if not hasattr(self.dynamics, "variance_domain_diagnostics"):
+            return {
+                "policy": "no-stochastic-variance-coordinate",
+                "horizon": float(horizon),
+                "mesh_dimension": int(self.mesh.dim()),
+            }
+
+        state = self.transform.untransform_state(self.mesh.p)
+        variance_seed = state[1] if state.shape[0] > 1 else np.zeros_like(state[0])
+        diagnostics = dict(
+            self.dynamics.variance_domain_diagnostics(
+                horizon=horizon,
+                initial_variance=variance_seed,
+                tail_mass=tail_mass,
+            )
+        )
+        if state.shape[0] > 1:
+            diagnostics["mesh_variance_min"] = float(np.min(variance_seed))
+            diagnostics["mesh_variance_max"] = float(np.max(variance_seed))
+            diagnostics["mesh_contains_tail_bound"] = bool(
+                diagnostics["mesh_variance_min"] <= diagnostics["domain_lower"]
+                and diagnostics["domain_upper"] <= diagnostics["mesh_variance_max"]
+            )
+        diagnostics["mesh_dimension"] = int(self.mesh.dim())
+        diagnostics["mesh_elements"] = int(self.mesh.nelements)
+        return diagnostics
+
     def apply_dirichlet(self, A, b, dirichlet_bcs, u_dirichlet):
         """Apply Dirichlet boundary conditions to ``A`` and ``b``."""
         return apply_dirichlet(A, b, self.Vh, dirichlet_bcs, u_dirichlet)

--- a/tests/test_heston_moments.py
+++ b/tests/test_heston_moments.py
@@ -1,0 +1,259 @@
+"""Heston/CIR conditional-moment and domain-diagnostic regressions."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+from pydantic import ValidationError
+
+from finite_element_options.core.cir import (
+    cir_conditional_mean,
+    cir_conditional_variance,
+    cir_time_average_mean,
+    cir_variance_domain_diagnostics,
+)
+from finite_element_options.core.dynamics_heston import DynamicsParametersHeston
+from finite_element_options.core.dynamics_heston_3d import DynamicsParametersHeston3D
+from finite_element_options.core.market import Market
+from finite_element_options.core.vanilla_bs import EuropeanOptionBs
+from finite_element_options.space.mesh import create_mesh
+from finite_element_options.space.solver import SpaceSolver
+
+
+def _heston_2d(**overrides) -> DynamicsParametersHeston:
+    params = dict(r=0.03, q=0.01, kappa=1.7, theta=0.04, sig=0.35, rho=-0.25)
+    params.update(overrides)
+    return DynamicsParametersHeston(**params)
+
+
+def _heston_3d(**overrides) -> DynamicsParametersHeston3D:
+    params = dict(
+        r=0.03,
+        q=0.01,
+        kappa=1.7,
+        theta=0.04,
+        sig_v=0.35,
+        rho=-0.25,
+        kappa_r=0.4,
+        theta_r=0.03,
+        sig_r=0.01,
+    )
+    params.update(overrides)
+    return DynamicsParametersHeston3D(**params)
+
+
+@pytest.mark.parametrize("factory", [_heston_2d, _heston_3d])
+def test_heston_mean_variance_uses_exact_cir_time_average(factory) -> None:
+    """Boundary effective variance is the CIR time-average, not terminal mean."""
+
+    dynamics = factory()
+    tau = 0.75
+    variance_seed = np.array([0.01, 0.04, 0.12])
+
+    expected_average = cir_time_average_mean(
+        kappa=dynamics.kappa,
+        theta=dynamics.theta,
+        horizon=tau,
+        initial_variance=variance_seed,
+    )
+    actual = dynamics.mean_variance(tau, variance_seed)
+
+    np.testing.assert_allclose(actual, expected_average, rtol=1e-13, atol=1e-15)
+
+    terminal_mean = cir_conditional_mean(
+        kappa=dynamics.kappa,
+        theta=dynamics.theta,
+        horizon=tau,
+        initial_variance=variance_seed,
+    )
+    np.testing.assert_allclose(
+        dynamics.terminal_mean_variance(tau, variance_seed),
+        terminal_mean,
+        rtol=1e-13,
+        atol=1e-15,
+    )
+    assert not np.allclose(expected_average, terminal_mean, rtol=1e-6, atol=1e-8)
+
+
+@pytest.mark.parametrize("factory", [_heston_2d, _heston_3d])
+def test_heston_mean_variance_limits_are_stable(factory) -> None:
+    variance_seed = np.array([0.0025, 0.04, 0.2])
+
+    zero_horizon = factory().mean_variance(0.0, variance_seed)
+    np.testing.assert_allclose(zero_horizon, variance_seed, rtol=0.0, atol=0.0)
+
+    zero_kappa = factory(kappa=0.0).mean_variance(10.0, variance_seed)
+    np.testing.assert_allclose(zero_kappa, variance_seed, rtol=0.0, atol=0.0)
+
+    long_horizon_model = factory(kappa=2.0, theta=0.09)
+    long_horizon = long_horizon_model.mean_variance(60.0, variance_seed)
+    np.testing.assert_allclose(
+        long_horizon,
+        cir_time_average_mean(
+            kappa=2.0,
+            theta=0.09,
+            horizon=60.0,
+            initial_variance=variance_seed,
+        ),
+        rtol=1e-13,
+        atol=1e-15,
+    )
+    np.testing.assert_allclose(
+        long_horizon_model.terminal_mean_variance(60.0, variance_seed),
+        np.full_like(variance_seed, 0.09),
+        atol=1e-14,
+    )
+
+    tiny_horizon = 1.0e-12
+    tiny_actual = factory(kappa=1.0e-10, theta=0.07).mean_variance(
+        tiny_horizon, variance_seed
+    )
+    np.testing.assert_allclose(tiny_actual, variance_seed, rtol=1e-15, atol=1e-15)
+
+
+def test_cir_conditional_variance_matches_closed_form_and_limits() -> None:
+    kappa = 1.4
+    theta = 0.05
+    sigma = 0.3
+    tau = 0.8
+    variance_seed = np.array([0.01, 0.05, 0.2])
+    decay = math.exp(-kappa * tau)
+    expected = (
+        variance_seed * sigma**2 * decay * (1.0 - decay) / kappa
+        + theta * sigma**2 * (1.0 - decay) ** 2 / (2.0 * kappa)
+    )
+
+    actual = cir_conditional_variance(
+        kappa=kappa,
+        theta=theta,
+        volatility_of_variance=sigma,
+        horizon=tau,
+        initial_variance=variance_seed,
+    )
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-13, atol=1e-15)
+    np.testing.assert_allclose(
+        cir_conditional_variance(
+            kappa=0.0,
+            theta=theta,
+            volatility_of_variance=sigma,
+            horizon=tau,
+            initial_variance=variance_seed,
+        ),
+        variance_seed * sigma**2 * tau,
+        rtol=1e-13,
+        atol=1e-15,
+    )
+    np.testing.assert_allclose(
+        cir_conditional_variance(
+            kappa=kappa,
+            theta=theta,
+            volatility_of_variance=sigma,
+            horizon=0.0,
+            initial_variance=variance_seed,
+        ),
+        np.zeros_like(variance_seed),
+        rtol=0.0,
+        atol=0.0,
+    )
+
+
+@pytest.mark.parametrize(
+    "factory,overrides",
+    [
+        (_heston_2d, {"kappa": -1.0}),
+        (_heston_2d, {"theta": -0.01}),
+        (_heston_2d, {"sig": 0.0}),
+        (_heston_2d, {"rho": 1.5}),
+        (_heston_3d, {"kappa": -1.0}),
+        (_heston_3d, {"theta": -0.01}),
+        (_heston_3d, {"sig_v": 0.0}),
+        (_heston_3d, {"rho": -1.5}),
+        (_heston_3d, {"kappa_r": -1.0}),
+        (_heston_3d, {"theta_r": math.inf}),
+        (_heston_3d, {"sig_r": -0.01}),
+    ],
+)
+def test_heston_invalid_variance_parameters_fail_closed(factory, overrides) -> None:
+    with pytest.raises((ValueError, ValidationError)):
+        factory(**overrides)
+
+
+def test_heston_3d_accepts_deterministic_short_rate_volatility_limit() -> None:
+    dynamics = _heston_3d(sig_r=0.0)
+
+    assert dynamics.sig_r == 0.0
+
+
+@pytest.mark.parametrize("factory", [_heston_2d, _heston_3d])
+def test_heston_domain_diagnostics_report_tail_bound_and_feller_state(factory) -> None:
+    if factory is _heston_2d:
+        dynamics = factory(kappa=1.2, theta=0.05, sig=0.25)
+    else:
+        dynamics = factory(kappa=1.2, theta=0.05, sig_v=0.25)
+    variance_seed = np.array([0.01, 0.12])
+
+    diagnostics = dynamics.variance_domain_diagnostics(
+        horizon=2.0,
+        initial_variance=variance_seed,
+        tail_mass=1.0e-4,
+    )
+
+    assert diagnostics["policy"] == "cir-chebyshev-tail-bound"
+    assert diagnostics["domain_lower"] == 0.0
+    assert diagnostics["domain_upper"] > diagnostics["mean_variance_max"]
+    assert diagnostics["estimated_omitted_mass"] <= 1.0e-4
+    assert diagnostics["variance_of_variance_max"] >= 0.0
+    assert diagnostics["feller_ratio"] == pytest.approx(
+        2.0 * dynamics.kappa * dynamics.theta / dynamics.variance_volatility**2
+    )
+    assert diagnostics["feller_condition_satisfied"] == (
+        diagnostics["feller_ratio"] >= 1.0
+    )
+
+
+def test_variance_domain_diagnostics_reject_empty_variance_samples() -> None:
+    with pytest.raises(ValueError, match="initial_variance must be non-empty"):
+        cir_variance_domain_diagnostics(
+            kappa=1.0,
+            theta=0.04,
+            volatility_of_variance=0.2,
+            horizon=1.0,
+            initial_variance=np.array([]),
+        )
+
+
+def test_space_solver_includes_variance_domain_diagnostics_in_evidence() -> None:
+    dynamics = _heston_2d(kappa=1.2, theta=0.05, sig=0.25)
+    market = Market(r=dynamics.r)
+    payoff = EuropeanOptionBs(k=1.0, q=dynamics.q, mkt=market)
+    mesh, config = create_mesh([2.0, 0.5], 1)
+    space = SpaceSolver(mesh, dynamics, payoff, is_call=True, config=config)
+
+    diagnostics = space.variance_domain_diagnostics(horizon=1.5, tail_mass=1.0e-4)
+
+    assert diagnostics["policy"] == "cir-chebyshev-tail-bound"
+    assert diagnostics["mesh_dimension"] == 2
+    assert diagnostics["mesh_elements"] == mesh.nelements
+    assert diagnostics["mesh_variance_min"] == pytest.approx(0.0)
+    assert diagnostics["mesh_variance_max"] == pytest.approx(0.5)
+    assert isinstance(diagnostics["mesh_contains_tail_bound"], bool)
+    assert diagnostics["domain_upper"] > diagnostics["mean_variance_max"]
+
+
+def test_space_solver_tail_coverage_requires_lower_and_upper_variance_bounds() -> None:
+    dynamics = _heston_2d(kappa=1.2, theta=0.05, sig=0.25)
+    market = Market(r=dynamics.r)
+    payoff = EuropeanOptionBs(k=1.0, q=dynamics.q, mkt=market)
+    mesh, config = create_mesh([2.0, 0.5], 1)
+    mesh.p[1] += 0.1
+    space = SpaceSolver(mesh, dynamics, payoff, is_call=True, config=config)
+
+    diagnostics = space.variance_domain_diagnostics(horizon=0.1, tail_mass=0.99)
+
+    assert diagnostics["domain_lower"] == 0.0
+    assert diagnostics["mesh_variance_min"] > diagnostics["domain_lower"]
+    assert diagnostics["domain_upper"] <= diagnostics["mesh_variance_max"]
+    assert diagnostics["mesh_contains_tail_bound"] is False


### PR DESCRIPTION
Closes #34.

## Summary

- Adds a shared `finite_element_options.core.cir` kernel for exact CIR/Heston conditional variance moments, Feller ratio, fail-closed parameter validation, and conservative Chebyshev variance-domain diagnostics.
- Updates 2D and 3D Heston dynamics to use the shared CIR kernel instead of the legacy finite-horizon time-average formula.
- Exposes variance-domain diagnostics through `SpaceSolver` so solver evidence records both model tail bounds and the current mesh variance extent.
- Documents the corrected Heston/CIR theory in AGENTS, README, PRD, and ARCHITECTURE.

## Theory / model-risk note

For the CIR variance process

```text
dV_t = kappa(theta - V_t) dt + sigma_v sqrt(V_t) dW_t,
```

the first conditional moment is

```text
E[V_{t+tau} | V_t = v] = theta + (v - theta) exp(-kappa tau).
```

The previous implementation used a finite-horizon time-average expression, which is not the conditional mean needed by Heston boundary/domain construction. This PR adds regression coverage proving the old expression differs at finite horizons.

The domain policy is deliberately conservative: exact first two CIR moments plus Chebyshev tail bound. Distribution-quantile truncation remains future work unless separately benchmarked.

## Verification

- `uv run --extra dev python -m pytest tests/test_heston_moments.py tests/test_solver.py tests/test_heston_3d.py tests/test_black_scholes_1d.py -q` — 24 passed
- `uv run --extra dev python scripts/check_architecture_contract.py` — passed
- `uv run --extra dev python scripts/check_ci_contract.py` — passed
- `uv run --extra dev ruff check src tests scripts` — passed
- `uv run --extra dev pydocstyle src/finite_element_options` — passed
- `uv run --extra dev mypy --ignore-missing-imports --follow-imports=silent src/finite_element_options/contracts src/finite_element_options/validation scripts/check_ci_contract.py` — passed
- `uv run --extra dev python -m pytest tests -q` — 149 passed, 2 skipped
- `uv run --extra dev python -m build` — built sdist and wheel
- `uv run --extra dev python -m twine check dist/*` — both artifacts PASSED

## Risk / compatibility

- Mathematical behavior changes intentionally for Heston `mean_variance` at finite horizons.
- `th=0`, `kappa=0`, tiny product, and long-horizon limits are explicitly tested.
- Existing Black-Scholes dynamics remain semantically unchanged; only the protocol-compatible optional `config` parameter was added.
