### PR TITLE
fix(fem): replace solver introspection with typed protocols

### DIFF
--- a/src/finite_element_options/space/solver.py
+++ b/src/finite_element_options/space/solver.py
@@ -71,9 +71,6 @@ class SpaceSolver:
             dynamics=dynamics,
             transform=self.transform,
         )
-        self._mean_variance_supports_config = (
-            "config" in dynamics.mean_variance.__code__.co_varnames
-        )
         self.mass = self.forms.id_bil().assemble(self.Vh)
         self._operator_matrix_cache: dict[float, object] = {}
         self.matrix_time_calls: list[tuple[float, float]] = []
@@ -140,11 +137,10 @@ class SpaceSolver:
         variance_seed = (
             variance_inputs if variance_inputs is not None else np.zeros_like(spot)
         )
-        kwargs = {"config": self.config} if self._mean_variance_supports_config else {}
         mean_variance = self.dynamics.mean_variance(
             th_phys,
             variance_seed,
-            **kwargs,
+            config=self.config,
         )
         return price_fn(th_phys, spot, mean_variance)
 

--- a/src/finite_element_options/time_integration/stepper.py
+++ b/src/finite_element_options/time_integration/stepper.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from hashlib import sha256
-import inspect
 from time import perf_counter
 from typing import Callable, Iterable
 
@@ -363,16 +362,9 @@ def _sequence_cache_key(keys: Iterable[str]) -> str:
 
 
 def _space_matrices(space: SpaceDiscretization, step: _InternalThetaStep):
-    """Return spatial matrices, passing endpoint times when supported."""
+    """Return spatial matrices through the explicit endpoint-aware protocol."""
 
-    parameters = inspect.signature(space.matrices).parameters
-    supports_endpoint_times = "start" in parameters or any(
-        parameter.kind == inspect.Parameter.VAR_KEYWORD
-        for parameter in parameters.values()
-    )
-    if supports_endpoint_times:
-        return space.matrices(step.theta, step.dt, start=step.start, end=step.end)
-    return space.matrices(step.theta, step.dt)
+    return space.matrices(step.theta, step.dt, start=step.start, end=step.end)
 
 
 def _theta_cache_key(

--- a/tests/architecture/test_architecture_contracts.py
+++ b/tests/architecture/test_architecture_contracts.py
@@ -439,6 +439,28 @@ def test_fem_core_does_not_import_application_or_research_stacks() -> None:
     )
 
 
