### PR TITLE
provider(manifest): export Pinares FEM evidence sidecar

### DIFF
--- a/scripts/export_pinares_fixed_price_proxy_fixture.py
+++ b/scripts/export_pinares_fixed_price_proxy_fixture.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from finite_element_options.validation.pinares_fixed_price_proxy import (
+    PINARES_FEM_PROVIDER_EVIDENCE_MANIFEST_PATH,
     PINARES_FEM_PROXY_PROBLEM_SPEC_PATH,
     PINARES_FEM_PROXY_RESULT_EXPORT_PATH,
     PINARES_FEM_PROXY_UNSUPPORTED_SPEC_PATH,
@@ -20,6 +21,7 @@ def main() -> None:
     for path in (
         PINARES_FEM_PROXY_PROBLEM_SPEC_PATH,
         PINARES_FEM_PROXY_RESULT_EXPORT_PATH,
+        PINARES_FEM_PROVIDER_EVIDENCE_MANIFEST_PATH,
         PINARES_FEM_PROXY_UNSUPPORTED_SPEC_PATH,
         PINARES_QPS_FIXTURE_PATH,
     ):

--- a/src/finite_element_options/validation/pinares_fixed_price_proxy.py
+++ b/src/finite_element_options/validation/pinares_fixed_price_proxy.py
@@ -50,6 +50,9 @@ PINARES_FEM_PROXY_FIXTURE_ROOT = (
 )
 PINARES_FEM_PROXY_PROBLEM_SPEC_PATH = PINARES_FEM_PROXY_FIXTURE_ROOT / "problem_spec.json"
 PINARES_FEM_PROXY_RESULT_EXPORT_PATH = PINARES_FEM_PROXY_FIXTURE_ROOT / "result_export.json"
+PINARES_FEM_PROVIDER_EVIDENCE_MANIFEST_PATH = (
+    PINARES_FEM_PROXY_FIXTURE_ROOT / "provider_evidence_manifest.json"
+)
 PINARES_FEM_PROXY_UNSUPPORTED_SPEC_PATH = (
     PINARES_FEM_PROXY_FIXTURE_ROOT / "unsupported_full_deal_problem_spec.json"
 )
@@ -583,6 +586,7 @@ def run_public_pinares_fixed_price_proxy_fixture(
     if refresh_exports:
         write_public_pinares_fixed_price_problem_spec(report=report)
         write_public_pinares_fixed_price_result_export(report=report, refresh=True)
+        write_public_pinares_provider_evidence_manifest(report=report, refresh=True)
         write_public_pinares_unsupported_problem_spec(refresh=True)
         write_public_pinares_quant_problem_spec(report=report)
     return report
@@ -618,6 +622,130 @@ def write_public_pinares_fixed_price_result_export(
             report = run_public_pinares_fixed_price_proxy_fixture()
         target.write_text(
             json.dumps(report.export_payload(), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    return target
+
+
+def build_pinares_fem_provider_evidence_manifest(
+    report: PinaresFEMProxyReport | None = None,
+) -> dict[str, Any]:
+    """Return dashboard-consumable FEM provider evidence for the Pinares proxy route."""
+
+    active_report = report or run_public_pinares_fixed_price_proxy_fixture()
+    manifest = DEFAULT_FEM_CAPABILITY_MANIFEST
+    case = active_report.case
+    scipy_direct = next(
+        backend for backend in manifest.solver_backends if backend.name == "scipy_direct"
+    )
+    final_row = active_report.rows[-1]
+    return _stable_public_payload(
+        {
+            "schema": "pinares.provider_evidence_manifest.v1",
+            "producer": "finite_element_options",
+            "provider_role": "weak-form-pde-provider",
+            "issue_refs": ["googa27/finite_element_options#104"],
+            "project_ref": "googa27#19",
+            "privacy_class": "public_synthetic",
+            "evidence_class": "deterministic_proxy_not_full_family_contract_valuation",
+            "problem": {
+                "problem_id": case.problem_id,
+                "problem_hash": case.problem_hash,
+                "fixture_id": case.fixture_id,
+                "measure": "Q*",
+                "numeraire": "UF_money_market_account_proxy",
+                "valuation_date": case.valuation_date,
+                "maturity_date": case.maturity_date,
+                "units": case.normalized_units(),
+            },
+            "fixture_refs": {
+                "problem_spec": "tests/fixtures/fem_pinares_fixed_price_proxy_v1/problem_spec.json",
+                "result_export": "tests/fixtures/fem_pinares_fixed_price_proxy_v1/result_export.json",
+                "unsupported_problem_spec": "tests/fixtures/fem_pinares_fixed_price_proxy_v1/unsupported_full_deal_problem_spec.json",
+                "provider_evidence_manifest": "tests/fixtures/fem_pinares_fixed_price_proxy_v1/provider_evidence_manifest.json",
+                "quant_problem_spec": "tests/fixtures/quant_problem_specs/pinares_fixed_price_proxy.json",
+            },
+            "capability_manifest": manifest.to_public_dict(),
+            "route": {
+                "route_id": case.route_id,
+                "method_kind": "finite_element",
+                "mesh_family": "line_uniform",
+                "element_family": "lagrange_p2",
+                "time_integrator": "theta_crank_nicolson",
+                "weak_form": _weak_form_metadata(),
+                "boundary_conditions": _boundary_metadata(case),
+                "requested_outputs": ["value", "delta", "gamma"],
+            },
+            "cache_factorization_policy": {
+                "linear_solver": scipy_direct.name,
+                "method": scipy_direct.method,
+                "factorization_reuse": scipy_direct.factorization_reuse,
+                "cache_scope": scipy_direct.cache_scope,
+            },
+            "resource_controls": {
+                "refinement_levels": list(case.refinement_levels),
+                "time_steps": case.time_steps,
+                "max_degrees_of_freedom": final_row.degrees_of_freedom,
+                "deterministic": "true",
+            },
+            "error_budgets": {
+                "price_abs_uf": case.price_abs_tolerance_uf,
+                "delta_abs": case.delta_abs_tolerance,
+                "gamma_abs": case.gamma_abs_tolerance,
+            },
+            "parity_metrics": {
+                "price_abs_uf": active_report.price_absolute_error_uf,
+                "price_rel": active_report.price_relative_error,
+                "delta_abs": active_report.delta_absolute_error,
+                "gamma_abs": active_report.gamma_absolute_error,
+                "converged": active_report.converged,
+                "no_arbitrage": active_report.no_arbitrage,
+            },
+            "performance_sidecar": {
+                "runtime": {
+                    "seconds": None,
+                    "policy": "deterministic fixture omits wall-clock timing",
+                },
+                "degrees_of_freedom": final_row.degrees_of_freedom,
+                "mesh_metadata": _mesh_metadata(case),
+                "time_metadata": _time_metadata(case),
+            },
+            "unsupported_routes": {
+                "rofr": "fail_closed",
+                "full_family_contract": "fail_closed",
+                "legal_tax_conclusion": "fail_closed",
+                "liquidity_default": "fail_closed",
+                "market_rent_alternative": "fail_closed",
+                "adaptive_mesh": "fail_closed_until_separate_evidence",
+                "higher_dimensional_contract": "fail_closed_until_separate_evidence",
+            },
+            "limitations": [
+                "fixed-price proxy only; ROFR is not a vanilla call",
+                "public-synthetic fixture only; no private family facts or PDP rows",
+                "FEM backend supplies numerical weak-form route evidence, not legal/tax advice",
+            ],
+        }
+    )
+
+
+def write_public_pinares_provider_evidence_manifest(
+    path: Path | str = PINARES_FEM_PROVIDER_EVIDENCE_MANIFEST_PATH,
+    *,
+    refresh: bool = False,
+    report: PinaresFEMProxyReport | None = None,
+) -> Path:
+    """Write the public-synthetic Pinares FEM provider evidence manifest."""
+
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if (not target.exists()) or refresh:
+        if report is None:
+            report = run_public_pinares_fixed_price_proxy_fixture()
+        target.write_text(
+            json.dumps(
+                build_pinares_fem_provider_evidence_manifest(report), indent=2, sort_keys=True
+            )
+            + "\n",
             encoding="utf-8",
         )
     return target
@@ -845,6 +973,7 @@ __all__ = [
     "PINARES_FEM_FIXED_PRICE_PROXY_PROBLEM_HASH",
     "PINARES_FEM_FIXED_PRICE_PROXY_PROBLEM_ID",
     "PINARES_FEM_FIXED_PRICE_PROXY_ROUTE_ID",
+    "PINARES_FEM_PROVIDER_EVIDENCE_MANIFEST_PATH",
     "PINARES_FEM_PROXY_PROBLEM_SPEC_PATH",
     "PINARES_FEM_PROXY_RESULT_EXPORT_PATH",
     "PINARES_FEM_PROXY_UNSUPPORTED_SPEC_PATH",
@@ -853,12 +982,14 @@ __all__ = [
     "PinaresFEMProxyConvergenceRow",
     "PinaresFEMProxyReport",
     "PinaresFixedPriceProxyCase",
+    "build_pinares_fem_provider_evidence_manifest",
     "build_pinares_fem_proxy_hash",
     "public_pinares_fixed_price_problem_spec",
     "public_pinares_full_deal_unsupported_problem_spec",
     "run_public_pinares_fixed_price_proxy_fixture",
     "write_public_pinares_fixed_price_problem_spec",
     "write_public_pinares_fixed_price_result_export",
+    "write_public_pinares_provider_evidence_manifest",
     "write_public_pinares_quant_problem_spec",
     "write_public_pinares_unsupported_problem_spec",
 ]

--- a/tests/fixtures/fem_pinares_fixed_price_proxy_v1/provider_evidence_manifest.json
+++ b/tests/fixtures/fem_pinares_fixed_price_proxy_v1/provider_evidence_manifest.json
@@ -1,0 +1,246 @@
+{
+  "cache_factorization_policy": {
+    "cache_scope": "per invariant theta-system solve; invalidated by mesh, dt, theta, operator or boundary-dof changes",
+    "factorization_reuse": true,
+    "linear_solver": "scipy_direct",
+    "method": "scipy.sparse.linalg.splu"
+  },
+  "capability_manifest": {
+    "backend_id": "finite_element_options.fem_backend.v0",
+    "boundary_conditions": [
+      "dirichlet"
+    ],
+    "contract_version": "0.1.0",
+    "diagnostics": [
+      "unsupported dimension",
+      "unsupported mesh family",
+      "unsupported element family",
+      "unsupported PDE term",
+      "unsupported boundary condition",
+      "unsupported exercise style",
+      "unsupported output",
+      "missing measure/numeraire/units/date convention"
+    ],
+    "element_families": [
+      "lagrange_p2"
+    ],
+    "exercise_styles": [
+      "european"
+    ],
+    "linear_solvers": [
+      "scipy_direct"
+    ],
+    "mesh_families": [
+      "line_uniform"
+    ],
+    "notes": [
+      "The executable parity fixture validates the 1D public-synthetic Black-Scholes call value.",
+      "The Pinares fixed-price proxy validates the same 1D weak-form envelope with public-synthetic UF units, survival-scaled terminal payoff, Lagrange P2 line mesh, theta stepping and SciPy direct solves.",
+      "Adaptive meshes, higher-order elements, American exercise, obstacles/free boundaries, HJB/control and jump terms fail closed until evidenced.",
+      "Greek output names are backed by deterministic central-stencil Delta/Gamma errors in the public parity fixtures; broader kink-aware production evidence remains separate."
+    ],
+    "outputs": [
+      "value",
+      "delta",
+      "gamma"
+    ],
+    "pde_terms": [
+      "drift",
+      "diffusion",
+      "reaction"
+    ],
+    "required_conventions": [
+      "measure",
+      "numeraire",
+      "units",
+      "valuation_date",
+      "maturity_or_time_domain"
+    ],
+    "solver_backends": [
+      {
+        "cache_scope": "per invariant theta-system solve; invalidated by mesh, dt, theta, operator or boundary-dof changes",
+        "extra": null,
+        "factorization_reuse": true,
+        "method": "scipy.sparse.linalg.splu",
+        "name": "scipy_direct",
+        "status": "validated",
+        "unsupported_reason": null
+      },
+      {
+        "cache_scope": "not advertised for current FEM sparse boundary-eliminated matrices",
+        "extra": null,
+        "factorization_reuse": false,
+        "method": "scipy.linalg.solve_banded",
+        "name": "scipy_banded",
+        "status": "unsupported",
+        "unsupported_reason": "banded extraction/equal-error residual evidence is not part of the released FEM route"
+      },
+      {
+        "cache_scope": "optional dependency route fails closed",
+        "extra": "amg",
+        "factorization_reuse": false,
+        "method": "pyamg or scipy iterative with AMG preconditioner",
+        "name": "amg",
+        "status": "unsupported",
+        "unsupported_reason": "AMG convergence, tolerance and equal-error benchmark evidence is absent"
+      },
+      {
+        "cache_scope": "optional dependency route fails closed",
+        "extra": "petsc",
+        "factorization_reuse": false,
+        "method": "petsc4py/KSP",
+        "name": "petsc",
+        "status": "unsupported",
+        "unsupported_reason": "PETSc platform/profile and parity evidence is absent"
+      }
+    ],
+    "stability_controls": [
+      "theta",
+      "crank_nicolson"
+    ],
+    "status": "validated",
+    "supported_dimensions": [
+      1
+    ]
+  },
+  "error_budgets": {
+    "delta_abs": 0.001,
+    "gamma_abs": 5e-06,
+    "price_abs_uf": 1.0
+  },
+  "evidence_class": "deterministic_proxy_not_full_family_contract_valuation",
+  "fixture_refs": {
+    "problem_spec": "tests/fixtures/fem_pinares_fixed_price_proxy_v1/problem_spec.json",
+    "provider_evidence_manifest": "tests/fixtures/fem_pinares_fixed_price_proxy_v1/provider_evidence_manifest.json",
+    "quant_problem_spec": "tests/fixtures/quant_problem_specs/pinares_fixed_price_proxy.json",
+    "result_export": "tests/fixtures/fem_pinares_fixed_price_proxy_v1/result_export.json",
+    "unsupported_problem_spec": "tests/fixtures/fem_pinares_fixed_price_proxy_v1/unsupported_full_deal_problem_spec.json"
+  },
+  "issue_refs": [
+    "googa27/finite_element_options#104"
+  ],
+  "limitations": [
+    "fixed-price proxy only; ROFR is not a vanilla call",
+    "public-synthetic fixture only; no private family facts or PDP rows",
+    "FEM backend supplies numerical weak-form route evidence, not legal/tax advice"
+  ],
+  "parity_metrics": {
+    "converged": true,
+    "delta_abs": 3.1728918e-05,
+    "gamma_abs": 8.1432621e-07,
+    "no_arbitrage": {
+      "delta_lower_bound_ok": true,
+      "delta_upper_bound_ok": true,
+      "gamma_non_negative_ok": true,
+      "survival_scale_ok": true,
+      "upper_bound_ok": true,
+      "upper_gap_uf": 5588.2142,
+      "value_bound_ok": true,
+      "value_minus_intrinsic_uf": 231.78576
+    },
+    "price_abs_uf": 0.013734133,
+    "price_rel": 5.9250057e-05
+  },
+  "performance_sidecar": {
+    "degrees_of_freedom": 257,
+    "mesh_metadata": {
+      "domain_max": 1.9354839,
+      "domain_min": 0.0,
+      "element_family": "lagrange_p2",
+      "mesh_family": "line_uniform",
+      "refinement_levels": [
+        5,
+        6,
+        7
+      ],
+      "solver_backing": "scikit-fem+sparse-direct",
+      "spatial_domain": "[0, 1.93548387097] normalized spot S/K"
+    },
+    "runtime": {
+      "policy": "deterministic fixture omits wall-clock timing",
+      "seconds": null
+    },
+    "time_metadata": {
+      "end_time": 1.0,
+      "integrator": "theta_crank_nicolson",
+      "start_time": 0.0,
+      "theta": 0.5,
+      "time_domain": "[0, 1]",
+      "time_steps": 160
+    }
+  },
+  "privacy_class": "public_synthetic",
+  "problem": {
+    "fixture_id": "public-synthetic.pinares-fem-fixed-price-proxy.v1",
+    "maturity_date": "2027-06-30",
+    "measure": "Q*",
+    "numeraire": "UF_money_market_account_proxy",
+    "problem_hash": "publicsyntheticpinares001",
+    "problem_id": "pinares.fixed_price_option_proxy.v1",
+    "units": {
+      "S": "UF",
+      "rate": "1/year",
+      "time": "year",
+      "underlying": "UF",
+      "value": "UF"
+    },
+    "valuation_date": "2026-06-30"
+  },
+  "producer": "finite_element_options",
+  "project_ref": "googa27#19",
+  "provider_role": "weak-form-pde-provider",
+  "resource_controls": {
+    "deterministic": "true",
+    "max_degrees_of_freedom": 257,
+    "refinement_levels": [
+      5,
+      6,
+      7
+    ],
+    "time_steps": 160
+  },
+  "route": {
+    "boundary_conditions": [
+      {
+        "condition_type": "dirichlet",
+        "enforced_nodes": 1,
+        "expression": "0",
+        "location": "S=0"
+      },
+      {
+        "condition_type": "dirichlet",
+        "enforced_nodes": 1,
+        "expression": "linear_growth_call_far_field",
+        "location": "S=S_max",
+        "s_max_uf": 12000.0
+      }
+    ],
+    "element_family": "lagrange_p2",
+    "mesh_family": "line_uniform",
+    "method_kind": "finite_element",
+    "requested_outputs": [
+      "value",
+      "delta",
+      "gamma"
+    ],
+    "route_id": "fem.pinares_fixed_price_proxy.weak_form_p2_theta",
+    "time_integrator": "theta_crank_nicolson",
+    "weak_form": {
+      "coordinate_transform": "normalized_spot_x_equals_S_over_K",
+      "equation_id": "pinares_fixed_price_proxy_black_scholes_weak_form",
+      "payoff_scaling": "UF value = survival_probability * K_uf * normalized_call_value",
+      "sign_convention": "existing_forward_tau_identity_transform_black_scholes_forms",
+      "time_transformation": "tau = T - t"
+    }
+  },
+  "schema": "pinares.provider_evidence_manifest.v1",
+  "unsupported_routes": {
+    "adaptive_mesh": "fail_closed_until_separate_evidence",
+    "full_family_contract": "fail_closed",
+    "higher_dimensional_contract": "fail_closed_until_separate_evidence",
+    "legal_tax_conclusion": "fail_closed",
+    "liquidity_default": "fail_closed",
+    "market_rent_alternative": "fail_closed",
+    "rofr": "fail_closed"
+  }
+}

--- a/tests/test_pinares_fem_proxy.py
+++ b/tests/test_pinares_fem_proxy.py
@@ -19,12 +19,14 @@ from finite_element_options.validation.pinares_fixed_price_proxy import (
     PINARES_FEM_FIXED_PRICE_PROXY_BENCHMARK_ID,
     PINARES_FEM_FIXED_PRICE_PROXY_PROBLEM_HASH,
     PINARES_FEM_FIXED_PRICE_PROXY_PROBLEM_ID,
+    PINARES_FEM_PROVIDER_EVIDENCE_MANIFEST_PATH,
     PINARES_FEM_PROXY_PROBLEM_SPEC_PATH,
     PINARES_FEM_PROXY_RESULT_EXPORT_PATH,
     PINARES_FEM_PROXY_UNSUPPORTED_SPEC_PATH,
     PINARES_QPS_FIXTURE_PATH,
     PinaresFEMProxyReport,
     PinaresFixedPriceProxyCase,
+    build_pinares_fem_provider_evidence_manifest,
     build_pinares_fem_proxy_hash,
     public_pinares_fixed_price_problem_spec,
     public_pinares_full_deal_unsupported_problem_spec,
@@ -112,6 +114,7 @@ def test_static_pinares_exports_are_current_public_and_hash_stable(
     qps_spec = _load_json(PINARES_QPS_FIXTURE_PATH)
     result_export = _load_json(PINARES_FEM_PROXY_RESULT_EXPORT_PATH)
     unsupported_spec = _load_json(PINARES_FEM_PROXY_UNSUPPORTED_SPEC_PATH)
+    provider_manifest = _load_json(PINARES_FEM_PROVIDER_EVIDENCE_MANIFEST_PATH)
 
     generated_spec = public_pinares_fixed_price_problem_spec(case=pinares_report.case)
     generated_unsupported = public_pinares_full_deal_unsupported_problem_spec()
@@ -120,6 +123,7 @@ def test_static_pinares_exports_are_current_public_and_hash_stable(
     assert qps_spec == generated_spec
     assert unsupported_spec == generated_unsupported
     assert result_export == pinares_report.export_payload()
+    assert provider_manifest == build_pinares_fem_provider_evidence_manifest(pinares_report)
     assert problem_spec["contract_id"] == build_pinares_fem_proxy_hash(
         {key: value for key, value in problem_spec.items() if key != "contract_id"}
     )
@@ -133,6 +137,39 @@ def test_static_pinares_exports_are_current_public_and_hash_stable(
         result_export["summary"]["price_absolute_error_uf"]
         <= result_export["summary"]["price_tolerance_absolute_uf"]
     )
+
+
+def test_pinares_fem_provider_evidence_manifest_reports_cache_and_performance_fields(
+    pinares_report: PinaresFEMProxyReport,
+) -> None:
+    manifest = build_pinares_fem_provider_evidence_manifest(pinares_report)
+
+    assert manifest["schema"] == "pinares.provider_evidence_manifest.v1"
+    assert manifest["producer"] == "finite_element_options"
+    assert manifest["privacy_class"] == "public_synthetic"
+    assert manifest["issue_refs"] == ["googa27/finite_element_options#104"]
+    assert manifest["evidence_class"] == "deterministic_proxy_not_full_family_contract_valuation"
+    assert (
+        manifest["capability_manifest"]["backend_id"] == DEFAULT_FEM_CAPABILITY_MANIFEST.backend_id
+    )
+    assert (
+        manifest["capability_manifest"]["contract_version"]
+        == DEFAULT_FEM_CAPABILITY_MANIFEST.contract_version
+    )
+    assert manifest["route"]["method_kind"] == "finite_element"
+    assert (
+        manifest["route"]["weak_form"]["equation_id"]
+        == "pinares_fixed_price_proxy_black_scholes_weak_form"
+    )
+    assert manifest["cache_factorization_policy"]["linear_solver"] == "scipy_direct"
+    assert manifest["cache_factorization_policy"]["factorization_reuse"] is True
+    assert manifest["performance_sidecar"]["runtime"]["seconds"] is None
+    assert (
+        manifest["performance_sidecar"]["degrees_of_freedom"]
+        == pinares_report.rows[-1].degrees_of_freedom
+    )
+    assert manifest["parity_metrics"]["price_abs_uf"] <= manifest["error_budgets"]["price_abs_uf"]
+    assert manifest["unsupported_routes"]["full_family_contract"] == "fail_closed"
 
 
 def test_unsupported_full_deal_route_fails_closed_with_actionable_diagnostics() -> None:


### PR DESCRIPTION
## Summary
- add `build_pinares_fem_provider_evidence_manifest()` for the deterministic FEM weak-form Pinares fixed-price proxy
- export `tests/fixtures/fem_pinares_fixed_price_proxy_v1/provider_evidence_manifest.json`
- include capability manifest, weak-form route metadata, SciPy-direct factorization cache policy, resource controls, parity metrics, performance sidecar, and fail-closed unsupported routes

## Scope guard
- public-synthetic fixed-price option proxy only
- ROFR, full family contract, legal/tax conclusion, liquidity/default, adaptive/higher-dimensional routes, and market-rent alternatives remain fail-closed unless separately evidenced

## Verification
- `uv run pytest -q tests/test_pinares_fem_proxy.py` -> 6 passed
- targeted `uv run ruff check scripts/export_pinares_fixed_price_proxy_fixture.py src/finite_element_options/validation/pinares_fixed_price_proxy.py tests/test_pinares_fem_proxy.py` -> passed
- targeted `uv run ruff format --check ...` after formatting -> passed
- `uv run pytest -q` -> 191 passed, 2 skipped, 25 warnings

## Known pre-existing repo gate
- full `uv run ruff format --check .` still reports unrelated pre-existing formatting drift across older source/build/test files; this PR's changed files pass targeted ruff.

Closes #104
