### PR TITLE
fix(adaptivity): preserve topology and transfer states

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,9 +164,10 @@ print(f"European put:  price={put_price:.4f}")
 ### Example Output
 
 The adaptive mesh demo refines the domain around sharp features. The validated
-adaptivity API preserves domain measure, transfers nodal values to the refined
-basis and keeps coarsening disabled until reversible hierarchy checks exist. The
-final solution after several refinement steps is shown below:
+adaptivity API preserves domain measure, carries named boundary/domain metadata,
+transfers nodal values to the refined basis and keeps coarsening disabled until
+reversible hierarchy checks exist. The final solution after several refinement
+steps is shown below:
 
 ![Adaptive mesh solution showing refined grid](docs/images/adaptive_solution.svg)
 

--- a/README.md
+++ b/README.md
@@ -163,8 +163,10 @@ print(f"European put:  price={put_price:.4f}")
 
 ### Example Output
 
-The adaptive mesh demo refines the domain around sharp features. The final
-solution after several refinement steps is shown below:
+The adaptive mesh demo refines the domain around sharp features. The validated
+adaptivity API preserves domain measure, transfers nodal values to the refined
+basis and keeps coarsening disabled until reversible hierarchy checks exist. The
+final solution after several refinement steps is shown below:
 
 ![Adaptive mesh solution showing refined grid](docs/images/adaptive_solution.svg)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -319,7 +319,7 @@ solve → estimate → mark → refine/coarsen → transfer → verify → conti
 
 The estimator, norm or goal functional, marking fraction, mesh limits, transfer operator and stopping condition are typed. Diagnostics include estimator totals/local values, marked elements, degrees of freedom, transfer error, effectivity where reference error exists and target-functional evolution.
 
-`AdaptiveMesh.refine_with_transfer` is the canonical refinement entry point: it validates positive element measures and unchanged domain measure, materializes a non-empty scikit-fem marking set, transfers nodal values to the refined basis by interpolation, and returns `AdaptiveDiagnostics`. `SpaceSolver.refine_with_transfer` rebuilds the mesh, basis and assembled matrices from that transferred state. Coarsening raises `NotImplementedError` until parent/child hierarchy, restriction/prolongation and coverage invariants are implemented.
+`AdaptiveMesh.refine_with_transfer` is the canonical refinement entry point: it validates positive element measures and unchanged domain measure, materializes a non-empty scikit-fem marking set, restores named boundary/domain metadata after `Mesh.refined()` invalidates it, transfers nodal values to the refined basis by interpolation, and returns `AdaptiveDiagnostics`. `SpaceSolver.refine_with_transfer` rebuilds the mesh, basis and assembled matrices from that transferred state. Coarsening raises `NotImplementedError` until parent/child hierarchy, restriction/prolongation and coverage invariants are implemented.
 
 ## 15. Sensitivities and Greeks
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -319,6 +319,8 @@ solve → estimate → mark → refine/coarsen → transfer → verify → conti
 
 The estimator, norm or goal functional, marking fraction, mesh limits, transfer operator and stopping condition are typed. Diagnostics include estimator totals/local values, marked elements, degrees of freedom, transfer error, effectivity where reference error exists and target-functional evolution.
 
+`AdaptiveMesh.refine_with_transfer` is the canonical refinement entry point: it validates positive element measures and unchanged domain measure, materializes a non-empty scikit-fem marking set, transfers nodal values to the refined basis by interpolation, and returns `AdaptiveDiagnostics`. `SpaceSolver.refine_with_transfer` rebuilds the mesh, basis and assembled matrices from that transferred state. Coarsening raises `NotImplementedError` until parent/child hierarchy, restriction/prolongation and coverage invariants are implemented.
+
 ## 15. Sensitivities and Greeks
 
 Sensitivity methods are distinct adapters:

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -141,7 +141,7 @@ Invariant matrices and factorizations should be reused where mathematically vali
 
 Adaptive refinement requires an explicit estimator, marking policy, refinement limits, transfer operator and goal quantity. Experimental demos cannot be exposed as production capability without effectivity, convergence and stability evidence.
 
