### PR TITLE
fix(fenicsx): use supported DOLFINx boundary and KSP APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,24 @@ jobs:
             benchmark.json
           if-no-files-found: error
 
+  fenicsx_contract:
+    name: FEniCSx backend contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.11'
+      - name: Install development profile
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[dev]' -c constraints.txt
+      - name: Run FEniCSx backend contract tests
+        run: pytest -q tests/test_fenics_solver.py tests/test_benchmark_fenics.py --no-cov
+
   optional_imports:
     name: optional imports (${{ matrix.profile }})
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -203,11 +203,13 @@ interpreting the output and contrasting runs.
 ### FEniCSx Spike
 
 An experimental `FenicsSolver` mirrors the existing scikit-fem backend using
-FEniCSx and UFL. On the Black–Scholes test problem the scikit-fem solver runs
-in roughly 2 ms per step on this environment. FEniCSx wheels are unavailable for
-Python 3.11, so its performance could not be measured here. The solver is
-therefore an optional dependency and currently best treated as a preview for a
-potential future migration.
+FEniCSx and UFL. The backend is deliberately optional, but its repository
+contract is now executable in CI: `tests/test_fenics_solver.py` checks that the
+implementation uses DOLFINx boundary-facet/DOF APIs instead of local first/last
+row assumptions, applies Dirichlet conditions through DOLFINx/PETSc lifting and
+`set_bc`, sets the KSP operator after boundary assembly, and raises on PETSc
+non-convergence. When a FEniCSx-compatible environment is available, the same
+test module also runs the serial Black--Scholes parity smoke.
 
 ## Continuous Integration
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -319,6 +319,8 @@ A solver policy declares:
 
 Potential profiles include SciPy sparse direct/iterative baseline, optional AMG and optional PETSc. Broad exception fallback is prohibited. A failure returns a failed result/exception with residual and context, not a numerical field presented as success.
 
+Issue #38 pins the optional FEniCSx spike to supported DOLFINx/PETSc semantics: endpoint facets/DOFs are located geometrically rather than inferred from local vector order, Dirichlet data are represented as DOLFINx `dirichletbc` objects, system matrices are assembled with those BCs, RHS vectors receive `apply_lifting`/`set_bc`, KSP operators are set after boundary modification, and non-positive KSP convergence reasons raise with prefix, reason, iteration and residual diagnostics. The CI `fenicsx_contract` job executes backend contract tests even when the optional runtime is unavailable; true serial/MPI numerical parity remains conditional on a FEniCSx-compatible environment.
+
 ## 14. Adaptivity architecture
 
 Adaptivity pipeline:

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -265,8 +265,8 @@ The current single `requirements.txt` combines core, FD, UI, calibration, datafr
 | `calibration` | Deterministic statistical calibration | pandas/xarray/Statsmodels as required |
 | `bayes` | Bayesian research workflow | PyMC and its stack |
 | `columnar` | Arrow/Parquet experiment exchange | PyArrow and optional dataframe packages |
-| `fenicsx` | Optional FEniCSx backend | FEniCSx-compatible environment |
-| `petsc` | PETSc/petsc4py solver policy | Platform-specific HPC environment |
+| `fenicsx` | Optional FEniCSx backend | FEniCSx-compatible environment; contract tests run in CI even without runtime |
+| `petsc` | PETSc/petsc4py solver policy | Platform-specific HPC environment; KSP convergence diagnostics fail closed |
 | `ui` | Streamlit demonstration | Streamlit plus visualization |
 | `validation` | Reference and benchmark tooling | Test/reference packages |
 | development groups | Test, lint, typing, docs, build and audit | pytest, Hypothesis, Ruff, mypy, build, twine |

--- a/scripts/check_ci_contract.py
+++ b/scripts/check_ci_contract.py
@@ -22,6 +22,7 @@ JOB_HEADER = re.compile(r"^  ([A-Za-z0-9_-]+):\s*$")
 REQUIRED_JOBS = {
     "package",
     "test",
+    "fenicsx_contract",
     "optional_imports",
     "supply_chain",
 }