+def test_solver_protocols_do_not_depend_on_signature_introspection() -> None:
+    forbidden_fragments = {
+        "__code__": "callable bytecode details",
+        "co_varnames": "callable local variable names",
+        "inspect.signature": "argument-name introspection",
+    }
+    violations: dict[str, list[str]] = {}
+    for relative in (
+        "space/solver.py",
+        "time_integration/stepper.py",
+    ):
+        text = (PACKAGE_ROOT / relative).read_text(encoding="utf-8")
+        hits = [label for fragment, label in forbidden_fragments.items() if fragment in text]
+        if hits:
+            violations[f"src/{PACKAGE}/{relative}"] = hits
+
+    assert not violations, (
+        "Solver protocols must use explicit typed contracts instead of introspection: "
+        + repr(violations)
+    )
+
+
 def test_base_package_import_surface_stays_lightweight() -> None:
     imported = _imports(PACKAGE_ROOT / "__init__.py")
     forbidden = sorted(

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -15,6 +15,7 @@ flowchart TD
 
 import os
 import sys
+from dataclasses import dataclass, field
 
 import numpy as np
 import pytest
@@ -28,6 +29,44 @@ from finite_element_options.space.mesh import create_mesh  # noqa: E402
 from finite_element_options.space.solver import SpaceSolver  # noqa: E402
 from finite_element_options.space.boundary import DirichletBC  # noqa: E402
 from finite_element_options.time_integration.stepper import ThetaScheme  # noqa: E402
+
+
+@dataclass
+class _ConfigRecordingMeanVariance:
+    """Callable mean-variance oracle deliberately lacking ``__code__`` metadata."""
+
+    calls: list[object] = field(default_factory=list)
+
+    def __call__(self, th, v, *, config=None):  # pylint: disable=unused-argument
+        self.calls.append(config)
+        return np.full_like(v, 0.04, dtype=float)
+
+
+@dataclass
+class _CallableMeanVarianceDynamics:
+    """Minimal dynamics whose explicit callable contract replaces signature probes."""
+
+    r: float = 0.03
+    q: float = 0.01
+    sig: float = 0.2
+    mean_variance: _ConfigRecordingMeanVariance = field(
+        default_factory=_ConfigRecordingMeanVariance
+    )
+
+    def A(self, s):
+        return [[self.sig**2 * s**2]]
+
+    def dA(self, s):
+        return [2 * self.sig**2 * s]
+
+    def b(self, s):
+        return [(self.r - self.q) * s]
+
+    def discount(self, state, time):  # pylint: disable=unused-argument
+        return self.r
+
+    def source(self, state, time):  # pylint: disable=unused-argument
+        return 0.0
 
 
 def _build_space_solver(is_call: bool, *, adaptive_criterion: str | None = None):
@@ -78,14 +117,26 @@ def test_dirichlet_matches_model_prices(is_call, price_attr):
     th = 0.25
     values = space.dirichlet(th)
     th_phys = float(np.asarray(space.transform.untransform_time(th)))
-    supports_config = "config" in dynamics.mean_variance.__code__.co_varnames
     state = space.transform.untransform_state(space.Vh.doflocs)
     spots = state[0]
     variance_seed = state[1] if state.shape[0] > 1 else np.zeros_like(spots)
-    kwargs = {"config": space.config} if supports_config else {}
-    mean_var = dynamics.mean_variance(th_phys, variance_seed, **kwargs)
+    mean_var = dynamics.mean_variance(th_phys, variance_seed, config=space.config)
     expected = getattr(payoff, price_attr)(th_phys, spots, mean_var)
     np.testing.assert_allclose(values, expected)
+
+
+def test_dirichlet_uses_explicit_mean_variance_protocol_without_code_introspection():
+    dynamics = _CallableMeanVarianceDynamics()
+    payoff = EuropeanOptionBs(k=0.4, q=dynamics.q, mkt=Market(r=dynamics.r))
+    mesh, cfg = create_mesh([1.0], 1)
+    space = SpaceSolver(mesh, dynamics, payoff, is_call=True, config=cfg)
+
+    assert not hasattr(dynamics.mean_variance, "__code__")
+
+    values = space.dirichlet(0.25)
+
+    assert values.shape == (space.Vh.N,)
+    assert dynamics.mean_variance.calls == [space.config]
 
 
 def test_refine_with_transfer_rebuilds_basis_and_returns_values():

--- a/tests/test_time_stepper.py
+++ b/tests/test_time_stepper.py
@@ -25,6 +25,9 @@ class _ScalarSpace:
     source_scale: float = 0.0
     Vh: _FakeBasis = field(default_factory=_FakeBasis)
     matrix_calls: list[tuple[float, float]] = field(default_factory=list)
+    matrix_endpoint_calls: list[tuple[float | None, float | None]] = field(
+        default_factory=list
+    )
     boundary_term_calls: list[float] = field(default_factory=list)
 
     def initial_condition(self) -> np.ndarray:
@@ -32,10 +35,18 @@ class _ScalarSpace:
 
         return np.array([1.0])
 
-    def matrices(self, theta: float, dt: float):
+    def matrices(
+        self,
+        theta: float,
+        dt: float,
+        *,
+        start: float | None = None,
+        end: float | None = None,
+    ):
         """Record each local theta/dt pair and return scalar matrices."""
 
         self.matrix_calls.append((theta, dt))
+        self.matrix_endpoint_calls.append((start, end))
         if self.matrix_mode == "growth":
             return sps.csr_matrix([[1.0]]), sps.csr_matrix([[1.0 + dt]])
         if self.matrix_mode == "dt_system":
@@ -82,6 +93,9 @@ def test_nonuniform_time_grid_uses_each_local_dt_once() -> None:
     solution = stepper.solve(iter([0.0, 0.25, 1.0, 1.5]), space)
 
     assert [dt for _, dt in space.matrix_calls] == pytest.approx([0.25, 0.75, 0.5])
+    assert space.matrix_endpoint_calls == pytest.approx(
+        [(0.0, 0.25), (0.25, 1.0), (1.0, 1.5)]
+    )
     assert solution[:, 0] == pytest.approx([1.0, 1.25, 2.1875, 3.28125])
     assert stepper.last_time_grid_diagnostics["local_time_steps"] == pytest.approx(
         (0.25, 0.75, 0.5)


### PR DESCRIPTION
## Summary
- removes solver dependency on callable implementation metadata (`__code__`, argument names, `inspect.signature`)
- makes `mean_variance` and space-matrix calls use explicit endpoint/config protocols
- adds architecture and behavioral regression tests so solver protocols stay typed rather than introspection-based

## Acceptance criteria mapping
- [x] No behavior depends on `__code__`, argument names, or mutable global/config state: `SpaceSolver` now calls `mean_variance(..., config=...)` directly, `ThetaScheme` calls `space.matrices(..., start=..., end=...)` directly, and the architecture gate forbids the old introspection fragments in solver seams.
- [x] Unsupported problem/backend combinations fail before assembly with actionable explanations: covered by existing `FEMRouteRequest` / capability manifest tests in `tests/test_pinares_fem_proxy.py` and `tests/test_fem_backend_capabilities.py`.
- [x] Every result records problem/config/backend/version and convergence diagnostics: covered by existing public result/export and diagnostic tests exercised in the gate suite below.
- [x] Remeshing requires an explicit tested transfer operation: covered by existing adaptive-transfer tests (`tests/test_adaptive_mesh.py`) and unchanged by this PR.
- [x] Compatibility shims warn and have removal targets: covered by existing FD compatibility/architecture tests exercised in the full suite.
- [x] Strict type checking covers public problem/solver interfaces: CI contract runs mypy over public contract/validation surfaces; this PR additionally ran mypy on the touched solver/stepper tests.

## Evidence
- RED before implementation: `uv run pytest -q --override-ini addopts= tests/test_solver.py::test_dirichlet_uses_explicit_mean_variance_protocol_without_code_introspection tests/architecture/test_architecture_contracts.py::test_solver_protocols_do_not_depend_on_signature_introspection tests/test_time_stepper.py::test_nonuniform_time_grid_uses_each_local_dt_once` failed with the expected `__code__`/`inspect.signature` violations.
- GREEN targeted: same command passed: `3 passed in 0.53s`.
- Focused interfaces: `uv run pytest -q --override-ini addopts= tests/test_solver.py tests/test_time_stepper.py tests/test_state_time_coefficients.py tests/architecture tests/test_packaging_contract.py tests/test_fem_backend_capabilities.py tests/test_pinares_fem_proxy.py` -> `66 passed in 15.21s`.
- Static/contract gates: `uv run ruff check src tests scripts`; `uv run pydocstyle src/finite_element_options`; `uv run mypy --ignore-missing-imports --follow-imports=silent src/finite_element_options/contracts src/finite_element_options/validation scripts/check_ci_contract.py`; `uv run mypy --ignore-missing-imports --follow-imports=silent src/finite_element_options/space/solver.py src/finite_element_options/time_integration/stepper.py tests/test_solver.py tests/test_time_stepper.py`; `python scripts/check_architecture_contract.py`; `python scripts/check_ci_contract.py` -> all passed.
- Full regression: `uv run pytest -q --override-ini addopts=` -> `195 passed, 2 skipped, 25 warnings in 29.50s`.
- Benchmark smoke: `uv run pytest -q --override-ini addopts= tests/test_benchmark_black_scholes.py --benchmark-json=/tmp/feo-benchmark.json` -> `1 passed in 3.22s`.

Closes #48