-The current validated core supports residual or gradient-driven refinement through `AdaptiveMesh.refine_with_transfer`: it checks positive simplex measures, preserves total domain measure, transfers nodal values by interpolation, emits estimator/marking/transfer diagnostics and disables coarsening until a reversible hierarchy and coverage proof exist.
+The current validated core supports residual or gradient-driven refinement through `AdaptiveMesh.refine_with_transfer`: it checks positive simplex measures, preserves total domain measure, carries named boundary/domain metadata across scikit-fem remeshing, transfers nodal values by interpolation, emits estimator/marking/transfer diagnostics and disables coarsening until a reversible hierarchy and coverage proof exist.
 
 Goal-oriented estimators must identify the target functional and adjoint assumptions.
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -141,6 +141,8 @@ Invariant matrices and factorizations should be reused where mathematically vali
 
 Adaptive refinement requires an explicit estimator, marking policy, refinement limits, transfer operator and goal quantity. Experimental demos cannot be exposed as production capability without effectivity, convergence and stability evidence.
 
+The current validated core supports residual or gradient-driven refinement through `AdaptiveMesh.refine_with_transfer`: it checks positive simplex measures, preserves total domain measure, transfers nodal values by interpolation, emits estimator/marking/transfer diagnostics and disables coarsening until a reversible hierarchy and coverage proof exist.
+
 Goal-oriented estimators must identify the target functional and adjoint assumptions.
 
 ### FR-FEM-009 — Values, Greeks and sensitivities

--- a/src/finite_element_options/space/__init__.py
+++ b/src/finite_element_options/space/__init__.py
@@ -5,7 +5,7 @@ from .domain import DomainAxis, DomainSpec, ensure_domain_spec
 from .forms import Forms, PDEForms
 from .solver import SpaceSolver
 from .boundary import apply_dirichlet, DirichletBC
-from .adaptive import AdaptiveMesh
+from .adaptive import AdaptiveDiagnostics, AdaptiveMesh, AdaptiveResult, mesh_measure
 
 __all__ = [
     "create_mesh",
@@ -18,5 +18,8 @@ __all__ = [
     "SpaceSolver",
     "apply_dirichlet",
     "DirichletBC",
+    "AdaptiveDiagnostics",
     "AdaptiveMesh",
+    "AdaptiveResult",
+    "mesh_measure",
 ]

--- a/src/finite_element_options/space/adaptive.py
+++ b/src/finite_element_options/space/adaptive.py
@@ -1,12 +1,67 @@
-"""Adaptive mesh refinement utilities."""
+"""Adaptive mesh refinement utilities with topology and transfer guards."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Callable, Dict
 
 import numpy as np
 import skfem as fem
 import skfem.helpers as fh
+
+
+@dataclass(frozen=True)
+class AdaptiveDiagnostics:
+    """Diagnostics emitted by one adaptive mesh operation."""
+
+    criterion: str
+    marking_theta: float
+    marked_elements: int
+    old_elements: int
+    new_elements: int
+    old_measure: float
+    new_measure: float
+    element_measures: np.ndarray
+    estimator: np.ndarray
+    transfer_operator: str
+    transfer_l2_change: float
+
+
+@dataclass(frozen=True)
+class AdaptiveResult:
+    """Mesh, transferred values, and diagnostics after adaptation."""
+
+    mesh: fem.Mesh
+    values: np.ndarray
+    diagnostics: AdaptiveDiagnostics
+
+
+def element_measures(mesh: fem.Mesh) -> np.ndarray:
+    """Return positive simplex measure for every mesh element."""
+
+    p = np.asarray(mesh.p, dtype=float)
+    t = np.asarray(mesh.t, dtype=int)
+    dim = int(mesh.dim())
+    if dim == 1:
+        return np.abs(p[0, t[1]] - p[0, t[0]])
+    if dim == 2:
+        a = p[:, t[1]] - p[:, t[0]]
+        b = p[:, t[2]] - p[:, t[0]]
+        return 0.5 * np.abs(a[0] * b[1] - a[1] * b[0])
+    if dim == 3:
+        a = p[:, t[1]] - p[:, t[0]]
+        b = p[:, t[2]] - p[:, t[0]]
+        c = p[:, t[3]] - p[:, t[0]]
+        cross = np.cross(a.T, b.T)
+        return np.abs(np.einsum("ij,ij->i", cross, c.T)) / 6.0
+    msg = f"adaptive topology checks support simplex meshes in 1D/2D/3D, got {dim}D"
+    raise NotImplementedError(msg)
+
+
+def mesh_measure(mesh: fem.Mesh) -> float:
+    """Return the total geometric measure covered by ``mesh``."""
+
+    return float(np.sum(element_measures(mesh)))
 
 
 class AdaptiveMesh:
@@ -18,15 +73,14 @@ class AdaptiveMesh:
         Finite element used for basis functions.
     criterion:
         Refinement criterion to use. Supported values are ``"residual"``
-        (edge jump residual estimator) and ``"gradient"`` (gradient magnitude
-        indicator).
+        (facet/edge jump residual estimator) and ``"gradient"`` (gradient
+        magnitude indicator).
     theta:
         Parameter passed to :func:`skfem.adaptive_theta` controlling how many
         elements are refined. Values closer to ``1`` refine fewer elements.
     boundaries:
         Optional boundary definition dictionary passed to
-        :meth:`skfem.Mesh.with_boundaries` after each refinement or
-        coarsening step.
+        :meth:`skfem.Mesh.with_boundaries` after each refinement step.
     """
 
     def __init__(
@@ -40,6 +94,7 @@ class AdaptiveMesh:
         ) = None,
     ) -> None:
         """Store mesh refinement configuration."""