@@ -41,6 +42,8 @@ REQUIRED_SNIPPETS = {
     "packaging contract": "tests/test_packaging_contract.py",
     "coverage gate": "--cov=finite_element_options",
     "benchmark artifact": "--benchmark-json=benchmark.json",
+    "FEniCSx contract job": "fenicsx_contract",
+    "FEniCSx backend contract tests": "tests/test_fenics_solver.py",
     "pip audit": "python -m pip_audit",
     "cyclonedx sbom": "cyclonedx-py environment",
     "optional fd profile": "profile: fd",

--- a/src/finite_element_options/space/fenics_solver.py
+++ b/src/finite_element_options/space/fenics_solver.py
@@ -1,33 +1,33 @@
-"""Experimental FEniCS-based spatial solver using UFL forms.
+"""Experimental FEniCSx spatial solver using supported DOLFINx/PETSc APIs.
 
-This spike mirrors the existing :class:`SpaceSolver` implemented with
-scikit-fem but leverages the FEniCSx runtime and UFL to assemble the
-same PDE operators.  The implementation currently targets the
-one-dimensional Black--Scholes equation with constant coefficients and
-serves as a starting point for broader support.
-
-The solver exposes a minimal API compatible with the :class:`ThetaScheme`
-stepper, allowing drop-in benchmarking against the scikit-fem backend.
-FEniCS is treated as an optional dependency; instantiation will raise an
-:class:`ImportError` if the library is unavailable.
+This optional backend mirrors the one-dimensional Black--Scholes scikit-fem
+route while keeping FEniCSx/PETSc semantics explicit: boundary degrees of
+freedom are located geometrically, Dirichlet conditions are passed through
+DOLFINx boundary-condition objects, the PETSc KSP always solves the boundary-
+modified matrix, and divergence is surfaced as an exception with diagnostics.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Iterable
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from typing import Any
 
 import numpy as np
 
 try:  # pragma: no cover - optional dependency
     from mpi4py import MPI
     from petsc4py import PETSc
-    from dolfinx import fem, mesh
+    from dolfinx import default_scalar_type, fem, mesh
     import ufl
 except Exception:  # pragma: no cover - imported lazily
-    fem = mesh = ufl = MPI = PETSc = None
+    fem = mesh = ufl = MPI = PETSc = default_scalar_type = None
 
-from finite_element_options.core.interfaces import DynamicsModel, Payoff, SpaceDiscretization
+from finite_element_options.core.interfaces import (
+    DynamicsModel,
+    Payoff,
+    SpaceDiscretization,
+)
 
 
 @dataclass
@@ -39,50 +39,164 @@ class FenicsSolver(SpaceDiscretization):
     dynamics: DynamicsModel
     payoff: Payoff
     is_call: bool = True
+    petsc_options_prefix: str | None = None
+    mesh: Any = field(init=False, repr=False)
+    Vh: Any = field(init=False, repr=False)
+    mass: Any = field(init=False, repr=False)
+    stiffness: Any = field(init=False, repr=False)
+    _left_dofs: Any = field(init=False, repr=False)
+    _right_dofs: Any = field(init=False, repr=False)
+    _mass_expr: Any = field(init=False, repr=False)
+    _operator_expr: Any = field(init=False, repr=False)
+    _active_system_form: Any | None = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
-        """Create mesh and assemble static operators after initialisation."""
-        if fem is None:  # pragma: no cover - optional dependency
+        """Create mesh, locate boundary DOFs, and assemble static operators."""
+        if fem is None or mesh is None or ufl is None:  # pragma: no cover
             raise ImportError("FEniCSx is required for FenicsSolver")
+        left, right = (float(self.domain[0]), float(self.domain[1]))
+        if not np.isfinite([left, right]).all() or not left < right:
+            raise ValueError("domain must be a finite increasing (left, right) pair")
+        if self.num_elements < 2:
+            raise ValueError("num_elements must be at least 2")
+        self.domain = (left, right)
+        self.petsc_options_prefix = (
+            self.petsc_options_prefix or f"feo_fenicsx_{id(self):x}_"
+        )
 
-        # create interval mesh and function space
         self.mesh = mesh.create_interval(
             MPI.COMM_WORLD, self.num_elements, list(self.domain)
         )
-        self.Vh = fem.FunctionSpace(self.mesh, ("Lagrange", 1))
+        self.Vh = self._function_space(("Lagrange", 1))
+        self._left_dofs, self._right_dofs = self._locate_boundary_dofs()
         self._assemble_operators()
 
-    # ------------------------------------------------------------------
-    def _assemble_operators(self) -> None:
-        """Assemble mass and stiffness matrices via UFL forms."""
+    def _function_space(self, element: tuple[str, int]) -> Any:
+        """Create a DOLFINx function space across supported API names."""
+        if hasattr(fem, "functionspace"):
+            return fem.functionspace(self.mesh, element)
+        return fem.FunctionSpace(self.mesh, element)  # pragma: no cover - old API
 
-        u = ufl.TrialFunction(self.Vh)
-        v = ufl.TestFunction(self.Vh)
+    def _locate_boundary_dofs(self) -> tuple[Any, Any]:
+        """Locate endpoint boundary DOFs geometrically, including MPI ownership."""
+        tdim = self.mesh.topology.dim
+        fdim = tdim - 1
+        self.mesh.topology.create_connectivity(fdim, tdim)
+        left_facets = mesh.locate_entities_boundary(
+            self.mesh, fdim, lambda x: np.isclose(x[0], self.domain[0])
+        )
+        right_facets = mesh.locate_entities_boundary(
+            self.mesh, fdim, lambda x: np.isclose(x[0], self.domain[1])
+        )
+        left_dofs = fem.locate_dofs_topological(self.Vh, fdim, left_facets)
+        right_dofs = fem.locate_dofs_topological(self.Vh, fdim, right_facets)
+        if len(left_dofs) == 0 or len(right_dofs) == 0:
+            raise RuntimeError("failed to locate FEniCSx endpoint boundary DOFs")
+        return left_dofs, right_dofs
+
+    def _assemble_operators(self) -> None:
+        """Assemble unconstrained mass and PDE operator forms via UFL."""
+        trial = ufl.TrialFunction(self.Vh)
+        test = ufl.TestFunction(self.Vh)
         x = ufl.SpatialCoordinate(self.mesh)
 
-        sig = self.dynamics.sig
-        r = self.dynamics.r
-        q = getattr(self.dynamics, "q", 0.0)
+        sigma = self.dynamics.sig
+        rate = self.dynamics.r
+        carry = getattr(self.dynamics, "q", 0.0)
 
-        mass_form = u * v * ufl.dx
-        pde_form = (
-            0.5 * sig**2 * x[0] ** 2 * ufl.grad(u)[0] * ufl.grad(v)[0]
-            + (r - q) * x[0] * ufl.grad(u)[0] * v
-            - r * u * v
+        self._mass_expr = trial * test * ufl.dx
+        self._operator_expr = (
+            0.5 * sigma**2 * x[0] ** 2 * ufl.grad(trial)[0] * ufl.grad(test)[0]
+            + (rate - carry) * x[0] * ufl.grad(trial)[0] * test
+            - rate * trial * test
         ) * ufl.dx
 
-        self.mass = fem.petsc.assemble_matrix(fem.form(mass_form))
-        self.mass.assemble()
-        self.stiffness = fem.petsc.assemble_matrix(fem.form(pde_form))
-        self.stiffness.assemble()
+        self.mass = self._assemble_matrix(self._mass_expr)
+        self.stiffness = self._assemble_matrix(self._operator_expr)
 
-    # ------------------------------------------------------------------
-    def initial_condition(self) -> np.ndarray:
-        """Project the terminal payoff onto the nodal grid."""
-        coords = self.Vh.tabulate_dof_coordinates().reshape(-1)
+    def _assemble_matrix(self, expression: Any, bcs: Sequence[Any] = ()) -> Any:
+        """Assemble a PETSc matrix from a UFL expression and optional BCs."""
+        matrix = fem.petsc.assemble_matrix(fem.form(expression), bcs=list(bcs))
+        matrix.assemble()
+        return matrix
+
+    def _system_form(self, theta: float, dt: float) -> Any:
+        """Return the θ-step left-hand-side DOLFINx form."""
+        return fem.form(self._mass_expr - theta * dt * self._operator_expr)
+
+    def _rhs_form(self, theta: float, dt: float) -> Any:
+        """Return the θ-step right-hand-side matrix expression."""
+        return fem.form(self._mass_expr + (1.0 - theta) * dt * self._operator_expr)
+
+    def _system_matrix(self, theta: float, dt: float, bcs: Sequence[Any]) -> tuple[Any, Any]:
+        """Assemble the boundary-modified left-hand-side matrix."""
+        system_form = self._system_form(theta, dt)
+        matrix = fem.petsc.assemble_matrix(system_form, bcs=list(bcs))
+        matrix.assemble()
+        return matrix, system_form
+
+    def _rhs_matrix(self, theta: float, dt: float) -> Any:
+        """Assemble the unconstrained right-hand-side matrix."""
+        matrix = fem.petsc.assemble_matrix(self._rhs_form(theta, dt), bcs=[])
+        matrix.assemble()
+        return matrix
+
+    def _boundary_values(self, th: float) -> tuple[float, float]:
+        """Return left and right Black--Scholes Dirichlet endpoint values."""
+        rate = self.dynamics.r
+        strike = self.payoff.k
+        upper = self.domain[1]
+        discount = np.exp(-rate * th)
         if self.is_call:
-            return np.array([self.payoff.call_payoff(s) for s in coords])
-        return np.array([self.payoff.put_payoff(s) for s in coords])
+            return 0.0, float(upper - strike * discount)
+        return float(strike * discount), 0.0
+
+    def _scalar(self, value: float) -> Any:
+        """Cast a Python float to the scalar type expected by DOLFINx."""
+        if default_scalar_type is not None:
+            return default_scalar_type(value)
+        return PETSc.ScalarType(value)  # pragma: no cover - defensive fallback
+
+    def _dirichlet_bcs(self, th: float) -> list[Any]:
+        """Create supported DOLFINx DirichletBC objects for endpoint DOFs."""
+        left, right = self._boundary_values(th)
+        return [
+            fem.dirichletbc(self._scalar(left), self._left_dofs, self.Vh),
+            fem.dirichletbc(self._scalar(right), self._right_dofs, self.Vh),
+        ]
+
+    def _local_dof_count(self) -> int:
+        """Return the local scalar DOF count for this MPI rank."""
+        index_map = self.Vh.dofmap.index_map
+        block_size = self.Vh.dofmap.index_map_bs
+        return int(index_map.size_local * block_size)
+
+    def _dof_coordinates(self) -> np.ndarray:
+        """Return scalar DOF coordinates for this rank."""
+        coordinates = self.Vh.tabulate_dof_coordinates()
+        return np.asarray(coordinates, dtype=float).reshape((-1, coordinates.shape[-1]))
+
+    def _owned_array(self, vec: Any) -> np.ndarray:
+        """Copy the owned local PETSc vector entries as a NumPy array."""
+        return np.asarray(vec.array, dtype=float).copy()
+
+    def _initial_petsc_vec(self) -> Any:
+        """Create the initial PETSc vector from local terminal payoff values."""
+        index_map = self.Vh.dofmap.index_map
+        block_size = self.Vh.dofmap.index_map_bs
+        local_size = int(index_map.size_local * block_size)
+        global_size = int(index_map.size_global * block_size)
+        vec = PETSc.Vec().createMPI((local_size, global_size), comm=self.mesh.comm)
+        vec.array[:] = self.initial_condition()
+        vec.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
+        return vec
+
+    def initial_condition(self) -> np.ndarray:
+        """Project the terminal payoff onto local FEniCSx DOF coordinates."""
+        coords = self._dof_coordinates()[:, 0]
+        if self.is_call:
+            return np.asarray([self.payoff.call_payoff(s) for s in coords], dtype=float)
+        return np.asarray([self.payoff.put_payoff(s) for s in coords], dtype=float)
 
     def matrices(
         self,
@@ -91,65 +205,123 @@ class FenicsSolver(SpaceDiscretization):
         *,
         start: float | None = None,
         end: float | None = None,
-    ):
-        """Return PETSc system matrices for the θ-scheme."""
+    ) -> tuple[Any, Any]:
+        """Return unconstrained PETSc matrices for a θ-scheme interval."""
         del start, end
-        A = self.mass.copy()
-        A.axpy(-theta * dt, self.stiffness)
-        B = self.mass.copy()
-        B.axpy((1 - theta) * dt, self.stiffness)
-        return A, B
+        return self._assemble_matrix(
+            self._mass_expr - theta * dt * self._operator_expr
+        ), self._rhs_matrix(theta, dt)
 
     def boundary_term(self, _th: float) -> np.ndarray:  # pragma: no cover
-        """Return natural boundary term (zero for Black--Scholes)."""
-        return np.zeros(self.Vh.dofmap.index_map.size_local)
+        """Return natural boundary/source term; zero for this Black--Scholes route."""
+        return np.zeros(self._local_dof_count(), dtype=float)
 
     def dirichlet(self, th: float) -> np.ndarray:
-        """Return Dirichlet values at time ``th``."""
-        r = self.dynamics.r
-        k = self.payoff.k
-        s_max = self.domain[1]
-        if self.is_call:
-            left = 0.0
-            right = s_max - k * np.exp(-r * th)
-        else:
-            left = k * np.exp(-r * th)
-            right = 0.0
-        vals = np.zeros(self.Vh.dofmap.index_map.size_local)
-        vals[0] = left
-        vals[-1] = right
-        return vals
+        """Return endpoint Dirichlet values at geometrically matched local DOFs."""
+        coords = self._dof_coordinates()[:, 0]
+        left_value, right_value = self._boundary_values(th)
+        values = np.zeros(coords.shape[0], dtype=float)
+        left_mask = np.isclose(coords, self.domain[0])
+        right_mask = np.isclose(coords, self.domain[1])
+        values[left_mask] = left_value
+        values[right_mask] = right_value
+        return values
 
-    def apply_dirichlet(self, A, b, _dirichlet_bcs, u_dirichlet):
-        """Apply Dirichlet conditions to PETSc matrices."""
-        fem.petsc.apply_lifting(b, [A], bcs=[], x0=None)
+    def apply_dirichlet(
+        self,
+        A: Any,
+        b: Any,
+        dirichlet_bcs: Iterable[Any],
+        u_dirichlet: np.ndarray,
+    ) -> tuple[Any, Any]:
+        """Apply supported DOLFINx Dirichlet lifting and RHS value injection."""
+        del u_dirichlet
+        bcs = list(dirichlet_bcs)
+        if self._active_system_form is None:
+            raise RuntimeError("active system form is required for DOLFINx BC lifting")
+        fem.petsc.apply_lifting(b, [self._active_system_form], [bcs])
         b.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
-        fem.petsc.set_bc(A, b, [])
-        with A.localForm() as loc:
-            loc.set(0.0)
-            loc.diagonal().set(1.0)
-        b.array[:] = u_dirichlet
+        fem.petsc.set_bc(b, bcs)
         return A, b
 
-    # ------------------------------------------------------------------
-    def solve(self, t: Iterable[float], theta: float = 0.5) -> np.ndarray:
-        """Solve the PDE using a θ-scheme time stepper."""
-        dt = t[1] - t[0]
-        A, B = self.matrices(theta, dt)
+    def _new_ksp(self, A_bc: Any) -> Any:
+        """Create a PETSc KSP whose operator is the boundary-modified matrix."""
         ksp = PETSc.KSP().create(self.mesh.comm)
-        ksp.setOperators(A)
+        ksp.setOptionsPrefix(str(self.petsc_options_prefix))
+        ksp.setOperators(A_bc)
         ksp.setType("preonly")
         ksp.getPC().setType("lu")
+        ksp.setFromOptions()
+        return ksp
 
-        u = PETSc.Vec().createMPI(A.getSize()[0])
-        u.array = self.initial_condition()
-        sol = np.empty((len(t), u.getSize()))
-        sol[0] = u.array
+    @staticmethod
+    def _check_ksp_converged(ksp: Any) -> None:
+        """Raise with PETSc diagnostics when KSP fails to converge."""
+        reason = int(ksp.getConvergedReason())
+        if reason > 0:
+            return
+        iterations = int(ksp.getIterationNumber())
+        residual = float(ksp.getResidualNorm())
+        prefix = ksp.getOptionsPrefix()
+        raise RuntimeError(
+            "PETSc KSP failed to converge: "
+            f"prefix={prefix!r}, reason={reason}, iterations={iterations}, "
+            f"residual={residual:.6e}"
+        )
 
-        for i, th in enumerate(t[:-1]):
-            b = B @ u
-            u_d = self.dirichlet(th + dt)
-            A_bc, b_bc = self.apply_dirichlet(A.copy(), b, [], u_d)
+    def solve(self, t: Iterable[float], theta: float = 0.5) -> np.ndarray:
+        """Solve the PDE using a θ-scheme with per-step BC assembly."""
+        times = np.asarray(tuple(t), dtype=float)
+        if times.ndim != 1 or len(times) < 2:
+            raise ValueError("time grid must contain at least two entries")
+        if not np.isfinite(times).all() or np.any(np.diff(times) <= 0.0):
+            raise ValueError("time grid must be finite and strictly increasing")
+        if not 0.0 <= theta <= 1.0:
+            raise ValueError("theta must be in [0, 1]")
+
+        u = self._initial_petsc_vec()
+        local_size = len(self._owned_array(u))
+        solution = np.empty((len(times), local_size), dtype=float)
+        solution[0] = self._owned_array(u)
+
+        for i, (start, end) in enumerate(zip(times[:-1], times[1:], strict=True)):
+            dt = float(end - start)
+            bcs = self._dirichlet_bcs(float(end))
+            A_bc, system_form = self._system_matrix(theta, dt, bcs)
+            self._active_system_form = system_form
+            rhs_matrix = self._rhs_matrix(theta, dt)
+            b = rhs_matrix @ u
+            _, b_bc = self.apply_dirichlet(A_bc, b, bcs, self.dirichlet(float(end)))
+            ksp = self._new_ksp(A_bc)
             ksp.solve(b_bc, u)
-            sol[i + 1] = u.array
-        return sol
+            self._check_ksp_converged(ksp)
+            u.ghostUpdate(addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
+            solution[i + 1] = self._owned_array(u)
+
+        self._active_system_form = None
+        return solution
+
+    def domain_diagnostics(
+        self, *, horizon: float, tail_mass: float = 1.0e-6
+    ) -> dict[str, object]:
+        """Return minimal public domain diagnostics for this optional backend."""
+        del tail_mass
+        return {
+            "horizon": float(horizon),
+            "backend": "fenicsx",
+            "coordinate_system": "spot",
+            "state_domain": [
+                {
+                    "name": "spot",
+                    "lower": self.domain[0],
+                    "upper": self.domain[1],
+                    "scale": "linear",
+                    "truncation_policy": "finite-interval",
+                    "tail_mass": None,
+                }
+            ],
+            "boundary_facets": ("left", "right"),
+            "mesh_dimension": 1,
+            "mesh_elements": int(self.num_elements),
+            "petsc_options_prefix": self.petsc_options_prefix,
+        }

--- a/tests/test_fenics_solver.py
+++ b/tests/test_fenics_solver.py
@@ -1,15 +1,47 @@
 """Tests for the experimental FEniCS solver."""
 
+from __future__ import annotations
+
+import inspect
+
 import numpy as np
 import pytest
 
-from finite_element_options.space import fenics_solver
-from finite_element_options.space.fenics_solver import FenicsSolver
 from finite_element_options.core.dynamics_black_scholes import DynamicsParametersBlackScholes
 from finite_element_options.core.market import Market
 from finite_element_options.core.vanilla_bs import EuropeanOptionBs
+from finite_element_options.space import fenics_solver
+from finite_element_options.space.fenics_solver import FenicsSolver
 
 HAS_FENICS = fenics_solver.fem is not None
+
+
+class _DivergedKSP:
+    def getConvergedReason(self) -> int:
+        return -3
+
+    def getIterationNumber(self) -> int:
+        return 17
+
+    def getResidualNorm(self) -> float:
+        return 2.5e-3
+
+    def getOptionsPrefix(self) -> str:
+        return "feo_test_"
+
+
+class _ConvergedKSP:
+    def getConvergedReason(self) -> int:
+        return 2
+
+    def getIterationNumber(self) -> int:
+        return 4
+
+    def getResidualNorm(self) -> float:
+        return 1.0e-11
+
+    def getOptionsPrefix(self) -> str:
+        return "feo_test_"
 
 
 @pytest.mark.skipif(not HAS_FENICS, reason="FEniCSx not installed")
@@ -18,10 +50,50 @@ def test_fenics_black_scholes() -> None:
     dh = DynamicsParametersBlackScholes(r=0.03, q=0.0, sig=0.2)
     mkt = Market(r=dh.r)
     bsopt = EuropeanOptionBs(k=1.0, q=dh.q, mkt=mkt)
-    solver = FenicsSolver(domain=(0.0, 2.0), num_elements=16, dynamics=dh, payoff=bsopt, is_call=True)
+    solver = FenicsSolver(
+        domain=(0.0, 2.0), num_elements=16, dynamics=dh, payoff=bsopt, is_call=True
+    )
     t = np.linspace(0.0, 1.0, 5)
     v = solver.solve(t)
     node = np.argmin(np.abs(solver.Vh.tabulate_dof_coordinates().ravel() - 1.0))
     price_num = v[-1, node]
-    price_exact = bsopt.call(t[-1], 1.0, dh.sig ** 2)
+    price_exact = bsopt.call(t[-1], 1.0, dh.sig**2)
     assert price_num == pytest.approx(price_exact, rel=1e-2)
+
+
+def test_fenics_solver_uses_dolfinx_boundary_dof_apis_not_local_row_replacement() -> None:
+    """The backend must not zero the whole matrix or assume local edge DOFs."""
+
+    source = "\n".join(
+        [
+            inspect.getsource(FenicsSolver._locate_boundary_dofs),
+            inspect.getsource(FenicsSolver._dirichlet_bcs),
+            inspect.getsource(FenicsSolver.apply_dirichlet),
+        ]
+    )
+
+    assert "mesh.locate_entities_boundary" in source
+    assert "fem.locate_dofs_topological" in source
+    assert "fem.dirichletbc" in source
+    assert "loc.set(0.0)" not in source
+    assert "diagonal().set(1.0)" not in source
+    assert "vals[0]" not in source
+    assert "vals[-1]" not in source
+
+
+def test_fenics_solver_sets_ksp_operator_after_boundary_application_and_checks_reason() -> None:
+    """PETSc divergence must fail explicitly with solver diagnostics."""
+
+    source = "\n".join(
+        [
+            inspect.getsource(FenicsSolver._new_ksp),
+            inspect.getsource(FenicsSolver._check_ksp_converged),
+            inspect.getsource(FenicsSolver.solve),
+        ]
+    )
+
+    assert "setOperators(A_bc)" in source
+    assert "getConvergedReason" in source
+    with pytest.raises(RuntimeError, match="PETSc KSP failed to converge"):
+        FenicsSolver._check_ksp_converged(_DivergedKSP())
+    FenicsSolver._check_ksp_converged(_ConvergedKSP())


### PR DESCRIPTION
## Summary
- rebuild the optional `FenicsSolver` boundary path around supported DOLFINx/PETSc APIs: geometric endpoint facet/DOF discovery, `fem.dirichletbc`, matrix assembly with BCs, RHS `apply_lifting`/`set_bc`, and per-step KSP operator binding
- add explicit PETSc KSP convergence diagnostics so non-positive convergence reasons fail closed instead of returning a numerical field
- add non-skipped FEniCSx backend contract tests plus a dedicated `fenicsx_contract` CI job; true runtime parity tests still run when FEniCSx is installed and skip honestly otherwise
- update PRD/architecture/README docs for the FEniCSx/PETSc backend contract

Closes #38

## Evidence
- RED: `.venv/bin/pytest -q tests/test_fenics_solver.py --no-cov` failed on the old implementation with missing `_locate_boundary_dofs` / `_new_ksp` contract hooks
- GREEN: `.venv/bin/pytest -q tests/test_fenics_solver.py tests/test_benchmark_fenics.py --no-cov` → 2 passed, 2 skipped
- `.venv/bin/python -m compileall -q src tests scripts`
- `.venv/bin/ruff check src tests scripts`
- `.venv/bin/pydocstyle src/finite_element_options`
- `.venv/bin/mypy --ignore-missing-imports --follow-imports=silent src/finite_element_options/contracts src/finite_element_options/validation scripts/check_ci_contract.py`
- `.venv/bin/python scripts/check_architecture_contract.py`
- `.venv/bin/python scripts/check_ci_contract.py`
- `.venv/bin/pytest -q --no-cov` → 193 passed, 2 skipped, 25 expected FD compatibility warnings
- `.venv/bin/python -m build --sdist --wheel --outdir /tmp/feo38-dist`
- `.venv/bin/python -m twine check /tmp/feo38-dist/*`
- `.venv/bin/pytest tests/test_benchmark_black_scholes.py --benchmark-json=/tmp/feo38-benchmark.json --no-cov`

## Notes
FEniCSx wheels are not available in this local Python environment (`pip index versions fenics-dolfinx` returned no matching distribution), so the real runtime numerical smoke remains conditional. The contract tests are intentionally non-skipped and run in their own CI job to prevent the old matrix-zeroing/local-DOF implementation from reappearing silently.