### PR TITLE
fix(transforms): apply generator chain rule

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -199,6 +199,13 @@ m(u,v)=\int_\Omega vu\,dx.
 
 The exact signs depend on the declared strong-form convention; code and fixtures must agree. Product adapters cannot silently reinterpret them. Problem identity/hash is distinct from FEM method controls so Pinares, Haircut, and other consumers can ask FD/FEM/analytical methods to solve the same claim without rewriting its economics.
 
+Issue #35 makes coordinate transforms part of the generator, not just mesh cosmetics. For componentwise transformed coordinates \(y_i=h_i(x_i)\), the weak form assembles the transformed Itô generator
+\[
+\widetilde A_{ij}(y)=h_i'(x_i)h_j'(x_j)A_{ij}(x),\qquad
+\widetilde b_i(y)=h_i'(x_i)b_i(x)+\frac12 h_i''(x_i)A_{ii}(x),
+\]
+with row divergence \(\nabla_y\cdot\widetilde A\) recomputed in transformed coordinates before forming \(\mu=\widetilde b-\frac12\nabla_y\cdot\widetilde A\). This covers identity, log-price and square-root-variance maps and fails closed at singular physical boundaries such as \(v=0\) for \(y=\sqrt v\). A mesh grading/reparameterization is a different object and must not be advertised as a state-variable transform unless these Jacobian/Hessian/measure terms are applied.
+
 ## 8. Native contract model
 
 ```text

--- a/docs/MODULE_OWNERSHIP.md
+++ b/docs/MODULE_OWNERSHIP.md
@@ -28,7 +28,7 @@ This module ownership inventory treats the repository as a finite-element numeri
 | `core/` | core | Market/model coefficient helpers and analytical references used by FEM tests | Public but FEM-owned | core | Consolidate with typed contracts under #48 |
 | `space/` | core | Meshes, finite-element spaces, weak forms, BCs, solvers and adaptivity | Public FEM mechanics | core | Stabilize under #48 |
 | `time_integration/` | core | Theta stepping and time-policy mechanics | Public FEM mechanics | core | Stabilize under #48 |
-| `transform.py` | core | Black-Scholes coordinate/time transforms | Public utility | core | Keep only convention-explicit transforms |
+| `transform.py` | core | Coordinate/time transforms plus componentwise generator chain-rule coefficients | Public utility | core | Keep only convention-explicit transforms with Jacobian/Hessian evidence |
 | `problems/` | validation | Thin backend-neutral problem fixtures and examples; not product ownership | Transitional public fixtures | core | Move problem identity into typed contracts under #48 |
 | `validation/` | validation | Analytical/manufactured/public-synthetic evidence and parity artifacts | Public validation helpers | validation | Feed generated capability matrix under #61 |
 | `fdsolver.py` | compatibility | Legacy finite-difference reference route retained only for benchmark/parity transition; production FD ownership belongs to `finite_difference_options` | Not re-exported by base package; emits `DeprecationWarning` on `FDSolver`, `solve_system`, and Greek helper use | fd | Removal version `0.3.0`, removal date `2026-10-31`; remove or replace with a benchmark oracle after FD parity and adapter gates (#49/#50) |

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -113,7 +113,7 @@ Mesh refinement, coarsening and mappings must preserve deterministic identity su
 
 Every operator must be defined through an explicit strong and weak form, sign convention and coefficient interpretation. Assembly must distinguish mass, diffusion, advection, reaction, source and optional coupling terms.
 
-Matrix and vector dimensions, symmetry, definiteness, sparsity and boundary modifications must be testable. Variable coefficients and mixed terms cannot be approximated by hidden constants.
+Coordinate transforms are model terms, not display metadata. If a state transform is used, assembly must apply the full componentwise chain rule: transformed diffusion, Hessian drift correction, transformed diffusion divergence, singular-Jacobian rejection and PSD covariance diagnostics where relevant. Matrix and vector dimensions, symmetry, definiteness, sparsity and boundary modifications must be testable. Variable coefficients and mixed terms cannot be approximated by hidden constants.
 
 ### FR-FEM-005 — Boundary conditions
 

--- a/docs/architecture_contract.toml
+++ b/docs/architecture_contract.toml
@@ -110,8 +110,8 @@ public_surface = "public FEM mechanics"
 path = "transform.py"
 layer = "core"
 owner = "finite_element_options"
-treatment = "Black-Scholes coordinate and time transforms"
-public_surface = "public convention-explicit utility"
+treatment = "coordinate/time transforms plus componentwise generator chain-rule coefficients"
+public_surface = "public convention-explicit utility with Jacobian/Hessian evidence"
 
 [[module_ownership]]
 path = "problems"

--- a/src/finite_element_options/space/forms.py
+++ b/src/finite_element_options/space/forms.py
@@ -72,10 +72,7 @@ class PDEForms(Forms):
 
         @fem.BilinearForm
         def _l(u, v, w):
-            coords = self.transform.untransform_state(w.x)
-            A = self.dynamics.A(*coords)
-            dA = self.dynamics.dA(*coords)
-            b = self.dynamics.b(*coords)
+            A, dA, b = self.transform.transformed_coefficients(self.dynamics, w.x)
             mu = [b_i - dA_i / 2 for b_i, dA_i in zip(b, dA)]
             return (
                 -(1 / 2) * fhl.dot(fhl.grad(v), fhl.mul(A, fhl.grad(u)))

--- a/src/finite_element_options/space/solver.py
+++ b/src/finite_element_options/space/solver.py
@@ -61,6 +61,8 @@ class SpaceSolver:
             if adaptive_criterion is not None
             else None
         )
+        if forms is None:
+            self.transform.validate_transformed_state_domain(mesh.p)
         self.forms = forms or PDEForms(
             is_call=is_call,
             payoff=payoff,

--- a/src/finite_element_options/transform.py
+++ b/src/finite_element_options/transform.py
@@ -17,16 +17,52 @@ from typing import Protocol
 import numpy as np
 
 
+def _as_float_array(name: str, value) -> np.ndarray:
+    """Return ``value`` as a finite floating array."""
+
+    array = np.asarray(value, dtype=float)
+    if np.any(~np.isfinite(array)):
+        raise ValueError(f"{name} must be finite")
+    return array
+
+
+def _match_input_shape(value, array: np.ndarray):
+    """Return a Python float for scalar inputs and an array otherwise."""
+
+    if np.asarray(value).ndim == 0:
+        return float(np.asarray(array, dtype=float))
+    return array
+
+
+def _require_strictly_positive(name: str, value) -> np.ndarray:
+    """Return ``value`` as a finite array with strictly positive entries."""
+
+    array = _as_float_array(name, value)
+    if np.any(array <= 0.0):
+        raise ValueError(f"{name} requires strictly positive physical values")
+    return array
+
+
 class Mapping(Protocol):
-    """Protocol for basic forward and inverse mappings."""
+    """Protocol for one-dimensional forward/inverse coordinate mappings."""
 
     # The following methods define the expected interface and are not
     # executed directly; hence they are excluded from coverage metrics.
     def transform(self, x: np.ndarray) -> np.ndarray:  # pragma: no cover
         """Map ``x`` from the physical to the transformed domain."""
+        ...
 
     def untransform(self, x: np.ndarray) -> np.ndarray:  # pragma: no cover
         """Map ``x`` from the transformed back to the physical domain."""
+        ...
+
+    def derivative(self, x: np.ndarray) -> np.ndarray:  # pragma: no cover
+        r"""Return ``dy/dx`` for the physical-to-transformed map."""
+        ...
+
+    def second_derivative(self, x: np.ndarray) -> np.ndarray:  # pragma: no cover
+        r"""Return ``d²y/dx²`` for the physical-to-transformed map."""
+        ...
 
 
 @dataclass
@@ -35,11 +71,19 @@ class Identity:
 
     def transform(self, x: np.ndarray) -> np.ndarray:
         """Return ``x`` unchanged."""
-        return x
+        return _match_input_shape(x, _as_float_array("identity coordinate", x))
 
     def untransform(self, x: np.ndarray) -> np.ndarray:
         """Return ``x`` unchanged."""
-        return x
+        return _match_input_shape(x, _as_float_array("identity coordinate", x))
+
+    def derivative(self, x: np.ndarray) -> np.ndarray:
+        r"""Return ``dy/dx = 1`` for the identity map."""
+        return np.ones_like(_as_float_array("identity coordinate", x), dtype=float)
+
+    def second_derivative(self, x: np.ndarray) -> np.ndarray:
+        r"""Return ``d²y/dx² = 0`` for the identity map."""
+        return np.zeros_like(_as_float_array("identity coordinate", x), dtype=float)
 
 
 @dataclass
@@ -51,12 +95,22 @@ class LogPrice:
     """
 
     def transform(self, s: np.ndarray) -> np.ndarray:
-        r"""Map spot price ``s`` to log space ``\log s``."""
-        return np.log(s)
+        r"""Map strictly positive spot price ``s`` to log space ``\log s``."""
+        return _match_input_shape(s, np.log(_require_strictly_positive("log-price transform", s)))
 
     def untransform(self, x: np.ndarray) -> np.ndarray:
         """Recover price ``s = e^x`` from log space."""
-        return np.exp(x)
+        return _match_input_shape(x, np.exp(_as_float_array("log-price coordinate", x)))
+
+    def derivative(self, s: np.ndarray) -> np.ndarray:
+        r"""Return ``d log(s) / ds = 1 / s``."""
+        spot = _require_strictly_positive("log-price transform", s)
+        return 1.0 / spot
+
+    def second_derivative(self, s: np.ndarray) -> np.ndarray:
+        r"""Return ``d² log(s) / ds² = -1 / s²``."""
+        spot = _require_strictly_positive("log-price transform", s)
+        return -1.0 / np.square(spot)
 
 
 @dataclass
@@ -64,12 +118,28 @@ class SqrtVol:
     """Square-root mapping for (co)variance variables."""
 
     def transform(self, v: np.ndarray) -> np.ndarray:
-        r"""Map variance ``v`` to its root ``\sqrt{v}``."""
-        return np.sqrt(v)
+        r"""Map non-negative variance ``v`` to its root ``\sqrt{v}``."""
+        variance = _as_float_array("sqrt-variance transform", v)
+        if np.any(variance < 0.0):
+            raise ValueError("sqrt-variance transform requires non-negative values")
+        return _match_input_shape(v, np.sqrt(variance))
 
     def untransform(self, y: np.ndarray) -> np.ndarray:
-        """Square to recover variance ``v = y^2``."""
-        return y ** 2
+        """Square a non-negative root coordinate to recover variance ``v = y^2``."""
+        root_variance = _as_float_array("sqrt-variance coordinate", y)
+        if np.any(root_variance < 0.0):
+            raise ValueError("sqrt-variance coordinate requires non-negative values")
+        return _match_input_shape(y, np.square(root_variance))
+
+    def derivative(self, v: np.ndarray) -> np.ndarray:
+        r"""Return ``d sqrt(v) / dv = 1/(2 sqrt(v))``."""
+        variance = _require_strictly_positive("sqrt-variance transform", v)
+        return 0.5 / np.sqrt(variance)
+
+    def second_derivative(self, v: np.ndarray) -> np.ndarray:
+        r"""Return ``d² sqrt(v) / dv² = -1/(4 v^{3/2})``."""
+        variance = _require_strictly_positive("sqrt-variance transform", v)
+        return -0.25 / np.power(variance, 1.5)
 
 
 @dataclass
@@ -81,24 +151,80 @@ class TimeToMaturity:
     def transform(self, t: np.ndarray) -> np.ndarray:
         """Return the time-to-maturity ``T - t``."""
 
-        return self.maturity - t
+        return _match_input_shape(t, self.maturity - _as_float_array("time coordinate", t))
 
     def untransform(self, tau: np.ndarray) -> np.ndarray:
         """Recover the original time from time-to-maturity ``tau``."""
 
-        return self.maturity - tau
+        return _match_input_shape(
+            tau,
+            self.maturity - _as_float_array("time-to-maturity coordinate", tau),
+        )
 
 
 @dataclass
 class CoordinateTransform:
     """Composite transformation for price, volatility and time.
 
-    Parameters default to :class:`Identity` when not supplied.
+    Parameters default to :class:`Identity` when not supplied.  State mappings
+    are componentwise.  For a transformed coordinate ``y = h(x)`` and physical
+    generator
+
+    ``0.5 A_ij(x) d²/dx_i dx_j + b_i(x) d/dx_i - r``,
+
+    :meth:`transformed_coefficients` returns the Itô/chain-rule coefficients in
+    ``y`` coordinates:
+
+    ``A_y = Dh A Dh.T`` and
+    ``b_y_i = h'_i b_i + 0.5 h''_i A_ii``.
+
+    The returned diffusion divergence is the row divergence of ``A_y`` with
+    respect to transformed coordinates, so the existing weak form can still use
+    ``mu = b_y - 0.5 div(A_y)``.
+
+    Custom mappings used for PDE assembly must provide ``derivative`` and
+    ``second_derivative`` methods; mappings without those methods can still be
+    used for pure coordinate round trips but cannot define transformed
+    generator coefficients safely.
     """
 
     price: Mapping = field(default_factory=Identity)
     vol: Mapping = field(default_factory=Identity)
     time: Mapping = field(default_factory=Identity)
+
+    def _mappings_for_dimension(self, dim: int) -> list[Mapping]:
+        """Return component mappings for ``dim`` spatial coordinates."""
+
+        if dim < 1:
+            raise ValueError("state coordinates must contain at least one dimension")
+        mappings: list[Mapping] = [self.price]
+        if dim > 1:
+            mappings.append(self.vol)
+        mappings.extend(Identity() for _ in range(max(0, dim - len(mappings))))
+        return mappings
+
+    @staticmethod
+    def _state_array(name: str, x: np.ndarray) -> np.ndarray:
+        """Validate a state-coordinate array with shape ``(dim, npoints...)``."""
+
+        array = _as_float_array(name, x)
+        if array.ndim == 0:
+            raise ValueError(f"{name} must include a coordinate dimension")
+        return array
+
+    @staticmethod
+    def _mapping_derivatives(mapping: Mapping, physical_component: np.ndarray):
+        """Return first and second derivatives for a coordinate mapping."""
+
+        try:
+            first = mapping.derivative(physical_component)
+            second = mapping.second_derivative(physical_component)
+        except AttributeError as exc:
+            raise TypeError(
+                "coordinate mappings used for PDE assembly must define "
+                "derivative and second_derivative methods"
+            ) from exc
+        return np.asarray(first, dtype=float), np.asarray(second, dtype=float)
 
     def transform_state(self, x: np.ndarray) -> np.ndarray:
         """Transform spatial coordinates.
@@ -108,20 +234,86 @@ class CoordinateTransform:
         row the volatility/variance coordinate.
         """
 
-        out = x.copy()
-        out[0] = self.price.transform(out[0])
-        if out.shape[0] > 1:
-            out[1] = self.vol.transform(out[1])
+        out = self._state_array("physical state", x).copy()
+        for axis, mapping in enumerate(self._mappings_for_dimension(out.shape[0])):
+            out[axis] = mapping.transform(out[axis])
         return out
 
     def untransform_state(self, x: np.ndarray) -> np.ndarray:
         """Inverse mapping of :meth:`transform_state`."""
 
-        out = x.copy()
-        out[0] = self.price.untransform(out[0])
-        if out.shape[0] > 1:
-            out[1] = self.vol.untransform(out[1])
+        out = self._state_array("transformed state", x).copy()
+        for axis, mapping in enumerate(self._mappings_for_dimension(out.shape[0])):
+            out[axis] = mapping.untransform(out[axis])
         return out
+
+    def validate_transformed_state_domain(self, x: np.ndarray) -> None:
+        """Fail closed when transformed mesh nodes lie outside mapping support."""
+
+        physical_state = self.untransform_state(x)
+        mappings = self._mappings_for_dimension(int(physical_state.shape[0]))
+        for axis, mapping in enumerate(mappings):
+            first, second = self._mapping_derivatives(mapping, physical_state[axis])
+            if np.any(~np.isfinite(first)) or np.any(~np.isfinite(second)):
+                raise ValueError("coordinate transform derivatives must be finite")
+            if np.any(first == 0.0):
+                raise ValueError("coordinate transform derivatives must be non-zero")
+
+    def transformed_coefficients(self, dynamics, transformed_state: np.ndarray):
+        """Return generator coefficients in transformed coordinates.
+
+        The formula supports componentwise transforms.  It is exact for the
+        current identity, log-price and square-root-variance maps and fails
+        closed at singular transformed boundaries such as ``sqrt(v)=0``.
+        """
+
+        physical_state = self.untransform_state(transformed_state)
+        dim = int(physical_state.shape[0])
+        mappings = self._mappings_for_dimension(dim)
+        derivatives = [
+            self._mapping_derivatives(mapping, physical_state[i])
+            for i, mapping in enumerate(mappings)
+        ]
+        first = [item[0] for item in derivatives]
+        second = [item[1] for item in derivatives]
+        if any(np.any(~np.isfinite(derivative)) for derivative in first + second):
+            raise ValueError("coordinate transform derivatives must be finite")
+        if any(np.any(derivative == 0.0) for derivative in first):
+            raise ValueError("coordinate transform derivatives must be non-zero")
+
+        physical_diffusion = dynamics.A(*physical_state)
+        physical_divergence = dynamics.dA(*physical_state)
+        physical_drift = dynamics.b(*physical_state)
+        if len(physical_diffusion) != dim or len(physical_drift) != dim:
+            raise ValueError("dynamics coefficient dimension does not match state dimension")
+
+        diffusion = [
+            [
+                first[i] * first[j] * np.asarray(physical_diffusion[i][j], dtype=float)
+                for j in range(dim)
+            ]
+            for i in range(dim)
+        ]
+        drift = [
+            first[i] * np.asarray(physical_drift[i], dtype=float)
+            + 0.5 * second[i] * np.asarray(physical_diffusion[i][i], dtype=float)
+            for i in range(dim)
+        ]
+        diffusion_divergence = []
+        for i in range(dim):
+            row_divergence = first[i] * np.asarray(physical_divergence[i], dtype=float)
+            row_divergence = row_divergence + second[i] * np.asarray(
+                physical_diffusion[i][i], dtype=float
+            )
+            for j in range(dim):
+                row_divergence = row_divergence + (
+                    first[i]
+                    * second[j]
+                    / first[j]
+                    * np.asarray(physical_diffusion[i][j], dtype=float)
+                )
+            diffusion_divergence.append(row_divergence)
+        return diffusion, diffusion_divergence, drift
 
     def transform_time(self, t: np.ndarray) -> np.ndarray:
         """Transform time variable."""

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,7 +1,21 @@
 import numpy as np
+import pytest
+import skfem as fem
 
+from finite_element_options.core.config import Config
+from finite_element_options.core.dynamics_black_scholes import (
+    DynamicsParametersBlackScholes,
+)
+from finite_element_options.core.dynamics_heston import DynamicsParametersHeston
+from finite_element_options.core.market import Market
+from finite_element_options.core.vanilla_bs import EuropeanOptionBs
+from finite_element_options.space.boundary import DirichletBC
+from finite_element_options.space.forms import PDEForms
+from finite_element_options.space.solver import SpaceSolver
+from finite_element_options.time_integration.stepper import ThetaScheme
 from finite_element_options.transform import (
     CoordinateTransform,
+    Identity,
     LogPrice,
     SqrtVol,
     TimeToMaturity,
@@ -33,3 +47,289 @@ def test_coordinate_transform_state_cycle():
     transformed = ct.transform_state(coords)
     back = ct.untransform_state(transformed)
     np.testing.assert_allclose(coords, back)
+
+
+def test_custom_mapping_without_derivatives_fails_closed_for_coefficients():
+    """Coordinate-only custom maps must not silently define PDE coefficients."""
+
+    class ShiftOnly:
+        def transform(self, x):
+            return x + 1.0
+
+        def untransform(self, x):
+            return x - 1.0
+
+    dynamics = DynamicsParametersBlackScholes(r=0.05, q=0.01, sig=0.2)
+    transform = CoordinateTransform(price=ShiftOnly())
+
+    with pytest.raises(TypeError, match="derivative and second_derivative"):
+        transform.transformed_coefficients(dynamics, np.array([[1.0]]))
+
+
+def test_log_price_black_scholes_transformed_generator_coefficients():
+    """Log-price coordinates use Ito chain-rule coefficients, not spot coefficients."""
+
+    dynamics = DynamicsParametersBlackScholes(r=0.05, q=0.01, sig=0.2)
+    transform = CoordinateTransform(price=LogPrice())
+    log_spot = np.log(np.array([[80.0, 100.0, 120.0]]))
+
+    diffusion, diffusion_divergence, drift = transform.transformed_coefficients(
+        dynamics,
+        log_spot,
+    )
+
+    np.testing.assert_allclose(diffusion[0][0], np.full(3, dynamics.sig**2))
+    np.testing.assert_allclose(diffusion_divergence[0], np.zeros(3), atol=1.0e-14)
+    np.testing.assert_allclose(
+        drift[0],
+        np.full(3, dynamics.r - dynamics.q - 0.5 * dynamics.sig**2),
+    )
+
+
+def test_log_price_form_matches_native_log_black_scholes_form():
+    """Weak-form assembly must consume transformed coefficients in log space."""
+
+    physical = DynamicsParametersBlackScholes(r=0.05, q=0.01, sig=0.2)
+    class NativeLogBlackScholes:
+        r = physical.r
+
+        def A(self, x):
+            return [[physical.sig**2 + 0.0 * x]]
+
+        def dA(self, x):
+            return [0.0 * x]
+
+        def b(self, x):
+            return [physical.r - physical.q - 0.5 * physical.sig**2 + 0.0 * x]
+
+    log_dynamics = NativeLogBlackScholes()
+
+    payoff = EuropeanOptionBs(k=100.0, q=physical.q, mkt=Market(r=physical.r))
+    mesh = fem.MeshLine(np.linspace(np.log(50.0), np.log(150.0), 6))
+    basis = fem.CellBasis(mesh, fem.ElementLineP2())
+
+    transformed_form = PDEForms(
+        is_call=True,
+        payoff=payoff,
+        dynamics=physical,
+        transform=CoordinateTransform(price=LogPrice()),
+    ).l_bil().assemble(basis)
+    native_log_form = PDEForms(
+        is_call=True,
+        payoff=payoff,
+        dynamics=log_dynamics,
+        transform=CoordinateTransform(price=Identity()),
+    ).l_bil().assemble(basis)
+
+    np.testing.assert_allclose(transformed_form.toarray(), native_log_form.toarray())
+
+
+def test_log_price_black_scholes_solution_matches_spot_solution_after_interpolation():
+    """Physical and log-price solves agree at shared spot locations."""
+
+    dynamics = DynamicsParametersBlackScholes(r=0.03, q=0.0, sig=0.2)
+    payoff = EuropeanOptionBs(k=1.0, q=dynamics.q, mkt=Market(r=dynamics.r))
+    time_grid = np.linspace(0.0, 1.0, 9)
+    stepper = ThetaScheme(theta=0.5)
+
+    physical_space = SpaceSolver(
+        fem.MeshLine(np.linspace(0.0, 2.0, 17)),
+        dynamics,
+        payoff,
+        is_call=True,
+        config=Config(elem=fem.ElementLineP2()),
+    )
+    log_space = SpaceSolver(
+        fem.MeshLine(np.linspace(np.log(0.25), np.log(2.0), 17)),
+        dynamics,
+        payoff,
+        is_call=True,
+        transform=CoordinateTransform(price=LogPrice()),
+        config=Config(elem=fem.ElementLineP2()),
+    )
+
+    physical_solution = stepper.solve(
+        time_grid,
+        physical_space,
+        boundary_condition=DirichletBC([]),
+    )
+    log_solution = stepper.solve(
+        time_grid,
+        log_space,
+        boundary_condition=DirichletBC([]),
+    )
+
+    spot = np.array([0.75, 1.0, 1.25])
+    physical_dofs = physical_space.Vh.doflocs[0]
+    log_dofs = log_space.Vh.doflocs[0]
+    physical_order = np.argsort(physical_dofs)
+    log_order = np.argsort(log_dofs)
+    physical_prices = np.interp(
+        spot,
+        physical_dofs[physical_order],
+        physical_solution[-1, physical_order],
+    )
+    log_prices = np.interp(
+        np.log(spot),
+        log_dofs[log_order],
+        log_solution[-1, log_order],
+    )
+
+    np.testing.assert_allclose(log_prices, physical_prices, rtol=3.0e-2, atol=3.0e-3)
+
+
+def test_heston_log_sqrt_transform_coefficients_and_psd_covariance():
+    """Log-spot/sqrt-variance coordinates include Hessian drift corrections."""
+
+    dynamics = DynamicsParametersHeston(
+        r=0.04,
+        q=0.01,
+        kappa=1.7,
+        theta=0.05,
+        sig=0.3,
+        rho=-0.4,
+    )
+    physical_state = np.array([[80.0, 100.0, 120.0], [0.04, 0.09, 0.16]])
+    transformed_state = CoordinateTransform(
+        price=LogPrice(),
+        vol=SqrtVol(),
+    ).transform_state(physical_state)
+
+    diffusion, diffusion_divergence, drift = CoordinateTransform(
+        price=LogPrice(),
+        vol=SqrtVol(),
+    ).transformed_coefficients(dynamics, transformed_state)
+
+    sqrt_v = np.sqrt(physical_state[1])
+    np.testing.assert_allclose(diffusion[0][0], physical_state[1])
+    np.testing.assert_allclose(diffusion[0][1], 0.5 * dynamics.rho * dynamics.sig * sqrt_v)
+    np.testing.assert_allclose(diffusion[1][0], 0.5 * dynamics.rho * dynamics.sig * sqrt_v)
+    np.testing.assert_allclose(diffusion[1][1], np.full(3, dynamics.sig**2 / 4.0))
+    np.testing.assert_allclose(
+        diffusion_divergence[0],
+        np.full(3, 0.5 * dynamics.rho * dynamics.sig),
+    )
+    np.testing.assert_allclose(diffusion_divergence[1], np.zeros(3), atol=1.0e-14)
+    np.testing.assert_allclose(drift[0], dynamics.r - dynamics.q - 0.5 * physical_state[1])
+    np.testing.assert_allclose(
+        drift[1],
+        dynamics.kappa * (dynamics.theta - physical_state[1]) / (2.0 * sqrt_v)
+        - dynamics.sig**2 / (8.0 * sqrt_v),
+    )
+
+    for point in range(physical_state.shape[1]):
+        covariance = np.array(
+            [[np.asarray(entry)[point] for entry in row] for row in diffusion],
+            dtype=float,
+        )
+        assert np.linalg.eigvalsh(covariance).min() >= -1.0e-14
+
+
+def test_heston_log_sqrt_diffusion_divergence_matches_finite_difference():
+    """Returned divergence is the row divergence of transformed diffusion."""
+
+    dynamics = DynamicsParametersHeston(
+        r=0.04,
+        q=0.01,
+        kappa=1.7,
+        theta=0.05,
+        sig=0.3,
+        rho=-0.4,
+    )
+    transform = CoordinateTransform(price=LogPrice(), vol=SqrtVol())
+    transformed_state = transform.transform_state(np.array([[100.0], [0.09]]))
+    diffusion, diffusion_divergence, _drift = transform.transformed_coefficients(
+        dynamics,
+        transformed_state,
+    )
+
+    def diffusion_entry(point, row: int, col: int) -> float:
+        matrix, _divergence, _drift = transform.transformed_coefficients(dynamics, point)
+        return float(np.asarray(matrix[row][col]).reshape(-1)[0])
+
+    eps = 1.0e-5
+    finite_difference_divergence = []
+    for row in range(2):
+        row_divergence = 0.0
+        for col in range(2):
+            plus = transformed_state.copy()
+            minus = transformed_state.copy()
+            plus[col, 0] += eps
+            minus[col, 0] -= eps
+            row_divergence += (
+                diffusion_entry(plus, row, col) - diffusion_entry(minus, row, col)
+            ) / (2.0 * eps)
+        finite_difference_divergence.append(row_divergence)
+
+    assert float(np.asarray(diffusion[0][0]).reshape(-1)[0]) == pytest.approx(0.09)
+    np.testing.assert_allclose(
+        [float(np.asarray(item).reshape(-1)[0]) for item in diffusion_divergence],
+        finite_difference_divergence,
+        rtol=1.0e-6,
+        atol=1.0e-8,
+    )
+
+
+def test_sqrt_variance_transform_rejects_singular_boundary_before_assembly():
+    dynamics = DynamicsParametersHeston(
+        r=0.04,
+        q=0.01,
+        kappa=1.7,
+        theta=0.05,
+        sig=0.3,
+        rho=-0.4,
+    )
+    singular_state = np.array([[np.log(100.0)], [0.0]])
+
+    with pytest.raises(ValueError, match="strictly positive"):
+        CoordinateTransform(price=LogPrice(), vol=SqrtVol()).transformed_coefficients(
+            dynamics,
+            singular_state,
+        )
+
+
+def test_sqrt_variance_transform_rejects_negative_transformed_coordinate():
+    """Negative root-variance coordinates are outside the sqrt transform range."""
+
+    dynamics = DynamicsParametersHeston(
+        r=0.04,
+        q=0.01,
+        kappa=1.7,
+        theta=0.05,
+        sig=0.3,
+        rho=-0.4,
+    )
+    negative_root_state = np.array([[np.log(100.0)], [-0.2]])
+
+    with pytest.raises(ValueError, match="non-negative"):
+        CoordinateTransform(price=LogPrice(), vol=SqrtVol()).transformed_coefficients(
+            dynamics,
+            negative_root_state,
+        )
+
+
+def test_heston_log_sqrt_space_solver_rejects_mesh_touching_singular_boundary():
+    """Mesh nodes touching sqrt-variance zero are rejected before assembly."""
+
+    dynamics = DynamicsParametersHeston(
+        r=0.04,
+        q=0.01,
+        kappa=1.7,
+        theta=0.05,
+        sig=0.3,
+        rho=-0.4,
+    )
+    payoff = EuropeanOptionBs(k=100.0, q=dynamics.q, mkt=Market(r=dynamics.r))
+    mesh = fem.MeshTri().init_tensor(
+        x=np.linspace(np.log(50.0), np.log(150.0), 3),
+        y=np.linspace(0.0, 0.3, 3),
+    )
+
+    with pytest.raises(ValueError, match="strictly positive"):
+        SpaceSolver(
+            mesh,
+            dynamics,
+            payoff,
+            is_call=True,
+            transform=CoordinateTransform(price=LogPrice(), vol=SqrtVol()),
+        )


### PR DESCRIPTION
Closes #35.

## Summary
- Treat coordinate transforms as generator transforms, not mesh/display metadata.
- Add componentwise transform derivatives and Itô chain-rule coefficients for identity, log-price, and sqrt-variance maps.
- Assemble `PDEForms` from transformed diffusion, transformed drift, and transformed diffusion-divergence so weak forms in transformed coordinates solve the intended PDE.
- Fail closed at singular transformed boundaries such as `sqrt(v)=0` before assembly.
- Document the transform convention in the architecture/PRD/module-ownership contract.

## Numerical contract
For componentwise `y_i = h_i(x_i)`, the implementation uses:

- `A_y[i,j] = h_i'(x_i) h_j'(x_j) A[i,j]`
- `b_y[i] = h_i'(x_i) b[i] + 0.5 h_i''(x_i) A[i,i]`
- row divergence of `A_y` in transformed coordinates before forming `mu = b_y - 0.5 div(A_y)`