+
         self.element = element
         self.criterion = criterion
         self.theta = theta
@@ -49,11 +104,46 @@ class AdaptiveMesh:
     # Estimators
     # ------------------------------------------------------------------
     def _residual_estimator(self, mesh: fem.Mesh, u: np.ndarray) -> np.ndarray:
-        """Return residual-based error indicator."""
+        """Return residual-based error indicators for every element."""
+
+        dim = int(mesh.dim())
+        if dim == 1:
+            return self._line_residual_estimator(mesh, u)
+        return self._facet_jump_residual_estimator(mesh, u)
+
+    def _line_residual_estimator(self, mesh: fem.Mesh, u: np.ndarray) -> np.ndarray:
+        """Return 1D slope-jump residual indicators."""
+
+        p = np.asarray(mesh.p, dtype=float)
+        t = np.asarray(mesh.t, dtype=int)
+        values = np.asarray(u, dtype=float)
+        lengths = element_measures(mesh)
+        dx = p[0, t[1]] - p[0, t[0]]
+        slopes = (values[t[1]] - values[t[0]]) / dx
+        eta = np.zeros(mesh.nelements, dtype=float)
+        point_to_elements: dict[int, list[int]] = {}
+        for elem, nodes in enumerate(t.T):
+            for node in nodes:
+                point_to_elements.setdefault(int(node), []).append(elem)
+        for elems in point_to_elements.values():
+            if len(elems) < 2:
+                continue
+            local_slopes = slopes[elems]
+            jump = float(np.max(local_slopes) - np.min(local_slopes))
+            scale = float(np.mean(lengths[elems]))
+            eta[elems] += 0.5 * scale * jump**2
+        return eta
+
+    def _facet_jump_residual_estimator(
+        self, mesh: fem.Mesh, u: np.ndarray
+    ) -> np.ndarray:
+        """Return normal-gradient jump indicators on interior facets."""
+
+        dim = int(mesh.dim())
         fbasis = [
             fem.InteriorFacetBasis(mesh, self.element, side=i) for i in [0, 1]
         ]
-        w = {f"u{i+1}": fbasis[i].interpolate(u) for i in [0, 1]}
+        w = {f"u{i + 1}": fbasis[i].interpolate(u) for i in [0, 1]}
 
         @fem.Functional
         def edge_jump(w):
@@ -61,18 +151,17 @@ class AdaptiveMesh:
             n = w.n
             dw1 = fh.grad(w["u1"])
             dw2 = fh.grad(w["u2"])
-            jump = (dw1[0] - dw2[0]) * n[0] + (
-                dw1[1] - dw2[1]
-            ) * n[1]
+            jump = sum((dw1[axis] - dw2[axis]) * n[axis] for axis in range(dim))
             return h * jump**2
 
-        eta_E = edge_jump.elemental(fbasis[0], **w)
-        tmp = np.zeros(mesh.facets.shape[1])
-        np.add.at(tmp, fbasis[0].find, eta_E)
-        return np.sum(0.5 * tmp[mesh.t2f], axis=0)
+        eta_e = edge_jump.elemental(fbasis[0], **w)
+        facet_eta = np.zeros(mesh.facets.shape[1])
+        np.add.at(facet_eta, fbasis[0].find, eta_e)
+        return np.sum(0.5 * facet_eta[mesh.t2f], axis=0)
 
     def _gradient_estimator(self, mesh: fem.Mesh, u: np.ndarray) -> np.ndarray:
