### PR TITLE
fix(heston): clamp CIR variance domain to initial state

### DIFF
--- a/src/finite_element_options/core/cir.py
+++ b/src/finite_element_options/core/cir.py
@@ -209,19 +209,22 @@ def cir_variance_domain_diagnostics(
     ratio = feller_ratio(
         kappa=kappa, theta=theta, volatility_of_variance=volatility_of_variance
     )
+    initial_variance_array = _as_float_array("initial_variance", initial_variance)
+    initial_variance_min = float(np.min(initial_variance_array))
+    initial_variance_max = float(np.max(initial_variance_array))
     return {
         "policy": "cir-chebyshev-tail-bound",
         "horizon": float(horizon),
         "kappa": float(kappa),
         "theta": float(theta),
         "volatility_of_variance": float(volatility_of_variance),
-        "initial_variance_min": float(np.min(_as_float_array("initial_variance", initial_variance))),
-        "initial_variance_max": float(np.max(_as_float_array("initial_variance", initial_variance))),
+        "initial_variance_min": initial_variance_min,
+        "initial_variance_max": initial_variance_max,
         "mean_variance_min": mean_min,
         "mean_variance_max": mean_max,
         "variance_of_variance_max": variance_max,
         "domain_lower": 0.0,
-        "domain_upper": max(0.0, mean_max + radius),
+        "domain_upper": max(0.0, initial_variance_max, mean_max + radius),
         "tail_mass": float(tail_mass),
         "estimated_omitted_mass": float(tail_mass),
         "feller_ratio": ratio,

--- a/tests/test_heston_moments.py
+++ b/tests/test_heston_moments.py
@@ -214,6 +214,21 @@ def test_heston_domain_diagnostics_report_tail_bound_and_feller_state(factory) -
     )
 
 
+def test_variance_domain_upper_bound_contains_initial_variance() -> None:
+    """Sharp mean reversion must not truncate the starting variance state."""
+
+    diagnostics = cir_variance_domain_diagnostics(
+        kappa=10.0,
+        theta=0.01,
+        volatility_of_variance=0.01,
+        horizon=1.0,
+        initial_variance=np.array([1.0]),
+    )
+
+    assert diagnostics["mean_variance_max"] < diagnostics["initial_variance_max"]
+    assert diagnostics["domain_upper"] >= diagnostics["initial_variance_max"]
+
+
 def test_variance_domain_diagnostics_reject_empty_variance_samples() -> None:
     with pytest.raises(ValueError, match="initial_variance must be non-empty"):
         cir_variance_domain_diagnostics(


### PR DESCRIPTION
Closes #94.
Follow-up to #34 / #93.

## Summary
- Clamp CIR variance-domain `domain_upper` so sharp mean reversion cannot exclude `initial_variance_max` from the numerical variance domain.
- Add a deterministic regression covering the post-merge review case where the terminal Chebyshev bound falls below the starting variance.
- Preserve #34 semantics: terminal CIR moments remain separate from the finite-horizon time-average variance used by Heston boundary pricing.

## TDD / evidence
- RED: `uv run --extra dev python -m pytest tests/test_heston_moments.py::test_variance_domain_upper_bound_contains_initial_variance -q` failed with `domain_upper=0.23465447109841064 < initial_variance_max=1.0`.
- GREEN: same focused test passed after clamping.
- `uv run --extra dev python -m pytest tests/test_heston_moments.py tests/test_solver.py tests/test_black_scholes_1d.py -q` — 31 passed.
- `uv run --extra dev ruff check src tests scripts` — passed.
- `uv run --extra dev pydocstyle src/finite_element_options` — passed.
- `uv run --extra dev python scripts/check_architecture_contract.py` — passed.
- `uv run --extra dev python scripts/check_ci_contract.py` — passed.
- `uv run --extra dev python -m pytest -q` — 157 passed, 2 skipped.

## Risk
Low. This only widens the conservative diagnostic upper bound; it does not change CIR terminal moments, Heston time-average boundary variance, or solver assembly.