This gives the expected log-Black-Scholes generator
`d log S = (r - q - sigma^2/2) dt + sigma dW` and Heston log/sqrt covariance with PSD checks.

## TDD / evidence
- RED: `uv run --extra dev python -m pytest tests/test_transform.py::test_log_price_black_scholes_transformed_generator_coefficients -q` failed with `AttributeError: 'CoordinateTransform' object has no attribute 'transformed_coefficients'`.
- GREEN focused: `uv run --extra dev python -m pytest tests/test_transform.py -q` — 9 passed.
- Local gate bundle: `uv run --extra dev python -m pytest tests/test_transform.py tests/test_black_scholes_1d.py tests/test_heston_moments.py tests/test_solver.py -q` — 39 passed.
- Static/docs/contracts: `ruff check src tests scripts`, `pydocstyle src/finite_element_options`, `scripts/check_architecture_contract.py`, `scripts/check_ci_contract.py` — passed.
- Full tests: `uv run --extra dev python -m pytest -q` — 162 passed, 2 skipped.
- CI parity locals: `mypy --ignore-missing-imports --follow-imports=silent src/finite_element_options/contracts src/finite_element_options/validation scripts/check_ci_contract.py`, `pytest -q tests/architecture tests/test_packaging_contract.py --no-cov`, `python -m build --sdist --wheel`, `twine check dist/*` — passed.

## Risk
Medium. This changes weak-form coefficient assembly whenever a non-identity transform is supplied, but identity transforms preserve the old coefficient path and existing solver tests pass. The transformed path is covered by coefficient-level, weak-form-equivalence, solution-comparison, PSD, and singular-boundary regression tests.