-        """Return gradient-based error indicator."""
+        """Return gradient-energy indicators for every element."""
+
         basis = fem.CellBasis(mesh, self.element)
         w = basis.interpolate(u)
 
@@ -80,31 +169,141 @@ class AdaptiveMesh:
         def grad_energy(w):
             return fh.dot(w["u"].grad, w["u"].grad)
 
-        return grad_energy.elemental(basis, u=w)
+        return np.asarray(grad_energy.elemental(basis, u=w), dtype=float)
 
     def _estimate(self, mesh: fem.Mesh, u: np.ndarray) -> np.ndarray:
+        """Return finite non-negative element indicators."""
+
         if self.criterion == "gradient":
-            return self._gradient_estimator(mesh, u)
-        return self._residual_estimator(mesh, u)
+            eta = self._gradient_estimator(mesh, u)
+        elif self.criterion == "residual":
+            eta = self._residual_estimator(mesh, u)
+        else:
+            msg = f"unsupported adaptive criterion: {self.criterion!r}"
+            raise ValueError(msg)
+        eta = np.asarray(eta, dtype=float)
+        if eta.shape != (mesh.nelements,):
+            msg = (
+                "adaptive estimator must return one indicator per element; "
+                f"got shape {eta.shape} for {mesh.nelements} elements"
+            )
+            raise ValueError(msg)
+        if not np.all(np.isfinite(eta)):
+            msg = "adaptive estimator returned non-finite indicators"
+            raise ValueError(msg)
+        return np.maximum(eta, 0.0)
+
+    def _marked_elements(self, eta: np.ndarray) -> np.ndarray:
+        """Return a non-empty set of element indices selected for refinement."""
+
+        marked = np.asarray(fem.adaptive_theta(eta, theta=self.theta), dtype=np.int32)
+        if marked.size == 0:
+            marked = np.asarray([int(np.argmax(eta))], dtype=np.int32)
+        return np.unique(marked)
+
+    # ------------------------------------------------------------------
+    # Topology and transfer
+    # ------------------------------------------------------------------
+    def _validate_topology(
+        self, mesh: fem.Mesh, *, reference_measure: float | None = None
+    ) -> np.ndarray:
+        """Validate element orientation, measure, and domain coverage."""
+
+        measures = element_measures(mesh)
+        if measures.shape != (mesh.nelements,):
+            msg = "mesh measure calculation did not produce one value per element"
+            raise ValueError(msg)
+        if not np.all(np.isfinite(measures)) or not np.all(measures > 0.0):
+            msg = "adaptive mesh contains inverted, degenerate, or non-finite elements"
+            raise ValueError(msg)
+        if reference_measure is not None and not np.isclose(
+            float(np.sum(measures)), reference_measure, rtol=1.0e-10, atol=1.0e-12
+        ):
+            msg = "adaptive refinement changed total domain measure"
+            raise ValueError(msg)
+        return measures
+
+    def transfer_solution(
+        self, old_mesh: fem.Mesh, new_mesh: fem.Mesh, values: np.ndarray
+    ) -> np.ndarray:
+        """Interpolate nodal solution values from ``old_mesh`` to ``new_mesh``."""
+
+        old_basis = fem.CellBasis(old_mesh, self.element)
+        new_basis = fem.CellBasis(new_mesh, self.element)
+        old_values = np.asarray(values, dtype=float)
+        if old_values.shape != (old_basis.N,):
+            msg = (
+                "solution transfer expected one value per old basis dof; "
+                f"got {old_values.shape} for {old_basis.N} dofs"
+            )
+            raise ValueError(msg)
+        interpolator = old_basis.interpolator(old_values)
+        transferred = np.asarray(interpolator(new_basis.doflocs), dtype=float)
+        if transferred.shape != (new_basis.N,):
+            msg = "solution transfer did not return one value per new basis dof"
+            raise ValueError(msg)
+        if not np.all(np.isfinite(transferred)):
+            msg = "solution transfer produced non-finite values"
+            raise ValueError(msg)
+        return transferred
+
+    def _transfer_l2_change(
+        self, old_mesh: fem.Mesh, new_mesh: fem.Mesh, old_values: np.ndarray,
+        new_values: np.ndarray,
+    ) -> float:
+        """Return round-trip RMS transfer change at old degrees of freedom."""
+
+        old_basis = fem.CellBasis(old_mesh, self.element)
+        new_basis = fem.CellBasis(new_mesh, self.element)
+        roundtrip = new_basis.interpolator(new_values)(old_basis.doflocs)
+        delta = np.asarray(roundtrip, dtype=float) - np.asarray(old_values, dtype=float)
+        return float(np.linalg.norm(delta) / np.sqrt(delta.size))
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
+    def refine_with_transfer(self, mesh: fem.Mesh, u: np.ndarray) -> AdaptiveResult:
+        """Refine ``mesh`` and transfer solution values to the new basis."""
+
+        old_measure = mesh_measure(mesh)
+        self._validate_topology(mesh)
+        eta = self._estimate(mesh, u)
+        marked = self._marked_elements(eta)
+        refined = mesh.refined(marked)
+        if int(refined.dim()) > 1:
+            refined = refined.smoothed()
+        if self.boundaries:
+            refined = refined.with_boundaries(self.boundaries)
+        measures = self._validate_topology(refined, reference_measure=old_measure)
+        transferred = self.transfer_solution(mesh, refined, u)
+        diagnostics = AdaptiveDiagnostics(
+            criterion=self.criterion,
+            marking_theta=float(self.theta),
+            marked_elements=int(marked.size),
+            old_elements=int(mesh.nelements),
+            new_elements=int(refined.nelements),
+            old_measure=old_measure,
+            new_measure=float(np.sum(measures)),
+            element_measures=measures,
+            estimator=eta,
+            transfer_operator="nodal_interpolation",
+            transfer_l2_change=self._transfer_l2_change(
+                mesh, refined, np.asarray(u, dtype=float), transferred
+            ),
+        )
+        return AdaptiveResult(refined, transferred, diagnostics)
+
     def refine(self, mesh: fem.Mesh, u: np.ndarray) -> fem.Mesh:
         """Refine ``mesh`` based on solution ``u`` and configured criterion."""
