### PR TITLE
fix(domains): accept numpy bound-pair extents

### DIFF
--- a/src/finite_element_options/space/domain.py
+++ b/src/finite_element_options/space/domain.py
@@ -108,14 +108,15 @@ class DomainSpec:
                 axes.append(item)
                 continue
             name = _DEFAULT_AXIS_NAMES[axis] if axis < len(_DEFAULT_AXIS_NAMES) else f"x{axis}"
-            if isinstance(item, Sequence) and not isinstance(item, (str, bytes)):
-                if len(item) != 2:
-                    raise ValueError("domain bound sequences must be (lower, upper) pairs")
-                lower, upper = item
-            elif isinstance(item, (str, bytes)):
+            if isinstance(item, (str, bytes)):
                 raise ValueError("domain extents must be numeric bounds, not strings")
+            values = np.asarray(item, dtype=float)
+            if values.ndim == 0:
+                lower, upper = 0.0, float(values)
+            elif values.shape == (2,):
+                lower, upper = values
             else:
-                lower, upper = 0.0, float(item)
+                raise ValueError("domain bound sequences must be (lower, upper) pairs")
             axes.append(DomainAxis(name, float(lower), float(upper)))
         return cls(tuple(axes))
 

--- a/tests/test_domain_boundary.py
+++ b/tests/test_domain_boundary.py
@@ -37,6 +37,18 @@ def test_create_mesh_supports_negative_domains_and_named_facets() -> None:
     assert {"r_min", "r_max"} <= set(mesh.boundaries)
 
 
+def test_create_mesh_accepts_numpy_bound_pair_extents() -> None:
+    """Explicit bound-pair domains may come from numerical NumPy arrays."""
+
+    mesh, _ = create_mesh(np.array([[0.25, 1.75]]), refine=1)
+
+    assert np.min(mesh.p[0]) == pytest.approx(0.25)
+    assert np.max(mesh.p[0]) == pytest.approx(1.75)
+    assert mesh.domain_spec.axes[0].lower == pytest.approx(0.25)
+    assert mesh.domain_spec.axes[0].upper == pytest.approx(1.75)
+    assert {"s_min", "s_max"} <= set(mesh.boundaries)
+
+
 def test_dirichlet_bc_materializes_generators_and_rejects_bad_facets() -> None:
     """Boundary collections are consumed once and validated before enforcement."""
 


### PR DESCRIPTION
Follow-up to #99 / Kilo finding on PR #99.

## Summary
- Make `DomainSpec.from_extents` materialize each extent with NumPy so row-sliced `ndarray` bound pairs are treated as `(lower, upper)` domains.
- Preserve scalar legacy extents and string fail-closed behavior.
- Add regression coverage for `create_mesh(np.array([[lower, upper]]), refine=...)`.

## Verification
- RED: `uv run --extra dev python -m pytest tests/test_domain_boundary.py::test_create_mesh_accepts_numpy_bound_pair_extents -q` failed with `TypeError: only 0-dimensional arrays can be converted to Python scalars`.
- GREEN: `uv run --extra dev python -m pytest tests/test_domain_boundary.py::test_create_mesh_accepts_numpy_bound_pair_extents -q` -> 1 passed.
- `uv run --extra dev ruff check src tests scripts`
- `uv run --extra dev mypy --ignore-missing-imports --follow-imports=silent src/finite_element_options/contracts src/finite_element_options/validation scripts/check_ci_contract.py`
- `uv run --extra dev python scripts/check_architecture_contract.py`
- `uv run --extra dev python scripts/check_ci_contract.py`
- `uv run --extra dev python -m pytest tests/test_domain_boundary.py -q --no-cov` -> 6 passed.
- `uv run --extra dev pydocstyle src/finite_element_options`
- `uv run --extra dev python -m pytest -q` -> 180 passed, 2 skipped.
- `uv run --extra dev python -m build --sdist --wheel`
- `uv run --extra dev python -m twine check dist/*`