-        eta = self._estimate(mesh, u)
-        mesh = mesh.refined(
-            fem.adaptive_theta(eta, theta=self.theta)
-        ).smoothed()
-        if self.boundaries:
-            mesh = mesh.with_boundaries(self.boundaries)
-        return mesh
+
+        return self.refine_with_transfer(mesh, u).mesh
 
     def coarsen(self, mesh: fem.Mesh, u: np.ndarray) -> fem.Mesh:
-        """Coarsen ``mesh`` by removing elements with the smallest error."""
-        eta = self._estimate(mesh, u)
-        remove = np.argsort(eta)[: len(eta) // 2]
-        mesh = mesh.remove_elements(remove)
-        if self.boundaries:
-            mesh = mesh.with_boundaries(self.boundaries)
-        return mesh
+        """Reject coarsening until reversible hierarchy guards are implemented."""
+
+        _ = (mesh, u)
+        msg = (
+            "adaptive coarsening is disabled until a reversible hierarchy, "
+            "coverage proof, and solution-transfer invariant are implemented"
+        )
+        raise NotImplementedError(msg)

--- a/src/finite_element_options/space/adaptive.py
+++ b/src/finite_element_options/space/adaptive.py
@@ -9,6 +9,8 @@ import numpy as np
 import skfem as fem
 import skfem.helpers as fh
 
+from finite_element_options.space.domain import attach_domain_metadata
+
 
 @dataclass(frozen=True)
 class AdaptiveDiagnostics:
@@ -259,6 +261,30 @@ class AdaptiveMesh:
         delta = np.asarray(roundtrip, dtype=float) - np.asarray(old_values, dtype=float)
         return float(np.linalg.norm(delta) / np.sqrt(delta.size))
 
+    def _metadata_boundary_predicates(
+        self, mesh: fem.Mesh
+    ) -> Dict[str, Callable[[np.ndarray], np.ndarray]]:
+        """Return boundary predicates stored on ``mesh`` domain metadata."""
+
+        domain = getattr(mesh, "domain_spec", None)
+        if domain is None:
+            return {}
+        return dict(domain.boundary_predicates())
+
+    def _restore_refined_metadata(self, original: fem.Mesh, refined: fem.Mesh) -> fem.Mesh:
+        """Restore named boundary and domain metadata after refinement."""
+
+        domain = getattr(original, "domain_spec", None)
+        domain_boundaries = self._metadata_boundary_predicates(original)
+        boundaries = self.boundaries or domain_boundaries
+        if boundaries:
+            refined = refined.with_boundaries(boundaries)
+        if domain is not None and set(boundaries) == set(domain_boundaries):
+            refined = attach_domain_metadata(refined, domain)
+        elif boundaries:
+            refined.boundary_names = tuple(boundaries)
+        return refined
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
@@ -272,8 +298,7 @@ class AdaptiveMesh:
         refined = mesh.refined(marked)
         if int(refined.dim()) > 1:
             refined = refined.smoothed()
-        if self.boundaries:
-            refined = refined.with_boundaries(self.boundaries)
+        refined = self._restore_refined_metadata(mesh, refined)
         measures = self._validate_topology(refined, reference_measure=old_measure)
         transferred = self.transfer_solution(mesh, refined, u)
         diagnostics = AdaptiveDiagnostics(

--- a/src/finite_element_options/space/solver.py
+++ b/src/finite_element_options/space/solver.py
@@ -7,7 +7,7 @@ import skfem as fem
 
 from .forms import Forms, PDEForms
 from .boundary import apply_dirichlet
-from .adaptive import AdaptiveMesh
+from .adaptive import AdaptiveDiagnostics, AdaptiveMesh, AdaptiveResult
 from finite_element_options.space.domain import DomainSpec
 from finite_element_options.transform import CoordinateTransform
 from finite_element_options.core.config import Config
@@ -62,6 +62,7 @@ class SpaceSolver:
             if adaptive_criterion is not None
             else None
         )
+        self.last_adaptive_diagnostics: AdaptiveDiagnostics | None = None
         if forms is None:
             self.transform.validate_transformed_state_domain(mesh.p)
         self.forms = forms or PDEForms(
@@ -215,6 +216,20 @@ class SpaceSolver:
         """Apply Dirichlet boundary conditions to ``A`` and ``b``."""
         return apply_dirichlet(A, b, self.Vh, boundaries, u_dirichlet)
 
+    def refine_with_transfer(self, u: np.ndarray) -> AdaptiveResult:
+        """Refine the internal mesh and transfer ``u`` to the new basis."""
+
+        if self.adapt is None:
+            raise ValueError("Adaptive mesh not configured for this solver.")
+        result = self.adapt.refine_with_transfer(self.mesh, u)
+        self.mesh = result.mesh
+        self.Vh = fem.CellBasis(self.mesh, self.config.elem)
+        self.dVh = fem.FacetBasis(self.mesh, self.config.elem)
+        self.mass = self.forms.id_bil().assemble(self.Vh)
+        self.stiffness = self.forms.l_bil().assemble(self.Vh)
+        self.last_adaptive_diagnostics = result.diagnostics
+        return result
+
     def refine_mesh(self, u: np.ndarray) -> fem.Mesh:
         """Refine the internal mesh using adaptive criterion.
 
@@ -223,11 +238,4 @@ class SpaceSolver:
         u:
             Current solution vector used to compute refinement indicators.
         """
-        if self.adapt is None:
-            raise ValueError("Adaptive mesh not configured for this solver.")
-        self.mesh = self.adapt.refine(self.mesh, u)
-        self.Vh = fem.CellBasis(self.mesh, self.config.elem)
-        self.dVh = fem.FacetBasis(self.mesh, self.config.elem)
-        self.mass = self.forms.id_bil().assemble(self.Vh)
-        self.stiffness = self.forms.l_bil().assemble(self.Vh)
-        return self.mesh
+        return self.refine_with_transfer(u).mesh

--- a/tests/test_adaptive_mesh.py
+++ b/tests/test_adaptive_mesh.py
@@ -1,19 +1,21 @@
 import os
 import sys
+
 import numpy as np
+import pytest
 import skfem as fem
 import skfem.helpers as fh
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from finite_element_options.space.adaptive import AdaptiveMesh
+from finite_element_options.space.adaptive import AdaptiveMesh, mesh_measure
 
 ELEM = fem.ElementTriP1()
 BOUNDARIES = {
-    "x_min": lambda x: x[0] == 0,
-    "x_max": lambda x: x[0] == 1,
-    "y_min": lambda x: x[1] == 0,
-    "y_max": lambda x: x[1] == 1,
+    "x_min": lambda x: np.isclose(x[0], 0.0),
+    "x_max": lambda x: np.isclose(x[0], 1.0),
+    "y_min": lambda x: np.isclose(x[1], 0.0),
+    "y_max": lambda x: np.isclose(x[1], 1.0),
 }
 
 
@@ -44,20 +46,73 @@ def initial_mesh() -> fem.Mesh:
     )
 
 
-def test_residual_refine_and_coarsen():
+def test_residual_refinement_preserves_domain_and_reports_transfer() -> None:
+    mesh = initial_mesh()
+    adapt = AdaptiveMesh(ELEM, criterion="residual", boundaries=BOUNDARIES)
+    u = solve(mesh)
+
+    result = adapt.refine_with_transfer(mesh, u)
+
+    assert result.mesh.nelements > mesh.nelements
+    assert set(result.mesh.boundaries) == set(BOUNDARIES)
+    assert mesh_measure(result.mesh) == pytest.approx(mesh_measure(mesh))
+    assert np.all(result.diagnostics.element_measures > 0.0)
+    assert result.diagnostics.old_elements == mesh.nelements
+    assert result.diagnostics.new_elements == result.mesh.nelements
+    assert result.diagnostics.marked_elements >= 1
+    assert result.diagnostics.transfer_l2_change >= 0.0
+    assert result.values.shape == (fem.CellBasis(result.mesh, ELEM).N,)
+
+
+def test_coarsening_is_disabled_until_hierarchy_and_transfer_are_proven() -> None:
     mesh = initial_mesh()
     adapt = AdaptiveMesh(ELEM, criterion="residual", boundaries=BOUNDARIES)
     u = solve(mesh)
     refined = adapt.refine(mesh, u)
-    assert refined.nelements > mesh.nelements
     u_ref = solve(refined)
-    coarse = adapt.coarsen(refined, u_ref)
-    assert coarse.nelements < refined.nelements
+
+    with pytest.raises(NotImplementedError, match="coarsening is disabled"):
+        adapt.coarsen(refined, u_ref)
 
 
-def test_gradient_refinement_increases_elements():
+def test_gradient_refinement_increases_elements_and_preserves_measure() -> None:
     mesh = initial_mesh()
     adapt = AdaptiveMesh(ELEM, criterion="gradient", boundaries=BOUNDARIES)
     u = solve(mesh)
     refined = adapt.refine(mesh, u)
     assert refined.nelements > mesh.nelements
+    assert mesh_measure(refined) == pytest.approx(mesh_measure(mesh))
+
+
+def test_solution_transfer_preserves_constant_and_linear_1d_functions() -> None:
+    element = fem.ElementLineP1()
+    mesh = fem.MeshLine(np.linspace(0.0, 1.0, 5)).with_boundaries(
+        {
+            "left": lambda x: np.isclose(x[0], 0.0),
+            "right": lambda x: np.isclose(x[0], 1.0),
+        }
+    )
+    adapt = AdaptiveMesh(element, criterion="gradient")
+    refined = mesh.refined(np.asarray([1, 2], dtype=np.int32))
+
+    constant = np.full(fem.CellBasis(mesh, element).N, 7.0)
+    transferred_constant = adapt.transfer_solution(mesh, refined, constant)
+    assert np.allclose(transferred_constant, 7.0)
+
+    linear = fem.CellBasis(mesh, element).doflocs[0]
+    transferred_linear = adapt.transfer_solution(mesh, refined, linear)
+    assert np.allclose(transferred_linear, fem.CellBasis(refined, element).doflocs[0])
+
+
+def test_residual_estimator_supports_1d_meshes() -> None:
+    element = fem.ElementLineP1()
+    mesh = fem.MeshLine(np.linspace(0.0, 1.0, 5))
+    basis = fem.CellBasis(mesh, element)
+    u = np.sin(np.pi * basis.doflocs[0])
+    adapt = AdaptiveMesh(element, criterion="residual", theta=0.5)
+
+    result = adapt.refine_with_transfer(mesh, u)
+
+    assert result.mesh.nelements > mesh.nelements
+    assert mesh_measure(result.mesh) == pytest.approx(mesh_measure(mesh))
+    assert result.values.shape == (fem.CellBasis(result.mesh, element).N,)

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -30,14 +30,21 @@ from finite_element_options.space.boundary import DirichletBC  # noqa: E402
 from finite_element_options.time_integration.stepper import ThetaScheme  # noqa: E402
 
 
-def _build_space_solver(is_call: bool):
+def _build_space_solver(is_call: bool, *, adaptive_criterion: str | None = None):
     dh = DynamicsParametersHeston(
         r=0.03, q=0.03, kappa=0.5, theta=0.5, sig=0.2, rho=0.5
     )
     mkt = Market(r=dh.r)
     bsopt = EuropeanOptionBs(k=0.4, q=dh.q, mkt=mkt)
     mesh, cfg = create_mesh([1.0, 1.0], 1)
-    space = SpaceSolver(mesh, dh, bsopt, is_call=is_call, config=cfg)
+    space = SpaceSolver(
+        mesh,
+        dh,
+        bsopt,
+        is_call=is_call,
+        config=cfg,
+        adaptive_criterion=adaptive_criterion,
+    )
     return space, dh, bsopt
 
 
@@ -79,3 +86,20 @@ def test_dirichlet_matches_model_prices(is_call, price_attr):
     mean_var = dynamics.mean_variance(th_phys, variance_seed, **kwargs)
     expected = getattr(payoff, price_attr)(th_phys, spots, mean_var)
     np.testing.assert_allclose(values, expected)
+
+
+def test_refine_with_transfer_rebuilds_basis_and_returns_values():
+    space, _, _ = _build_space_solver(
+        is_call=True, adaptive_criterion="gradient"
+    )
+    old_elements = space.mesh.nelements
+    values = space.initial_condition()
+
+    result = space.refine_with_transfer(values)
+
+    assert space.mesh.nelements > old_elements
+    assert result.mesh is space.mesh
+    assert result.values.shape == (space.Vh.N,)
+    assert result.diagnostics.old_elements == old_elements
+    assert result.diagnostics.new_elements == space.mesh.nelements
+    assert space.last_adaptive_diagnostics == result.diagnostics

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -89,10 +89,9 @@ def test_dirichlet_matches_model_prices(is_call, price_attr):
 
 
 def test_refine_with_transfer_rebuilds_basis_and_returns_values():
-    space, _, _ = _build_space_solver(
-        is_call=True, adaptive_criterion="gradient"
-    )
+    space, _, _ = _build_space_solver(is_call=True, adaptive_criterion="gradient")
     old_elements = space.mesh.nelements
+    old_domain = space.mesh.domain_spec
     values = space.initial_condition()
 
     result = space.refine_with_transfer(values)
@@ -103,3 +102,6 @@ def test_refine_with_transfer_rebuilds_basis_and_returns_values():
     assert result.diagnostics.old_elements == old_elements
     assert result.diagnostics.new_elements == space.mesh.nelements
     assert space.last_adaptive_diagnostics == result.diagnostics
+    assert space.mesh.domain_spec == old_domain
+    assert set(space.mesh.boundaries) == {"s_min", "s_max", "v_min", "v_max"}
+    assert space.Vh.get_dofs(["s_min"]).nodal["u"].size > 0


### PR DESCRIPTION
Closes #37.

## Summary
- Replaces destructive adaptive coarsening with a fail-closed `NotImplementedError` until reversible hierarchy and coverage invariants exist.
- Adds `AdaptiveMesh.refine_with_transfer`, `AdaptiveResult`, `AdaptiveDiagnostics`, positive-simplex/domain-measure guards, non-empty marking, 1D residual support and nodal interpolation transfer.
- Updates `SpaceSolver.refine_with_transfer` so remeshing rebuilds basis/matrices while returning transferred state values and diagnostics.
- Documents the validated refinement/transfer contract in README, PRD and ARCHITECTURE.

## Verification
- RED first: `uv run --extra dev python -m pytest tests/test_adaptive_mesh.py -q` failed before implementation because `mesh_measure` did not exist.
- `uv run --extra dev ruff check src tests scripts`
- `uv run --extra dev pydocstyle src/finite_element_options`
- `uv run --extra dev mypy --ignore-missing-imports --follow-imports=silent src/finite_element_options/space/adaptive.py src/finite_element_options/space/solver.py`
- `uv run --extra dev python scripts/check_architecture_contract.py`
- `uv run --extra dev python scripts/check_ci_contract.py`
- `uv run --extra dev python -m pytest -q tests/architecture tests/test_packaging_contract.py --no-cov`
- `uv run --extra dev python -m pytest -q` — 184 passed, 2 skipped.
- `uv run --extra dev mypy --ignore-missing-imports --follow-imports=silent src/finite_element_options/contracts src/finite_element_options/validation scripts/check_ci_contract.py`
- `uv run --extra dev python -m build --sdist --wheel`
- `uv run --extra dev python -m twine check dist/*`

## Risk / rollback
- Public `AdaptiveMesh.refine` remains backward-compatible and returns only the refined mesh.
- Coarsening now fails explicitly instead of deleting elements and silently creating holes; callers relying on old destructive coarsening must move behind a future proven hierarchy route.
